### PR TITLE
Add AureliumSkills support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,5 +186,12 @@
             <version>2.1.196</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.Archy-X</groupId>
+            <artifactId>AureliumSkills</artifactId>
+            <version>Beta1.2.8</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -8,6 +8,7 @@ import com.oheers.fish.config.*;
 import com.oheers.fish.config.messages.Messages;
 import com.oheers.fish.database.Database;
 import com.oheers.fish.database.FishReport;
+import com.oheers.fish.events.AureliumSkillsFishingEvent;
 import com.oheers.fish.events.FishEatEvent;
 import com.oheers.fish.events.FishInteractEvent;
 import com.oheers.fish.events.McMMOTreasureEvent;
@@ -218,6 +219,12 @@ public class EvenMoreFish extends JavaPlugin {
         if (Bukkit.getPluginManager().getPlugin("mcMMO") != null) {
             if (mainConfig.disableMcMMOTreasure()) {
                 getServer().getPluginManager().registerEvents(McMMOTreasureEvent.getInstance(), this);
+            }
+        }
+
+        if (Bukkit.getPluginManager().getPlugin("AureliumSkills") != null) {
+            if (mainConfig.disableAureliumSkills()) {
+                getServer().getPluginManager().registerEvents(AureliumSkillsFishingEvent.getInstance(), this);
             }
         }
     }

--- a/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -109,6 +109,10 @@ public class MainConfig {
         return config.getBoolean("disable-mcmmo-loot");
     }
 
+    public boolean disableAureliumSkills() {
+        return config.getBoolean("disable-aureliumskills-loot");
+    }
+
     public String rewardEffect() {
         return config.getString("reward-gui.reward-effect");
     }

--- a/src/main/java/com/oheers/fish/events/AureliumSkillsFishingEvent.java
+++ b/src/main/java/com/oheers/fish/events/AureliumSkillsFishingEvent.java
@@ -1,0 +1,31 @@
+package com.oheers.fish.events;
+
+import com.archyx.aureliumskills.api.event.LootDropCause;
+import com.archyx.aureliumskills.api.event.PlayerLootDropEvent;
+import com.oheers.fish.EvenMoreFish;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class AureliumSkillsFishingEvent implements Listener {
+
+    private static final AureliumSkillsFishingEvent aurelliumEvent = new AureliumSkillsFishingEvent();
+
+    public static AureliumSkillsFishingEvent getInstance() {
+        return aurelliumEvent;
+    }
+
+    @EventHandler
+    public void fishCatch(PlayerLootDropEvent event) {
+        if (event.getCause() == LootDropCause.LUCKY_CATCH || event.getCause() == LootDropCause.TREASURE_HUNTER || event.getCause() == LootDropCause.EPIC_CATCH || event.getCause() == LootDropCause.FISHING_OTHER_LOOT) {
+            if (EvenMoreFish.mainConfig.disableAureliumSkills()) {
+                if (EvenMoreFish.mainConfig.isCompetitionUnique()) {
+                    if (EvenMoreFish.active != null) {
+                        event.setCancelled(true);
+                    }
+                } else {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -72,6 +72,9 @@ gui:
 # Prevents mcMMO from overriding fishing loot, this means treasure won't appear when fish can.
 disable-mcmmo-loot: true
 
+# Prevents AureliumSkills from overriding fishing loot, this means treasure won't appear when fish can.
+disable-aureliumskills-loot: true
+
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE UNLESS YOU'RE UPDATING THE CONFIG.
 config-version: 9

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}
 main: com.oheers.fish.EvenMoreFish
 api-version: 1.16
 depend: [Vault]
-softdepend: [WorldGuard, PlaceholderAPI, RedProtect, mcMMO]
+softdepend: [WorldGuard, PlaceholderAPI, RedProtect, mcMMO, AureliumSkills]
 loadbefore: [AntiAC]
 
 commands:


### PR DESCRIPTION
This aims to prevent AureliumSkills fishing loot from replacing loot during competitions as is done with mcMMO