### PR TITLE
Fixes ItemsAdder spam on EMF first load

### DIFF
--- a/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -84,6 +84,8 @@ public class EvenMoreFish extends JavaPlugin {
     public static boolean isUpdateAvailable;
     public static boolean usingPAPI;
     public static boolean usingMcMMO;
+
+    public static boolean itemsAdderLoaded = false;
     public static WorldGuardPlugin wgPlugin;
     public static String guardPL;
     public static boolean papi;

--- a/src/main/java/com/oheers/fish/events/ItemsAdderLoadEvent.java
+++ b/src/main/java/com/oheers/fish/events/ItemsAdderLoadEvent.java
@@ -16,6 +16,7 @@ public class ItemsAdderLoadEvent implements Listener {
     public void onItemsLoad(ItemsAdderLoadDataEvent event) {
         plugin.getLogger().info("Detected that itemsadder has finished loading all items...");
         plugin.getLogger().info("Reloading EMF.");
+        EvenMoreFish.itemsAdderLoaded = true;
         plugin.reload();
     }
 

--- a/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -10,7 +10,11 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.*;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -183,7 +187,9 @@ public class ItemFactory {
             final String namespaceId = splitMaterialValue[1] + ":" + splitMaterialValue[2];
             final CustomStack customStack = CustomStack.getInstance(namespaceId);
             if (customStack == null) {
-                EvenMoreFish.logger.info(() -> String.format("Could not obtain itemsadder item %s", namespaceId));
+                if(EvenMoreFish.itemsAdderLoaded) {
+                    EvenMoreFish.logger.info(() -> String.format("Could not obtain itemsadder item %s", namespaceId));
+                }
                 return new ItemStack(Material.COD);
             }
             return CustomStack.getInstance(namespaceId).getItemStack();


### PR DESCRIPTION
This will prevent the "`Could not obtain itemsadder item %s`" error that happen when EMF loads but before the items for ItemsAdder have loaded in.