### PR TITLE
Fixes #173

### DIFF
--- a/src/main/java/com/oheers/fish/FishUtils.java
+++ b/src/main/java/com/oheers/fish/FishUtils.java
@@ -13,10 +13,7 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
-import de.tr7zw.changeme.nbtapi.NBTCompound;
-import de.tr7zw.changeme.nbtapi.NBTItem;
-import de.tr7zw.changeme.nbtapi.NBTListCompound;
-import de.tr7zw.changeme.nbtapi.NBTTileEntity;
+import de.tr7zw.changeme.nbtapi.*;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
@@ -104,18 +101,17 @@ public class FishUtils {
 
     public static Fish getFish(Skull skull, Player fisher) throws InvalidFishException {
         // all appropriate null checks can be safely assumed to have passed to get to a point where we're running this method.
-        NBTTileEntity nbtSkull = new NBTTileEntity(skull);
-
-        String nameString = NbtUtils.getString(nbtSkull, NbtUtils.Keys.EMF_FISH_NAME);
-        String playerString = NbtUtils.getString(nbtSkull, NbtUtils.Keys.EMF_FISH_PLAYER);
-        String rarityString = NbtUtils.getString(nbtSkull, NbtUtils.Keys.EMF_FISH_RARITY);
-        Float lengthFloat = NbtUtils.getFloat(nbtSkull, NbtUtils.Keys.EMF_FISH_LENGTH);
-        Integer randomIndex = NbtUtils.getInteger(nbtSkull, NbtUtils.Keys.EMF_FISH_RANDOM_INDEX);
-        Integer xmasINT = NbtUtils.getInteger(nbtSkull, NbtUtils.Keys.EMF_XMAS_FISH);
+        final String nameString = NBT.getPersistentData(skull,nbt -> nbt.getString(NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_NAME).toString()));
+        final String playerString = NBT.getPersistentData(skull, nbt -> nbt.getString(NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_PLAYER).toString()));
+        final String rarityString = NBT.getPersistentData(skull, nbt -> nbt.getString(NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_RARITY).toString()));
+        final Float lengthFloat = NBT.getPersistentData(skull,nbt -> nbt.getFloat(NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_LENGTH).toString()));
+        final Integer randomIndex = NBT.getPersistentData(skull,nbt -> nbt.getInteger(NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_RANDOM_INDEX).toString()));
+        final Integer xmasInteger = NBT.getPersistentData(skull, nbt -> nbt.getInteger(NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_XMAS_FISH).toString()));
+        
         boolean isXmasFish = false;
 
-        if (xmasINT != null) {
-            isXmasFish = xmasINT == 1;
+        if (xmasInteger != null) {
+            isXmasFish = xmasInteger == 1;
         }
 
         if (nameString == null || rarityString == null)

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -44,14 +44,14 @@ public class NbtUtils {
         }
 
         //NBT API PR
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString()))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(namespacedKey.toString()))) {
             return nbtCompound.getString(namespacedKey.toString());
         }
 
         //NBT COMPAT
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.getNamespace()))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(namespacedKey.getNamespace()))) {
             NBTCompound emfCompound = nbtCompound.getCompound(namespacedKey.getNamespace());
-            if (Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey()))) {
+            if (Boolean.TRUE.equals(emfCompound.hasTag(namespacedKey.getKey()))) {
                 return emfCompound.getString(namespacedKey.getKey());
             }
         }

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -15,20 +15,20 @@ public class NbtUtils {
     public static boolean hasKey(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
         //Pre NBT-API PR
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.PUBLIC_BUKKIT_VALUES))) {
             NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
-            if (Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+            if (Boolean.TRUE.equals(publicBukkitValues.hasTag(namespacedKey.toString())))
                 return true;
         }
 
         //NBT API PR
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(namespacedKey.toString())))
             return true;
 
         //NBT COMPAT
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.getNamespace()))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(namespacedKey.getNamespace()))) {
             NBTCompound emfCompound = nbtCompound.getCompound(namespacedKey.getNamespace());
-            return Boolean.TRUE.equals(emfCompound.hasKey(namespacedKey.getKey()));
+            return Boolean.TRUE.equals(emfCompound.hasTag(namespacedKey.getKey()));
         }
 
         return false;
@@ -36,9 +36,9 @@ public class NbtUtils {
 
     public static @Nullable String getString(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.PUBLIC_BUKKIT_VALUES))) {
             NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
-            if (Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString()))) {
+            if (Boolean.TRUE.equals(publicBukkitValues.hasTag(namespacedKey.toString()))) {
                 return publicBukkitValues.getString(namespacedKey.toString());
             }
         }
@@ -61,20 +61,20 @@ public class NbtUtils {
 
     public static @Nullable Float getFloat(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.PUBLIC_BUKKIT_VALUES))) {
             NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
-            if (Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+            if (Boolean.TRUE.equals(publicBukkitValues.hasTag(namespacedKey.toString())))
                 return publicBukkitValues.getFloat(namespacedKey.toString());
         }
 
         //NBT API PR
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(namespacedKey.toString())))
             return nbtCompound.getFloat(namespacedKey.toString());
 
         //NBT COMPAT
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(Keys.EMF_COMPOUND))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.EMF_COMPOUND))) {
             NBTCompound emfCompound = nbtCompound.getCompound(Keys.EMF_COMPOUND);
-            if (Boolean.TRUE.equals(emfCompound.hasKey(key)))
+            if (Boolean.TRUE.equals(emfCompound.hasTag(key)))
                 return emfCompound.getFloat(key);
         }
 
@@ -83,20 +83,20 @@ public class NbtUtils {
 
     public static @Nullable Integer getInteger(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(Keys.PUBLIC_BUKKIT_VALUES))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.PUBLIC_BUKKIT_VALUES))) {
             NBTCompound publicBukkitValues = nbtCompound.getCompound(Keys.PUBLIC_BUKKIT_VALUES);
-            if (Boolean.TRUE.equals(publicBukkitValues.hasKey(namespacedKey.toString())))
+            if (Boolean.TRUE.equals(publicBukkitValues.hasTag(namespacedKey.toString())))
                 return publicBukkitValues.getInteger(namespacedKey.toString());
         }
 
         //NBT API PR
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(namespacedKey.toString())))
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(namespacedKey.toString())))
             return nbtCompound.getInteger(namespacedKey.toString());
 
         //NBT COMPAT
-        if (Boolean.TRUE.equals(nbtCompound.hasKey(Keys.EMF_COMPOUND))) {
+        if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.EMF_COMPOUND))) {
             NBTCompound emfCompound = nbtCompound.getCompound(Keys.EMF_COMPOUND);
-            if (Boolean.TRUE.equals(emfCompound.hasKey(key)))
+            if (Boolean.TRUE.equals(emfCompound.hasTag(key)))
                 return emfCompound.getInteger(key);
         }
 
@@ -111,9 +111,9 @@ public class NbtUtils {
      * @return nbt version
      */
     public static NbtVersion getNbtVersion(final NBTCompound compound) {
-        if (Boolean.TRUE.equals(compound.hasKey(Keys.EMF_COMPOUND)))
+        if (Boolean.TRUE.equals(compound.hasTag(Keys.EMF_COMPOUND)))
             return NbtVersion.COMPAT; //def an emf item
-        if (Boolean.TRUE.equals(compound.hasKey(Keys.PUBLIC_BUKKIT_VALUES)))
+        if (Boolean.TRUE.equals(compound.hasTag(Keys.PUBLIC_BUKKIT_VALUES)))
             return NbtVersion.LEGACY;
         return NbtVersion.NBTAPI;
     }

--- a/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/src/main/java/com/oheers/fish/NbtUtils.java
@@ -1,5 +1,6 @@
 package com.oheers.fish;
 
+import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTItem;
 import org.bukkit.NamespacedKey;
@@ -33,7 +34,7 @@ public class NbtUtils {
 
         return false;
     }
-
+    
     public static @Nullable String getString(final @NotNull NBTCompound nbtCompound, final String key) {
         NamespacedKey namespacedKey = getNamespacedKey(key);
         if (Boolean.TRUE.equals(nbtCompound.hasTag(Keys.PUBLIC_BUKKIT_VALUES))) {
@@ -123,7 +124,7 @@ public class NbtUtils {
     }
 
     @Contract("_ -> new")
-    private static @NotNull NamespacedKey getNamespacedKey(final String key) {
+    public static @NotNull NamespacedKey getNamespacedKey(final String key) {
         return new NamespacedKey(JavaPlugin.getProvidingPlugin(NbtUtils.class), key);
     }
 

--- a/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/src/main/java/com/oheers/fish/SkullSaver.java
@@ -29,7 +29,7 @@ public class SkullSaver implements Listener {
         if (event.getPlayer().getGameMode() != GameMode.SURVIVAL) return;
         Block block = event.getBlock();
         if (block.getType() == Material.PLAYER_HEAD || block.getType() == Material.PLAYER_WALL_HEAD) {
-            if (block.getDrops().size() == 0) return;
+            if (block.getDrops().isEmpty()) return;
 
             BlockState state = event.getBlock().getState();
             Skull sm = (Skull) state;
@@ -70,7 +70,6 @@ public class SkullSaver implements Listener {
         }
 
         if (FishUtils.isFish(stack)) {
-
             if (EvenMoreFish.mainConfig.blockPlacingHeads()) {
                 event.setCancelled(true);
                 new Message(ConfigMessage.FISH_CANT_BE_PLACED).broadcast(event.getPlayer(), true, false);

--- a/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/src/main/java/com/oheers/fish/SkullSaver.java
@@ -21,67 +21,68 @@ import org.bukkit.inventory.ItemStack;
 import java.util.logging.Level;
 
 public class SkullSaver implements Listener {
-
+    
     // EventPriority.HIGHEST makes this run last so it can listen to the cancels of protection plugins like Towny
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onBreak(BlockBreakEvent event) {
         if (event.isCancelled()) return;
         if (event.getPlayer().getGameMode() != GameMode.SURVIVAL) return;
         Block block = event.getBlock();
-        if (block.getType() == Material.PLAYER_HEAD || block.getType() == Material.PLAYER_WALL_HEAD) {
-            if (block.getDrops().isEmpty()) return;
-
-            BlockState state = event.getBlock().getState();
-            Skull sm = (Skull) state;
-            if (FishUtils.isFish(sm)) {
-                ItemStack stack = block.getDrops().iterator().next().clone();
-                event.setCancelled(true);
-
-                try {
-                    Fish f = FishUtils.getFish(sm, event.getPlayer());
-
-                    stack.setItemMeta(f.give(f.getFactory().getChosenRandomIndex()).getItemMeta());
-                    block.setType(Material.AIR);
-                    block.getWorld().dropItem(block.getLocation(), stack);
-                    block.getWorld().playSound(block.getLocation(), Sound.BLOCK_BONE_BLOCK_BREAK, 1, 1);
-                } catch (InvalidFishException exception) {
-                    EvenMoreFish.logger.log(Level.SEVERE, "Error fetching fish from config at location:" +
-                            " x:" + event.getBlock().getLocation().getBlockX() +
-                            " y:" + event.getBlock().getLocation().getBlockY() +
-                            " z:" + event.getBlock().getLocation().getBlockZ() +
-                            " world:" + event.getBlock().getLocation().getBlock().getWorld().getName());
-                }
+        
+        if (!isHead(block)) return;
+        if (block.getDrops().isEmpty()) return;
+        
+        BlockState state = event.getBlock().getState();
+        Skull sm = (Skull) state;
+        if (FishUtils.isFish(sm)) {
+            ItemStack stack = block.getDrops().iterator().next().clone();
+            event.setCancelled(true);
+            
+            try {
+                Fish f = FishUtils.getFish(sm, event.getPlayer());
+                
+                stack.setItemMeta(f.give(f.getFactory().getChosenRandomIndex()).getItemMeta());
+                block.setType(Material.AIR);
+                block.getWorld().dropItem(block.getLocation(), stack);
+                block.getWorld().playSound(block.getLocation(), Sound.BLOCK_BONE_BLOCK_BREAK, 1, 1);
+            } catch (InvalidFishException exception) {
+                EvenMoreFish.logger.log(Level.SEVERE, "Error fetching fish from config at location:" +
+                    " x:" + event.getBlock().getLocation().getBlockX() +
+                    " y:" + event.getBlock().getLocation().getBlockY() +
+                    " z:" + event.getBlock().getLocation().getBlockZ() +
+                    " world:" + event.getBlock().getLocation().getBlock().getWorld().getName());
             }
         }
+        
     }
-
+    
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlace(BlockPlaceEvent event) {
-
+        
         if (event.isCancelled()) {
             return;
         }
-
+        
         Block block = event.getBlock();
         ItemStack stack = event.getItemInHand();
-
+        
         if (stack.getAmount() == 0 || !stack.hasItemMeta()) {
             return;
         }
-
+        
         if (FishUtils.isFish(stack)) {
             if (EvenMoreFish.mainConfig.blockPlacingHeads()) {
                 event.setCancelled(true);
                 new Message(ConfigMessage.FISH_CANT_BE_PLACED).broadcast(event.getPlayer(), true, false);
                 return;
             }
-
+            
             if (block.getState() instanceof Skull) {
-                Fish f = FishUtils.getFish(stack);
-                if (f != null) {
+                Fish fish = FishUtils.getFish(stack);
+                if (fish != null) {
                     BlockState state = block.getState();
                     Skull sm = (Skull) state;
-                    WorthNBT.setNBT(sm, f);
+                    WorthNBT.setNBT(sm, fish);
                     sm.update();
                 }
             } else {
@@ -89,4 +90,9 @@ public class SkullSaver implements Listener {
             }
         }
     }
+    
+    private boolean isHead(final Block block) {
+        return block.getType() == Material.PLAYER_HEAD || block.getType() == Material.PLAYER_WALL_HEAD;
+    }
+    
 }

--- a/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/src/main/java/com/oheers/fish/SkullSaver.java
@@ -41,7 +41,7 @@ public class SkullSaver implements Listener {
         event.setCancelled(true);
         
         try {
-            Fish f = FishUtils.getFish(skullMeta, event.getPlayer()); //issue 173
+            Fish f = FishUtils.getFish(skullMeta, event.getPlayer());
             
             stack.setItemMeta(f.give(f.getFactory().getChosenRandomIndex()).getItemMeta());
             block.setType(Material.AIR);

--- a/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/src/main/java/com/oheers/fish/SkullSaver.java
@@ -33,26 +33,30 @@ public class SkullSaver implements Listener {
         if (block.getDrops().isEmpty()) return;
         
         BlockState state = event.getBlock().getState();
-        Skull sm = (Skull) state;
-        if (FishUtils.isFish(sm)) {
-            ItemStack stack = block.getDrops().iterator().next().clone();
-            event.setCancelled(true);
+        Skull skullMeta = (Skull) state;
+        if (!FishUtils.isFish(skullMeta)) return;
+        
+        
+        ItemStack stack = block.getDrops().iterator().next().clone();
+        event.setCancelled(true);
+        
+        try {
+            Fish f = FishUtils.getFish(skullMeta, event.getPlayer()); //issue 173
             
-            try {
-                Fish f = FishUtils.getFish(sm, event.getPlayer());
-                
-                stack.setItemMeta(f.give(f.getFactory().getChosenRandomIndex()).getItemMeta());
-                block.setType(Material.AIR);
-                block.getWorld().dropItem(block.getLocation(), stack);
-                block.getWorld().playSound(block.getLocation(), Sound.BLOCK_BONE_BLOCK_BREAK, 1, 1);
-            } catch (InvalidFishException exception) {
-                EvenMoreFish.logger.log(Level.SEVERE, "Error fetching fish from config at location:" +
-                    " x:" + event.getBlock().getLocation().getBlockX() +
-                    " y:" + event.getBlock().getLocation().getBlockY() +
-                    " z:" + event.getBlock().getLocation().getBlockZ() +
-                    " world:" + event.getBlock().getLocation().getBlock().getWorld().getName());
-            }
+            stack.setItemMeta(f.give(f.getFactory().getChosenRandomIndex()).getItemMeta());
+            block.setType(Material.AIR);
+            block.getWorld().dropItem(block.getLocation(), stack);
+            block.getWorld().playSound(block.getLocation(), Sound.BLOCK_BONE_BLOCK_BREAK, 1, 1);
+        } catch (InvalidFishException exception) {
+            EvenMoreFish.logger.severe(() -> String.format("Error fetching fish from config at location: " +
+                "x:%d y:%d z:%d world:%s",
+                block.getLocation().getBlockX(),
+                block.getLocation().getBlockY(),
+                block.getLocation().getBlockZ(),
+                block.getLocation().getBlock().getWorld().getName()
+                ));
         }
+        
         
     }
     

--- a/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -64,20 +64,14 @@ public class Fish implements Cloneable {
         this.weight = 0;
         this.length = -1F;
         this.xmasFish = isXmas2022Fish;
-        if (this.xmasFish) {
-            this.fishConfig = EvenMoreFish.xmas2022Config.getConfig();
-            this.rarityConfig = EvenMoreFish.xmas2022Config.getConfig();
-        } else {
-            this.fishConfig = EvenMoreFish.fishFile.getConfig();
-            this.rarityConfig = EvenMoreFish.raritiesFile.getConfig();
-        }
+        this.setFishAndRarityConfig();
         final boolean defaultRarityDisableFisherman = EvenMoreFish.raritiesFile.getConfig().getBoolean("rarities." + this.rarity.getValue() + ".disable-fisherman", false);
         this.disableFisherman = this.fishConfig.getBoolean("fish." + this.rarity.getValue() + "." + this.name + ".disable-fisherman", defaultRarityDisableFisherman);
 
         if (rarity == null)
             throw new InvalidFishException(name + " could not be fetched from the config.");
 
-        this.factory = new ItemFactory("fish." + this.rarity.getValue() + "." + this.name, isXmas2022Fish);
+        this.factory = new ItemFactory("fish." + this.rarity.getValue() + "." + this.name, this.xmasFish);
         checkDisplayName();
 
         // These settings don't mean these will be applied, but they will be considered if the settings exist.
@@ -95,6 +89,21 @@ public class Fish implements Cloneable {
 
         fishRewards = new ArrayList<>();
         checkFishEvent();
+    }
+    
+    /*
+      Accounts for bug https://github.com/Oheers/EvenMoreFish/issues/173
+      This will allow breaking heads that have already been placed with the wrong nbt data.
+     */
+    private void setFishAndRarityConfig() {
+        if (this.xmasFish && EvenMoreFish.xmas2022Config.getConfig() != null) {
+            this.fishConfig = EvenMoreFish.xmas2022Config.getConfig();
+            this.rarityConfig = EvenMoreFish.xmas2022Config.getConfig();
+        } else {
+            this.xmasFish = false;
+            this.fishConfig = EvenMoreFish.fishFile.getConfig();
+            this.rarityConfig = EvenMoreFish.raritiesFile.getConfig();
+        }
     }
 
     /**

--- a/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -45,14 +45,16 @@ public class Fish implements Cloneable {
 
     double weight;
 
-    double minSize, maxSize;
+    double minSize;
+    double maxSize;
 
     boolean isCompExemptFish;
 
     boolean disableFisherman;
 
     boolean xmasFish;
-    FileConfiguration fishConfig, rarityConfig;
+    FileConfiguration fishConfig;
+    FileConfiguration rarityConfig;
 
     private int day = -1;
 
@@ -69,10 +71,8 @@ public class Fish implements Cloneable {
             this.fishConfig = EvenMoreFish.fishFile.getConfig();
             this.rarityConfig = EvenMoreFish.raritiesFile.getConfig();
         }
-        this.disableFisherman = this.fishConfig.getBoolean(
-                "fish." + this.rarity.getValue() + "." + this.name + ".disable-fisherman",
-                EvenMoreFish.raritiesFile.getConfig().getBoolean("rarities." + this.rarity.getValue() + ".disable-fisherman", false)
-        );
+        final boolean defaultRarityDisableFisherman = EvenMoreFish.raritiesFile.getConfig().getBoolean("rarities." + this.rarity.getValue() + ".disable-fisherman", false);
+        this.disableFisherman = this.fishConfig.getBoolean("fish." + this.rarity.getValue() + "." + this.name + ".disable-fisherman", defaultRarityDisableFisherman);
 
         if (rarity == null)
             throw new InvalidFishException(name + " could not be fetched from the config.");

--- a/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -74,7 +74,8 @@ public class Fish implements Cloneable {
                 EvenMoreFish.raritiesFile.getConfig().getBoolean("rarities." + this.rarity.getValue() + ".disable-fisherman", false)
         );
 
-        if (rarity == null) throw new InvalidFishException(name + " could not be fetched from the config.");
+        if (rarity == null)
+            throw new InvalidFishException(name + " could not be fetched from the config.");
 
         this.factory = new ItemFactory("fish." + this.rarity.getValue() + "." + this.name, isXmas2022Fish);
         checkDisplayName();

--- a/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -32,7 +32,7 @@ public class WorthNBT {
         return nbtItem.getItem();
     }
 
-    public static void setNBT(Skull fishSkull, Fish fish) {
+    public static void setNBT(Skull fishSkull, Fish fish) { //todo issue 173
         NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_LENGTH);
         NamespacedKey nbtplayer = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_PLAYER);
         NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_RARITY);
@@ -49,8 +49,7 @@ public class WorthNBT {
         itemMeta.set(nbtrandomIndex, PersistentDataType.INTEGER, fish.getFactory().getChosenRandomIndex());
         itemMeta.set(nbtrarity, PersistentDataType.STRING, fish.getRarity().getValue());
         itemMeta.set(nbtname, PersistentDataType.STRING, fish.getName());
-        itemMeta.set(nbtxmasfish, PersistentDataType.INTEGER, (fish.isXmasFish()) ? 0 : 1);
-
+        itemMeta.set(nbtxmasfish, PersistentDataType.INTEGER, (fish.isXmasFish()) ? 1 : 0);
     }
 
     public static double getValue(ItemStack item) {

--- a/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -33,12 +33,12 @@ public class WorthNBT {
     }
 
     public static void setNBT(Skull fishSkull, Fish fish) { //todo issue 173
-        NamespacedKey nbtlength = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_LENGTH);
-        NamespacedKey nbtplayer = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_PLAYER);
-        NamespacedKey nbtrarity = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_RARITY);
-        NamespacedKey nbtname = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_NAME);
-        NamespacedKey nbtrandomIndex = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_FISH_RANDOM_INDEX);
-        NamespacedKey nbtxmasfish = new NamespacedKey(JavaPlugin.getProvidingPlugin(WorthNBT.class), NbtUtils.Keys.EMF_XMAS_FISH);
+        NamespacedKey nbtlength = NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_LENGTH);
+        NamespacedKey nbtplayer = NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_PLAYER);
+        NamespacedKey nbtrarity = NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_RARITY);
+        NamespacedKey nbtname = NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_NAME);
+        NamespacedKey nbtrandomIndex = NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_FISH_RANDOM_INDEX);
+        NamespacedKey nbtxmasfish = NbtUtils.getNamespacedKey(NbtUtils.Keys.EMF_XMAS_FISH);
 
         PersistentDataContainer itemMeta = fishSkull.getPersistentDataContainer();
 


### PR DESCRIPTION
Fixes #173 

This issue was caused due to incorrect accessing of nbt values. Since you can only set nbt data for entities on default minecraft tags.
The xmas setting on fish was being set to true when in fact it was false. This would cause issues when trying to get the fish configuration for that fish.
Also added a check to ensure fish that were placed before this version can still be broken and their values fixed.

* Fixed incorrect accessing of nbt values.
* Fixed incorrect xmasInt setting,
* Added backwards compat pre this PR.