### PR TITLE
fix: Change the active variable at a later time (#244)

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -100,7 +100,6 @@ public class Competition {
     }
 
     public void end() {
-        active = false;
         // print leaderboard
         this.timingSystem.cancel();
         statusBar.hide();
@@ -110,6 +109,7 @@ public class Competition {
             new Message(ConfigMessage.COMPETITION_END).broadcast(player, true, true);
             sendPlayerLeaderboard(player);
         }
+        active = false;
         handleRewards();
         if (originallyRandom) competitionType = CompetitionType.RANDOM;
         if (EvenMoreFish.mainConfig.databaseEnabled()) {


### PR DESCRIPTION
The leaderboard at the end of the competition will again be correctly issued.
Fix for issue #244 