### PR TITLE
Better ItemsAdder compatability

### DIFF
--- a/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -10,10 +10,7 @@ import com.oheers.fish.config.*;
 import com.oheers.fish.config.messages.Messages;
 import com.oheers.fish.database.Database;
 import com.oheers.fish.database.FishReport;
-import com.oheers.fish.events.AureliumSkillsFishingEvent;
-import com.oheers.fish.events.FishEatEvent;
-import com.oheers.fish.events.FishInteractEvent;
-import com.oheers.fish.events.McMMOTreasureEvent;
+import com.oheers.fish.events.*;
 import com.oheers.fish.fishing.FishingProcessor;
 import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.Names;
@@ -154,6 +151,10 @@ public class EvenMoreFish extends JavaPlugin {
                 logger.log(Level.WARNING, "Could not update messages.yml");
             }
         });
+
+        if (Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
+            Bukkit.getPluginManager().registerEvents(new ItemsAdderLoadEvent(this), this);
+        }
 
         listeners();
         commands();

--- a/src/main/java/com/oheers/fish/events/ItemsAdderLoadEvent.java
+++ b/src/main/java/com/oheers/fish/events/ItemsAdderLoadEvent.java
@@ -1,0 +1,22 @@
+package com.oheers.fish.events;
+
+import com.oheers.fish.EvenMoreFish;
+import dev.lone.itemsadder.api.Events.ItemsAdderLoadDataEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ItemsAdderLoadEvent implements Listener {
+    private final EvenMoreFish plugin;
+
+    public ItemsAdderLoadEvent(EvenMoreFish plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onItemsLoad(ItemsAdderLoadDataEvent event) {
+        plugin.getLogger().info("Detected that itemsadder has finished loading all items...");
+        plugin.getLogger().info("Reloading EMF.");
+        plugin.reload();
+    }
+
+}


### PR DESCRIPTION
Ensures that baits & fish are loaded in properly.
This will reload emf after all itemsadder items have loaded in.

Right now for baits/fish to get proper itemsadder values we must run /emf reload. This will make it so we no longer need to reload emf after making changes to items in itemsadder.