### PR TITLE
Adds backward compatibility for NBT items

### DIFF
--- a/src/main/java/com/oheers/fish/FishUtils.java
+++ b/src/main/java/com/oheers/fish/FishUtils.java
@@ -101,18 +101,16 @@ public class FishUtils {
     }
 
     public static Fish getFish(Skull skull, Player fisher) throws InvalidFishException {
-        NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-rarity");
-        NamespacedKey nbtplayer = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-player");
-        NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-name");
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-length");
-
         // all appropriate null checks can be safely assumed to have passed to get to a point where we're running this method.
         NBTTileEntity nbtSkull = new NBTTileEntity(skull);
 
-        String nameString = nbtSkull.getString(nbtname.toString());
-        String playerString = nbtSkull.getString(nbtplayer.toString());
-        String rarityString = nbtSkull.getString(nbtrarity.toString());
-        Float lengthFloat = nbtSkull.getFloat(nbtlength.toString());
+        String nameString = NbtUtils.getString(nbtSkull,"emf-fish-name");
+        String playerString = NbtUtils.getString(nbtSkull,"emf-fish-player");
+        String rarityString = NbtUtils.getString(nbtSkull, "emf-fish-rarity");
+        Float lengthFloat = NbtUtils.getFloat(nbtSkull, "emf-fish-length");
+
+        if(nameString == null || rarityString == null || lengthFloat == null)
+            throw new InvalidFishException("NBT Error");
 
         // Generating an empty rarity
         Rarity rarity = null;
@@ -298,10 +296,8 @@ public class FishUtils {
      * @return Whether this ItemStack is a bait.
      */
     public boolean isBaitObject(ItemStack item) {
-        NamespacedKey nbtbait = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-bait");
-
         if (item.getItemMeta() != null) {
-            return new NBTItem(item).hasKey(nbtbait.toString());
+            return NbtUtils.hasKey(new NBTItem(item),"emf-bait");
         }
 
         return false;

--- a/src/main/java/com/oheers/fish/FishUtils.java
+++ b/src/main/java/com/oheers/fish/FishUtils.java
@@ -42,7 +42,7 @@ public class FishUtils {
      * we only need to check for the length since they're all added in a batch if it's an EMF fish */
     public static boolean isFish(ItemStack item) {
         if (item != null && item.hasItemMeta()) {
-            return NbtUtils.hasKey(new NBTItem(item), "emf-fish-length");
+            return NbtUtils.hasKey(new NBTItem(item), NbtUtils.Keys.EMF_FISH_LENGTH);
         }
 
         return false;
@@ -50,7 +50,7 @@ public class FishUtils {
 
     public static boolean isFish(Skull skull) {
         if (skull != null) {
-            return NbtUtils.hasKey(new NBTTileEntity(skull),"emf-fish-length");
+            return NbtUtils.hasKey(new NBTTileEntity(skull), NbtUtils.Keys.EMF_FISH_LENGTH);
         }
 
         return false;
@@ -60,12 +60,12 @@ public class FishUtils {
         // all appropriate null checks can be safely assumed to have passed to get to a point where we're running this method.
         NBTItem nbtItem = new NBTItem(item);
 
-        String nameString = NbtUtils.getString(nbtItem,"emf-fish-name");
-        String playerString = NbtUtils.getString(nbtItem,"emf-fish-player");
-        String rarityString = NbtUtils.getString(nbtItem, "emf-fish-rarity");
-        Float lengthFloat = NbtUtils.getFloat(nbtItem, "emf-fish-length");
+        String nameString = NbtUtils.getString(nbtItem, NbtUtils.Keys.EMF_FISH_NAME);
+        String playerString = NbtUtils.getString(nbtItem, NbtUtils.Keys.EMF_FISH_PLAYER);
+        String rarityString = NbtUtils.getString(nbtItem, NbtUtils.Keys.EMF_FISH_RARITY);
+        Float lengthFloat = NbtUtils.getFloat(nbtItem, NbtUtils.Keys.EMF_FISH_LENGTH);
 
-        if(nameString == null || rarityString == null || lengthFloat == null)
+        if (nameString == null || rarityString == null || lengthFloat == null)
             return null; //throw new InvalidFishException("NBT Error");
 
 
@@ -97,12 +97,12 @@ public class FishUtils {
         // all appropriate null checks can be safely assumed to have passed to get to a point where we're running this method.
         NBTTileEntity nbtSkull = new NBTTileEntity(skull);
 
-        String nameString = NbtUtils.getString(nbtSkull,"emf-fish-name");
-        String playerString = NbtUtils.getString(nbtSkull,"emf-fish-player");
-        String rarityString = NbtUtils.getString(nbtSkull, "emf-fish-rarity");
-        Float lengthFloat = NbtUtils.getFloat(nbtSkull, "emf-fish-length");
+        String nameString = NbtUtils.getString(nbtSkull, NbtUtils.Keys.EMF_FISH_NAME);
+        String playerString = NbtUtils.getString(nbtSkull, NbtUtils.Keys.EMF_FISH_PLAYER);
+        String rarityString = NbtUtils.getString(nbtSkull, NbtUtils.Keys.EMF_FISH_RARITY);
+        Float lengthFloat = NbtUtils.getFloat(nbtSkull, NbtUtils.Keys.EMF_FISH_LENGTH);
 
-        if(nameString == null || rarityString == null || lengthFloat == null)
+        if (nameString == null || rarityString == null || lengthFloat == null)
             throw new InvalidFishException("NBT Error");
 
         // Generating an empty rarity
@@ -190,12 +190,10 @@ public class FishUtils {
     }
 
     // credit to https://www.spigotmc.org/members/elementeral.717560/
-    public static String translateHexColorCodes(String message)
-    {
+    public static String translateHexColorCodes(String message) {
         Matcher matcher = HEX_PATTERN.matcher(message);
         StringBuffer buffer = new StringBuffer(message.length() + 4 * 8);
-        while (matcher.find())
-        {
+        while (matcher.find()) {
             String group = matcher.group(1);
             matcher.appendReplacement(buffer, COLOR_CHAR + "x"
                     + COLOR_CHAR + group.charAt(0) + COLOR_CHAR + group.charAt(1)
@@ -220,35 +218,35 @@ public class FishUtils {
 
     public static String timeFormat(long timeLeft) {
         String returning = "";
-        long hours = timeLeft/3600;
+        long hours = timeLeft / 3600;
 
         if (timeLeft >= 3600) {
             returning += hours + new Message(ConfigMessage.BAR_HOUR).getRawMessage(false, false) + " ";
         }
 
         if (timeLeft >= 60) {
-            returning += ((timeLeft%3600)/60) + new Message(ConfigMessage.BAR_MINUTE).getRawMessage(false, false) + " ";
+            returning += ((timeLeft % 3600) / 60) + new Message(ConfigMessage.BAR_MINUTE).getRawMessage(false, false) + " ";
         }
 
         // Remaining seconds to always show, e.g. "1 minutes and 0 seconds left" and "5 seconds left"
-        returning += (timeLeft%60) + new Message(ConfigMessage.BAR_SECOND).getRawMessage(false, false);
+        returning += (timeLeft % 60) + new Message(ConfigMessage.BAR_SECOND).getRawMessage(false, false);
         return returning;
     }
 
     public static String timeRaw(long timeLeft) {
         String returning = "";
-        long hours = timeLeft/3600;
+        long hours = timeLeft / 3600;
 
         if (timeLeft >= 3600) {
             returning += hours + ":";
         }
 
         if (timeLeft >= 60) {
-            returning += ((timeLeft%3600)/60) + ":";
+            returning += ((timeLeft % 3600) / 60) + ":";
         }
 
         // Remaining seconds to always show, e.g. "1 minutes and 0 seconds left" and "5 seconds left"
-        returning += (timeLeft%60);
+        returning += (timeLeft % 60);
         return returning;
     }
 
@@ -290,7 +288,7 @@ public class FishUtils {
      */
     public boolean isBaitObject(ItemStack item) {
         if (item.getItemMeta() != null) {
-            return NbtUtils.hasKey(new NBTItem(item),"emf-bait");
+            return NbtUtils.hasKey(new NBTItem(item), NbtUtils.Keys.EMF_BAIT);
         }
 
         return false;

--- a/src/main/java/com/oheers/fish/FishUtils.java
+++ b/src/main/java/com/oheers/fish/FishUtils.java
@@ -41,40 +41,33 @@ public class FishUtils {
     /* checks for the "emf-fish-length" nbt tag, to determine if this itemstack is a fish or not.
      * we only need to check for the length since they're all added in a batch if it's an EMF fish */
     public static boolean isFish(ItemStack item) {
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-length");
-
-        if (item != null) {
-            if (item.hasItemMeta()) {
-                return new NBTItem(item).hasKey(nbtlength.toString());
-            }
+        if (item != null && item.hasItemMeta()) {
+            return NbtUtils.hasKey(new NBTItem(item), "emf-fish-length");
         }
 
         return false;
     }
 
     public static boolean isFish(Skull skull) {
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-length");
-
         if (skull != null) {
-            return new NBTTileEntity(skull).hasKey(nbtlength.toString());
+            return NbtUtils.hasKey(new NBTTileEntity(skull),"emf-fish-length");
         }
 
         return false;
     }
 
     public static Fish getFish(ItemStack item) {
-        NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-rarity");
-        NamespacedKey nbtplayer = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-player");
-        NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-name");
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(FishUtils.class), "emf-fish-length");
-
         // all appropriate null checks can be safely assumed to have passed to get to a point where we're running this method.
         NBTItem nbtItem = new NBTItem(item);
 
-        String nameString = nbtItem.getString(nbtname.toString());
-        String playerString = nbtItem.getString(nbtplayer.toString());
-        String rarityString = nbtItem.getString(nbtrarity.toString());
-        Float lengthFloat = nbtItem.getFloat(nbtlength.toString());
+        String nameString = NbtUtils.getString(nbtItem,"emf-fish-name");
+        String playerString = NbtUtils.getString(nbtItem,"emf-fish-player");
+        String rarityString = NbtUtils.getString(nbtItem, "emf-fish-rarity");
+        Float lengthFloat = NbtUtils.getFloat(nbtItem, "emf-fish-length");
+
+        if(nameString == null || rarityString == null || lengthFloat == null)
+            return null; //throw new InvalidFishException("NBT Error");
+
 
         // Generating an empty rarity
         Rarity rarity = null;

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -1,7 +1,6 @@
 package com.oheers.fish;
 
 import de.tr7zw.changeme.nbtapi.NBTCompound;
-import de.tr7zw.changeme.nbtapi.NBTItem;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
@@ -24,19 +23,8 @@ public class NbtUtils {
         public static final String DEFAULT_GUI_ITEM = "default-gui-item";
     }
 
-    /*
-        3 possible options:
-        legacy: <-- check for this first
-            compound for PublicBukkitValues
-        nbt-api-pr: <-- then this
-            evenmorefish:key: value
-        nbt-compat-pr: <-- then this
-            compound for evenmorefish:
-                            key: value
-     */
     public static boolean hasKey(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
-
         //Pre NBT-API PR
         if(Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
             NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -1,0 +1,48 @@
+package com.oheers.fish;
+
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTItem;
+import org.bukkit.NamespacedKey;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public class NbtUtils {
+    /*
+        3 possible options:
+        legacy: <-- check for this first
+            compound for PublicBukkitValues
+        nbt-api-pr: <-- then this
+            evenmorefish:key: value
+        nbt-compat-pr: <-- then this
+            compound for evenmorefish:
+                            key: value
+     */
+    public static boolean hasKey(final @NotNull NBTItem nbtItem, final String key) {
+        NamespacedKey namespacedKey = getNamespacedKey(key);
+
+        //Pre NBT-API PR
+        if(Boolean.TRUE.equals(nbtItem.hasKey("PublicBukkitValues"))) {
+            NBTCompound publicBukkitValues = nbtItem.getCompound("PublicBukkitValues");
+            if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+                return true;
+        }
+
+        //NBT API PR
+        if(Boolean.TRUE.equals(nbtItem.hasKey(namespacedKey.toString())))
+            return true;
+
+        //NBT COMPAT
+        if(Boolean.TRUE.equals(nbtItem.hasKey(namespacedKey.getNamespace()))) {
+            NBTCompound emfCompound = nbtItem.getCompound(namespacedKey.getNamespace());
+            return Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey()));
+        }
+
+        return false;
+    }
+
+    @Contract("_ -> new")
+    private static @NotNull NamespacedKey getNamespacedKey(final String key) {
+        return new NamespacedKey(JavaPlugin.getProvidingPlugin(NbtUtils.class), key);
+    }
+}

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -6,6 +6,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class NbtUtils {
     /*
@@ -18,28 +19,74 @@ public class NbtUtils {
             compound for evenmorefish:
                             key: value
      */
-    public static boolean hasKey(final @NotNull NBTItem nbtItem, final String key) {
+    public static boolean hasKey(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
 
         //Pre NBT-API PR
-        if(Boolean.TRUE.equals(nbtItem.hasKey("PublicBukkitValues"))) {
-            NBTCompound publicBukkitValues = nbtItem.getCompound("PublicBukkitValues");
+        if(Boolean.TRUE.equals(nbtCompound.hasKey("PublicBukkitValues"))) {
+            NBTCompound publicBukkitValues = nbtCompound.getCompound("PublicBukkitValues");
             if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
                 return true;
         }
 
         //NBT API PR
-        if(Boolean.TRUE.equals(nbtItem.hasKey(namespacedKey.toString())))
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
             return true;
 
         //NBT COMPAT
-        if(Boolean.TRUE.equals(nbtItem.hasKey(namespacedKey.getNamespace()))) {
-            NBTCompound emfCompound = nbtItem.getCompound(namespacedKey.getNamespace());
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.getNamespace()))) {
+            NBTCompound emfCompound = nbtCompound.getCompound(namespacedKey.getNamespace());
             return Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey()));
         }
 
         return false;
     }
+
+
+    public static @Nullable String getString(final @NotNull NBTCompound nbtCompound, final String key) {
+        NamespacedKey namespacedKey = getNamespacedKey(key);
+        if(Boolean.TRUE.equals(nbtCompound.hasKey("PublicBukkitValues"))) {
+            NBTCompound publicBukkitValues = nbtCompound.getCompound("PublicBukkitValues");
+            if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+                return publicBukkitValues.getString(namespacedKey.toString());
+        }
+
+        //NBT API PR
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
+            return nbtCompound.getString(namespacedKey.toString());
+
+        //NBT COMPAT
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.getNamespace()))) {
+            NBTCompound emfCompound = nbtCompound.getCompound(namespacedKey.getNamespace());
+            if(Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey())))
+                return nbtCompound.getString(namespacedKey.getKey());
+        }
+
+        return null;
+    }
+
+    public static @Nullable Float getFloat(final @NotNull NBTCompound nbtCompound, final String key) {
+        NamespacedKey namespacedKey = getNamespacedKey(key);
+        if(Boolean.TRUE.equals(nbtCompound.hasKey("PublicBukkitValues"))) {
+            NBTCompound publicBukkitValues = nbtCompound.getCompound("PublicBukkitValues");
+            if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+                return publicBukkitValues.getFloat(namespacedKey.toString());
+        }
+
+        //NBT API PR
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
+            return nbtCompound.getFloat(namespacedKey.toString());
+
+        //NBT COMPAT
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.getNamespace()))) {
+            NBTCompound emfCompound = nbtCompound.getCompound(namespacedKey.getNamespace());
+            if(Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey())))
+                return nbtCompound.getFloat(namespacedKey.getKey());
+        }
+
+        return null;
+    }
+
 
     @Contract("_ -> new")
     private static @NotNull NamespacedKey getNamespacedKey(final String key) {

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -1,7 +1,9 @@
 package com.oheers.fish;
 
 import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTItem;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -106,6 +108,11 @@ public class NbtUtils {
             return NbtVersion.LEGACY;
         return NbtVersion.NBTAPI;
     }
+
+    public static NbtVersion getNbtVersion(final ItemStack itemStack) {
+        return getNbtVersion(new NBTItem(itemStack));
+    }
+
 
 
     @Contract("_ -> new")

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -18,6 +18,7 @@ public class NbtUtils {
         public static final String EMF_FISH_LENGTH = "emf-fish-length";
         public static final String EMF_FISH_NAME = "emf-fish-name";
         public static final String EMF_BAIT = "emf-bait";
+        public static final String EMF_APPLIED_BAIT = "emf-applied-bait";
 
         public static final String PUBLIC_BUKKIT_VALUES = "PublicBukkitValues";
         public static final String DEFAULT_GUI_ITEM = "default-gui-item";
@@ -99,24 +100,6 @@ public class NbtUtils {
         }
 
         return null;
-    }
-    //todo could be void?
-    public static @NotNull NBTCompound setByte(final @NotNull NBTCompound nbtCompound, final String key, final Byte value) {
-        final NBTCompound emfCompound = nbtCompound.getOrCreateCompound(Keys.EMF_COMPOUND);
-        emfCompound.setByte(key,value);
-        return emfCompound;
-    }
-
-    public static @NotNull NBTCompound setString(final @NotNull NBTCompound nbtCompound, final String key, final String value) {
-        final NBTCompound emfCompound = nbtCompound.getOrCreateCompound(Keys.EMF_COMPOUND);
-        emfCompound.setString(key,value);
-        return emfCompound;
-    }
-
-    public static @NotNull NBTCompound setFloat(final @NotNull NBTCompound nbtCompound, final String key, final Float value) {
-        final NBTCompound emfCompound = nbtCompound.getOrCreateCompound(Keys.EMF_COMPOUND);
-        emfCompound.setFloat(key,value);
-        return emfCompound;
     }
 
     /**

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -50,19 +50,22 @@ public class NbtUtils {
         NamespacedKey namespacedKey = getNamespacedKey(key);
         if(Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
             NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
-            if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+            if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString()))) {
                 return publicBukkitValues.getString(namespacedKey.toString());
+            }
         }
 
         //NBT API PR
-        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString()))) {
             return nbtCompound.getString(namespacedKey.toString());
+        }
 
         //NBT COMPAT
         if(Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.getNamespace()))) {
             NBTCompound emfCompound = nbtCompound.getCompound(namespacedKey.getNamespace());
-            if(Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey())))
-                return nbtCompound.getString(namespacedKey.getKey());
+            if(Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey()))) {
+                return emfCompound.getString(namespacedKey.getKey());
+            }
         }
 
         return null;

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -13,12 +13,14 @@ import java.util.Locale;
 public class NbtUtils {
     public static class Keys {
         public static final String EMF_COMPOUND = JavaPlugin.getProvidingPlugin(NbtUtils.class).getName().toLowerCase(Locale.ROOT);
-        public static final String PUBLIC_BUKKIT_VALUES = "PublicBukkitValues";
         public static final String EMF_FISH_PLAYER = "emf-fish-player";
         public static final String EMF_FISH_RARITY = "emf-fish-rarity";
         public static final String EMF_FISH_LENGTH = "emf-fish-length";
         public static final String EMF_FISH_NAME = "emf-fish-name";
         public static final String EMF_BAIT = "emf-bait";
+
+        public static final String PUBLIC_BUKKIT_VALUES = "PublicBukkitValues";
+        public static final String DEFAULT_GUI_ITEM = "default-gui-item";
     }
 
     /*
@@ -98,10 +100,48 @@ public class NbtUtils {
 
         return null;
     }
+    //todo could be void?
+    public static @NotNull NBTCompound setByte(final @NotNull NBTCompound nbtCompound, final String key, final Byte value) {
+        final NBTCompound emfCompound = nbtCompound.getOrCreateCompound(Keys.EMF_COMPOUND);
+        emfCompound.setByte(key,value);
+        return emfCompound;
+    }
+
+    public static @NotNull NBTCompound setString(final @NotNull NBTCompound nbtCompound, final String key, final String value) {
+        final NBTCompound emfCompound = nbtCompound.getOrCreateCompound(Keys.EMF_COMPOUND);
+        emfCompound.setString(key,value);
+        return emfCompound;
+    }
+
+    public static @NotNull NBTCompound setFloat(final @NotNull NBTCompound nbtCompound, final String key, final Float value) {
+        final NBTCompound emfCompound = nbtCompound.getOrCreateCompound(Keys.EMF_COMPOUND);
+        emfCompound.setFloat(key,value);
+        return emfCompound;
+    }
+
+    /**
+     * Returns the NBT Version of the item
+     * It does not mean that this is an emf item.
+     * @param compound
+     * @return
+     */
+    public static NbtVersion getNbtVersion(final NBTCompound compound) {
+        if(Boolean.TRUE.equals(compound.hasKey(Keys.EMF_COMPOUND)))
+            return NbtVersion.COMPAT; //def an emf item
+        if(Boolean.TRUE.equals(compound.hasKey(Keys.PUBLIC_BUKKIT_VALUES)))
+            return NbtVersion.LEGACY;
+        return NbtVersion.NBTAPI;
+    }
 
 
     @Contract("_ -> new")
     private static @NotNull NamespacedKey getNamespacedKey(final String key) {
         return new NamespacedKey(JavaPlugin.getProvidingPlugin(NbtUtils.class), key);
+    }
+
+    public enum NbtVersion {
+        LEGACY, //pre nbt-api pr
+        NBTAPI, //nbt-api pr
+        COMPAT //compatible with everything :)
     }
 }

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -8,7 +8,19 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 public class NbtUtils {
+    public static class Keys {
+        public static final String EMF_COMPOUND = JavaPlugin.getProvidingPlugin(NbtUtils.class).getName().toLowerCase(Locale.ROOT);
+        public static final String PUBLIC_BUKKIT_VALUES = "PublicBukkitValues";
+        public static final String EMF_FISH_PLAYER = "emf-fish-player";
+        public static final String EMF_FISH_RARITY = "emf-fish-rarity";
+        public static final String EMF_FISH_LENGTH = "emf-fish-length";
+        public static final String EMF_FISH_NAME = "emf-fish-name";
+        public static final String EMF_BAIT = "emf-bait";
+    }
+
     /*
         3 possible options:
         legacy: <-- check for this first
@@ -23,8 +35,8 @@ public class NbtUtils {
         NamespacedKey namespacedKey = getNamespacedKey(key);
 
         //Pre NBT-API PR
-        if(Boolean.TRUE.equals(nbtCompound.hasKey("PublicBukkitValues"))) {
-            NBTCompound publicBukkitValues = nbtCompound.getCompound("PublicBukkitValues");
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+            NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
             if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
                 return true;
         }
@@ -45,8 +57,8 @@ public class NbtUtils {
 
     public static @Nullable String getString(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
-        if(Boolean.TRUE.equals(nbtCompound.hasKey("PublicBukkitValues"))) {
-            NBTCompound publicBukkitValues = nbtCompound.getCompound("PublicBukkitValues");
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+            NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
             if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
                 return publicBukkitValues.getString(namespacedKey.toString());
         }
@@ -67,8 +79,8 @@ public class NbtUtils {
 
     public static @Nullable Float getFloat(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
-        if(Boolean.TRUE.equals(nbtCompound.hasKey("PublicBukkitValues"))) {
-            NBTCompound publicBukkitValues = nbtCompound.getCompound("PublicBukkitValues");
+        if(Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+            NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
             if(Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
                 return publicBukkitValues.getFloat(namespacedKey.toString());
         }

--- a/src/main/java/com/oheers/fish/baits/BaitApplicationListener.java
+++ b/src/main/java/com/oheers/fish/baits/BaitApplicationListener.java
@@ -97,6 +97,7 @@ public class BaitApplicationListener implements Listener {
 
             if(Boolean.TRUE.equals(nbtFishingRod.hasKey(namespacedKey))) { //bugged version
                 nbtFishingRod.removeKey(namespacedKey);
+                nbtFishingRod.getCompound("display").setObject("Lore",null);
             }
         }
 

--- a/src/main/java/com/oheers/fish/baits/BaitApplicationListener.java
+++ b/src/main/java/com/oheers/fish/baits/BaitApplicationListener.java
@@ -1,10 +1,13 @@
 package com.oheers.fish.baits;
 
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.NbtUtils;
 import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
 import com.oheers.fish.exceptions.MaxBaitReachedException;
 import com.oheers.fish.exceptions.MaxBaitsReachedException;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTItem;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
@@ -12,6 +15,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.logging.Level;
 
 public class BaitApplicationListener implements Listener {
 
@@ -39,18 +44,24 @@ public class BaitApplicationListener implements Listener {
         ApplicationResult result = null;
         Bait bait = EvenMoreFish.baits.get(BaitNBTManager.getBaitName(event.getCursor()));
 
+        ItemStack fishingRod = clickedItem;
+        NbtUtils.NbtVersion nbtVersion = NbtUtils.getNbtVersion(clickedItem);
+        if (nbtVersion != NbtUtils.NbtVersion.COMPAT) {
+            fishingRod = convertToCompatNbtItem(nbtVersion, fishingRod);
+        }
+
         try {
             if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
-                result = BaitNBTManager.applyBaitedRodNBT(clickedItem, bait, event.getCursor().getAmount());
+                result = BaitNBTManager.applyBaitedRodNBT(fishingRod, bait, event.getCursor().getAmount());
                 EvenMoreFish.metric_baitsApplied += event.getCursor().getAmount();
             } else {
-                result = BaitNBTManager.applyBaitedRodNBT(clickedItem, bait, 1);
+                result = BaitNBTManager.applyBaitedRodNBT(fishingRod, bait, 1);
                 EvenMoreFish.metric_baitsApplied++;
             }
 
         } catch (MaxBaitsReachedException exception) {
             new Message(ConfigMessage.BAITS_MAXED).broadcast(event.getWhoClicked(), true, false);
-            return;
+            result = exception.getRecoveryResult();
         } catch (MaxBaitReachedException exception) {
             result = exception.getRecoveryResult();
             Message message = new Message(ConfigMessage.BAITS_MAXED_ON_ROD);
@@ -59,7 +70,9 @@ public class BaitApplicationListener implements Listener {
             message.broadcast(event.getWhoClicked(), true, true);
         }
 
-        if (result == null || result.getFishingRod() == null) return;
+        if (result == null || result.getFishingRod() == null)
+            return;
+
 
         event.setCancelled(true);
         event.setCurrentItem(result.getFishingRod());
@@ -72,7 +85,27 @@ public class BaitApplicationListener implements Listener {
             cursor.setAmount(cursor.getAmount() + cursorModifier);
             event.getWhoClicked().setItemOnCursor(cursor);
         }
+    }
 
+    private ItemStack convertToCompatNbtItem(final NbtUtils.NbtVersion nbtVersion, final ItemStack fishingRod) {
+        NBTItem nbtFishingRod = new NBTItem(fishingRod);
+        final String appliedBaitString = NbtUtils.getString(nbtFishingRod, NbtUtils.Keys.EMF_APPLIED_BAIT);
 
+        if (nbtVersion == NbtUtils.NbtVersion.LEGACY) {
+            final String namespacedKey = NbtUtils.Keys.EMF_COMPOUND+":"+NbtUtils.Keys.EMF_APPLIED_BAIT;
+            nbtFishingRod.getCompound(NbtUtils.Keys.PUBLIC_BUKKIT_VALUES).removeKey(namespacedKey);
+
+            if(Boolean.TRUE.equals(nbtFishingRod.hasKey(namespacedKey))) { //bugged version
+                nbtFishingRod.removeKey(namespacedKey);
+            }
+        }
+
+        if (nbtVersion == NbtUtils.NbtVersion.NBTAPI) {
+            nbtFishingRod.removeKey(NbtUtils.Keys.EMF_COMPOUND+":"+NbtUtils.Keys.EMF_APPLIED_BAIT);
+        }
+
+        NBTCompound emfCompound = nbtFishingRod.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
+        emfCompound.setString(NbtUtils.Keys.EMF_APPLIED_BAIT, appliedBaitString);
+        return nbtFishingRod.getItem();
     }
 }

--- a/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -24,9 +24,6 @@ import java.util.logging.Level;
 
 public class BaitNBTManager {
 
-	private static final NamespacedKey baitNBT = new NamespacedKey(JavaPlugin.getProvidingPlugin(BaitNBTManager.class), "emf-bait");
-	private static final NamespacedKey baitedRodNBT = new NamespacedKey(JavaPlugin.getProvidingPlugin(BaitNBTManager.class), "emf-applied-bait");
-
 	/**
 	 * Checks whether the item has nbt to suggest it is a bait object.
 	 *
@@ -360,15 +357,18 @@ public class BaitNBTManager {
 	 * @param itemStack The lore of the itemstack having the bait section of its lore removed.
 	 */
 	public static List<String> deleteOldLore(ItemStack itemStack) throws IndexOutOfBoundsException {
-		if(!itemStack.hasItemMeta() || !itemStack.getItemMeta().hasLore())
+		if(!itemStack.hasItemMeta() || itemStack.getItemMeta()  == null || !itemStack.getItemMeta().hasLore())
 			return Collections.emptyList();
 
 		List<String> lore = itemStack.getItemMeta().getLore();
+		if(lore == null)
+			return Collections.emptyList();
 
 		if (EvenMoreFish.baitFile.showUnusedBaitSlots()) {
 			// starting at 1, because at least one bait replacing {baits} is repeated.
 			for (int i = 1; i < EvenMoreFish.baitFile.getMaxBaits() + EvenMoreFish.baitFile.getRodLoreFormat().size(); i++) {
 				lore.remove(lore.size()-1);
+
 			}
 		} else {
 			// starting at 1, because at least one bait replacing {baits} is repeated.

--- a/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -96,7 +96,7 @@ public class BaitNBTManager {
 		boolean maxBait = false;
 		int cursorModifier = 0;
 
-		NBTItem nbtItem = new NBTItem(item);
+		NBTItem nbtItem;
 		if (isBaitedRod(item)) {
 
 			try {
@@ -110,7 +110,7 @@ public class BaitNBTManager {
 				return null;
 			}
 
-
+			nbtItem = new NBTItem(item);
 			String[] baitList = nbtItem.getString(baitedRodNBT.toString()).split(",");
 			StringBuilder combined = new StringBuilder();
 
@@ -164,6 +164,7 @@ public class BaitNBTManager {
 				nbtItem.removeKey(baitedRodNBT.toString());
 			}
 		} else {
+			nbtItem = new NBTItem(item);
 			if (quantity > bait.getMaxApplications() && bait.getMaxApplications() != -1) {
 				nbtItem.setString(baitedRodNBT.toString(),bait.getName() + ":" + bait.getMaxApplications());
 				cursorModifier = -bait.getMaxApplications();

--- a/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -13,6 +13,8 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,12 +45,11 @@ public class BaitNBTManager {
 	 * @param itemStack The item stack that is a bait.
 	 * @return The name of the bait.
 	 */
-	public static String getBaitName(ItemStack itemStack) {
-		if (itemStack == null) return null;
-
+	public static @Nullable String getBaitName(@NotNull ItemStack itemStack) {
 		if (itemStack.hasItemMeta()) {
 			return NbtUtils.getString(new NBTItem(itemStack), NbtUtils.Keys.EMF_BAIT);
-		} else return null;
+		}
+		return null;
 	}
 
 	/**
@@ -64,7 +65,6 @@ public class BaitNBTManager {
 		NBTItem nbtItem = new NBTItem(item);
 		NBTCompound emfCompound = nbtItem.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
 		emfCompound.setString(NbtUtils.Keys.EMF_BAIT, bait);
-		nbtItem.setObject(NbtUtils.Keys.EMF_BAIT, emfCompound);
 		return nbtItem.getItem();
 	}
 
@@ -169,7 +169,6 @@ public class BaitNBTManager {
 			} else {
 				emfCompound.removeKey(NbtUtils.Keys.EMF_APPLIED_BAIT);
 			}
-			nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
 		} else {
 			nbtItem = new NBTItem(item);
 			NBTCompound emfCompound = nbtItem.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
@@ -181,7 +180,6 @@ public class BaitNBTManager {
 				emfCompound.setString(NbtUtils.Keys.EMF_APPLIED_BAIT, bait.getName() + ":" + quantity);
 				cursorModifier = -quantity;
 			}
-			nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
 		}
 
 		item = nbtItem.getItem();

--- a/src/main/java/com/oheers/fish/exceptions/MaxBaitsReachedException.java
+++ b/src/main/java/com/oheers/fish/exceptions/MaxBaitsReachedException.java
@@ -1,8 +1,16 @@
 package com.oheers.fish.exceptions;
 
-public class MaxBaitsReachedException extends Exception {
+import com.oheers.fish.baits.ApplicationResult;
 
-	public MaxBaitsReachedException(String errorMessage) {
+public class MaxBaitsReachedException extends Exception {
+	ApplicationResult recoveryResult;
+
+	public MaxBaitsReachedException(String errorMessage, ApplicationResult recoveryResult) {
 		super(errorMessage);
+		this.recoveryResult = recoveryResult;
+	}
+
+	public ApplicationResult getRecoveryResult() {
+		return recoveryResult;
 	}
 }

--- a/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -60,18 +60,15 @@ public class WorthNBT {
         Float length = nbtItem.getFloat(nbtlength.toString());
         String rarity = nbtItem.getString(nbtrarity.toString());
         String name = nbtItem.getString(nbtname.toString());
+
+
         // gets a possible set-worth in the fish.yml
-        int setVal;
-
         try {
-            setVal = EvenMoreFish.fishFile.getConfig().getInt("fish." + rarity + "." + name + ".set-worth");
+            return EvenMoreFish.fishFile.getConfig().getInt("fish." + rarity + "." + name + ".set-worth");
         } catch (NullPointerException npe) {
-            setVal = 0;
+            // there's no set-worth so we're calculating the worth ourselves
+            return getMultipliedValue(length, rarity, name);
         }
-
-        if (setVal != 0) return setVal;
-        // there's no set-worth so we're calculating the worth ourselves
-        return getMultipliedValue(length, rarity, name);
     }
 
     public static ItemStack attributeDefault(ItemStack defaultGUIItem) {

--- a/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -2,45 +2,46 @@ package com.oheers.fish.selling;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
+import com.oheers.fish.NbtUtils;
+import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTItem;
 import de.tr7zw.changeme.nbtapi.NBTTileEntity;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Skull;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 public class WorthNBT {
 
-    public static ItemStack setNBT(ItemStack fish, Float length, UUID player, String rarity, String name) {
+    public static ItemStack setNBT(ItemStack fish, Float length, @NotNull UUID player, String rarity, String name) {
         // creates key and plops in the value of "value"
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-length");
-        NamespacedKey nbtplayer = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-player");
-        NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-rarity");
-        NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-name");
-
         NBTItem nbtItem = new NBTItem(fish);
-        nbtItem.setFloat(nbtlength.toString(), length);
-        nbtItem.setString(nbtplayer.toString(), player.toString());
-        nbtItem.setString(nbtrarity.toString(), rarity);
-        nbtItem.setString(nbtname.toString(), name);
+
+        NBTCompound emfCompound = nbtItem.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
+        emfCompound.setFloat(NbtUtils.Keys.EMF_FISH_LENGTH, length);
+        emfCompound.setString(NbtUtils.Keys.EMF_FISH_PLAYER, player.toString());
+        emfCompound.setString(NbtUtils.Keys.EMF_FISH_NAME, name);
+        emfCompound.setString(NbtUtils.Keys.EMF_FISH_RARITY, rarity);
+        nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
 
         return nbtItem.getItem();
     }
 
     public static void setNBT(Skull fish, Float length, UUID player, String rarity, String name) {
         // creates key and plops in the value of "value"
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-length");
-        NamespacedKey nbtplayer = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-player");
-        NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-rarity");
-        NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-name");
-
         NBTTileEntity nbtItem = new NBTTileEntity(fish);
-        nbtItem.setFloat(nbtlength.toString(), length);
-        if (player != null) nbtItem.setString(nbtplayer.toString(), player.toString());
-        nbtItem.setString(nbtrarity.toString(), rarity);
-        nbtItem.setString(nbtname.toString(), name);
+        NBTCompound emfCompound = nbtItem.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
+        emfCompound.setFloat(NbtUtils.Keys.EMF_FISH_LENGTH, length);
+
+        if (player != null) {
+            emfCompound.setString(NbtUtils.Keys.EMF_FISH_PLAYER, player.toString());
+        }
+        emfCompound.setString(NbtUtils.Keys.EMF_FISH_NAME, name);
+        emfCompound.setString(NbtUtils.Keys.EMF_FISH_RARITY, rarity);
+        nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
     }
 
 
@@ -50,16 +51,12 @@ public class WorthNBT {
             return -1.0;
         }
 
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-length");
-        NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-rarity");
-        NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-name");
-
 
         NBTItem nbtItem = new NBTItem(item);
         // it's a fish so it'll definitely have these NBT values
-        Float length = nbtItem.getFloat(nbtlength.toString());
-        String rarity = nbtItem.getString(nbtrarity.toString());
-        String name = nbtItem.getString(nbtname.toString());
+        Float length = NbtUtils.getFloat(nbtItem, NbtUtils.Keys.EMF_FISH_LENGTH);
+        String rarity = NbtUtils.getString(nbtItem, NbtUtils.Keys.EMF_FISH_RARITY);
+        String name = NbtUtils.getString(nbtItem, NbtUtils.Keys.EMF_FISH_NAME);
 
 
         // gets a possible set-worth in the fish.yml
@@ -72,15 +69,15 @@ public class WorthNBT {
     }
 
     public static ItemStack attributeDefault(ItemStack defaultGUIItem) {
-        NamespacedKey key = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "default-gui-item");
         NBTItem nbtItem = new NBTItem(defaultGUIItem);
-        nbtItem.setByte(key.toString(), Byte.MAX_VALUE);
+        NBTCompound emfCompound = nbtItem.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
+        emfCompound.setByte(NbtUtils.Keys.DEFAULT_GUI_ITEM, Byte.MAX_VALUE);
+        nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
         return nbtItem.getItem();
     }
 
     public static boolean isDefault(ItemStack is) {
-        NamespacedKey key = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "default-gui-item");
-        return new NBTItem(is).hasKey(key.toString());
+        return NbtUtils.hasKey(new NBTItem(is), NbtUtils.Keys.DEFAULT_GUI_ITEM);
     }
 
     private static double getMultipliedValue(Float length, String rarity, String name) {

--- a/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -21,10 +21,10 @@ public class WorthNBT {
         NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-name");
 
         NBTItem nbtItem = new NBTItem(fish);
-        nbtItem.setFloat(nbtlength.toString(),length);
-        nbtItem.setString(nbtplayer.toString(),player.toString());
-        nbtItem.setString(nbtrarity.toString(),rarity);
-        nbtItem.setString(nbtname.toString(),name);
+        nbtItem.setFloat(nbtlength.toString(), length);
+        nbtItem.setString(nbtplayer.toString(), player.toString());
+        nbtItem.setString(nbtrarity.toString(), rarity);
+        nbtItem.setString(nbtname.toString(), name);
 
         return nbtItem.getItem();
     }
@@ -37,53 +37,47 @@ public class WorthNBT {
         NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-name");
 
         NBTTileEntity nbtItem = new NBTTileEntity(fish);
-        nbtItem.setFloat(nbtlength.toString(),length);
-        if (player != null) nbtItem.setString(nbtplayer.toString(),player.toString());
-        nbtItem.setString(nbtrarity.toString(),rarity);
-        nbtItem.setString(nbtname.toString(),name);
+        nbtItem.setFloat(nbtlength.toString(), length);
+        if (player != null) nbtItem.setString(nbtplayer.toString(), player.toString());
+        nbtItem.setString(nbtrarity.toString(), rarity);
+        nbtItem.setString(nbtname.toString(), name);
     }
 
 
     public static double getValue(ItemStack item) {
         // creating the key to check for
+        if (item == null || !item.hasItemMeta() || !FishUtils.isFish(item)) {
+            return -1.0;
+        }
+
         NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-length");
         NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-rarity");
         NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "emf-fish-name");
 
-        if (item != null) {
-            if (item.hasItemMeta()) {
-                if (FishUtils.isFish(item)) {
-                    NBTItem nbtItem = new NBTItem(item);
-                    // it's a fish so it'll definitely have these NBT values
-                    Float length = nbtItem.getFloat(nbtlength.toString());
-                    String rarity = nbtItem.getString(nbtrarity.toString());
-                    String name = nbtItem.getString(nbtname.toString());
-                    // gets a possible set-worth in the fish.yml
-                    int setVal;
 
-                    try {
-                        setVal = EvenMoreFish.fishFile.getConfig().getInt("fish." + rarity + "." + name + ".set-worth");
-                    } catch (NullPointerException npe) {
-                        setVal = 0;
-                    }
+        NBTItem nbtItem = new NBTItem(item);
+        // it's a fish so it'll definitely have these NBT values
+        Float length = nbtItem.getFloat(nbtlength.toString());
+        String rarity = nbtItem.getString(nbtrarity.toString());
+        String name = nbtItem.getString(nbtname.toString());
+        // gets a possible set-worth in the fish.yml
+        int setVal;
 
-                    if (setVal != 0) return setVal;
-                    // there's no set-worth so we're calculating the worth ourselves
-                    return getMultipliedValue(
-                            length,
-                            rarity,
-                            name);
-                } else return -1.0;
-            } else {
-                return -1.0;
-            }
-        } else return -1.0;
+        try {
+            setVal = EvenMoreFish.fishFile.getConfig().getInt("fish." + rarity + "." + name + ".set-worth");
+        } catch (NullPointerException npe) {
+            setVal = 0;
+        }
+
+        if (setVal != 0) return setVal;
+        // there's no set-worth so we're calculating the worth ourselves
+        return getMultipliedValue(length, rarity, name);
     }
 
     public static ItemStack attributeDefault(ItemStack defaultGUIItem) {
         NamespacedKey key = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), "default-gui-item");
         NBTItem nbtItem = new NBTItem(defaultGUIItem);
-        nbtItem.setByte(key.toString(),Byte.MAX_VALUE);
+        nbtItem.setByte(key.toString(), Byte.MAX_VALUE);
         return nbtItem.getItem();
     }
 
@@ -104,7 +98,7 @@ public class WorthNBT {
         // Whatever it finds the value to be, gets multiplied by the fish length and set
         value *= length;
         // Sorts out funky decimals during the above multiplication.
-        value = Math.round(value*10.0)/10.0;
+        value = Math.round(value * 10.0) / 10.0;
 
         return value;
     }

--- a/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -25,7 +25,6 @@ public class WorthNBT {
         emfCompound.setString(NbtUtils.Keys.EMF_FISH_PLAYER, player.toString());
         emfCompound.setString(NbtUtils.Keys.EMF_FISH_NAME, name);
         emfCompound.setString(NbtUtils.Keys.EMF_FISH_RARITY, rarity);
-        nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
 
         return nbtItem.getItem();
     }
@@ -41,7 +40,6 @@ public class WorthNBT {
         }
         emfCompound.setString(NbtUtils.Keys.EMF_FISH_NAME, name);
         emfCompound.setString(NbtUtils.Keys.EMF_FISH_RARITY, rarity);
-        nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
     }
 
 
@@ -72,7 +70,6 @@ public class WorthNBT {
         NBTItem nbtItem = new NBTItem(defaultGUIItem);
         NBTCompound emfCompound = nbtItem.getOrCreateCompound(NbtUtils.Keys.EMF_COMPOUND);
         emfCompound.setByte(NbtUtils.Keys.DEFAULT_GUI_ITEM, Byte.MAX_VALUE);
-        nbtItem.setObject(NbtUtils.Keys.EMF_COMPOUND, emfCompound);
         return nbtItem.getItem();
     }
 


### PR DESCRIPTION
This fixes the duplicated lore bug.

It will also convert old fishing rods into the new format. Once you try and apply a bait to an old fishing rod or a "bugged" fishing rod, it will convert the nbt data & fix the lore.

This adds a new nbt compound "evenmorefish". Instead of prefixing every tag with
`evenmorefish:emf-bait` you can now refer to it as just`emf-bait`.

Also added an NbtUtils class for backwards compatibility with old items.

