### PR TITLE
Multiple Fixes

### DIFF
--- a/even-more-fish-addons-j8/build.gradle.kts
+++ b/even-more-fish-addons-j8/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     compileOnly(libs.spigot.api)
     compileOnly(libs.commons.lang3)
     compileOnly(libs.itemsadder.api)
-    compileOnly(libs.denizens.api)
+    compileOnly(libs.denizen.api)
     compileOnly(libs.headdatabase.api)
 
     compileOnly(project(":even-more-fish-api"))

--- a/even-more-fish-addons-j8/src/main/java/com/oheers/evenmorefish/addons/DenizenItemAddon.java
+++ b/even-more-fish-addons-j8/src/main/java/com/oheers/evenmorefish/addons/DenizenItemAddon.java
@@ -2,13 +2,14 @@ package com.oheers.evenmorefish.addons;
 
 
 import com.denizenscript.denizen.objects.ItemTag;
+import com.denizenscript.denizen.scripts.containers.core.ItemScriptHelper;
 import com.oheers.fish.api.addons.ItemAddon;
 import org.bukkit.inventory.ItemStack;
 
 public class DenizenItemAddon extends ItemAddon {
     @Override
     public String getPrefix() {
-        return "denizens";
+        return "denizen";
     }
 
     @Override

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -88,7 +88,7 @@ bukkit {
         "mcMMO",
         "AureliumSkills",
         "ItemsAdder",
-        "Denizens",
+        "Denizen",
         "EcoItems",
         "Oraxen",
         "HeadDatabase"

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -208,7 +208,7 @@ public class Fish implements Cloneable {
         // if it's formatted wrong, it'll just give the player this as a stock effect
         if (separated.length < 3) {
             Objects.requireNonNull(Bukkit.getPlayer(this.fisherman)).addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 1));
-            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Invalid potion effect specified. Defaulting to Speed 2 for 100 seconds.");
+            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Invalid potion effect specified. Defaulting to Speed 2 for 5 seconds.");
             return;
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -209,6 +209,7 @@ public class Fish implements Cloneable {
         if (separated.length < 3) {
             Objects.requireNonNull(Bukkit.getPlayer(this.fisherman)).addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 1));
             EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Invalid potion effect specified. Defaulting to Speed 2 for 100 seconds.");
+            return;
         }
 
         PotionEffectType effect = PotionEffectType.getByName(separated[0].toUpperCase());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -206,8 +206,10 @@ public class Fish implements Cloneable {
 
         String[] separated = effectConfig.split(":");
         // if it's formatted wrong, it'll just give the player this as a stock effect
-        if (separated.length != 3)
+        if (separated.length < 3) {
             Objects.requireNonNull(Bukkit.getPlayer(this.fisherman)).addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 100, 1));
+            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Invalid potion effect specified. Defaulting to Speed 2 for 100 seconds.");
+        }
 
         PotionEffectType effect = PotionEffectType.getByName(separated[0].toUpperCase());
         int amplitude = Integer.parseInt(separated[1]);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -83,6 +83,15 @@ public class ItemFactory {
      */
     public ItemStack getType(OfflinePlayer player) {
 
+        ItemStack material = checkMaterial();
+        if (material != null) return material;
+
+        ItemStack rawMaterial = checkRawMaterial();
+        if (rawMaterial != null) return rawMaterial;
+
+        ItemStack externalItem = checkItem(this.configurationFile.getString(configLocation + ".item.material"));
+        if (externalItem != null) return externalItem;
+
         ItemStack oneHeadDB = checkRandomHeadDB(-1);
         if (oneHeadDB != null) return oneHeadDB;
 
@@ -101,17 +110,11 @@ public class ItemFactory {
         ItemStack headDB = checkHeadDB();
         if (headDB != null) return headDB;
 
-        ItemStack material = checkMaterial();
-        if (material != null) return material;
-
         ItemStack head64 = checkHead64();
         if (head64 != null) return head64;
 
         ItemStack headUUID = checkHeadUUID();
         if (headUUID != null) return headUUID;
-
-        ItemStack rawMaterial = checkRawMaterial();
-        if (rawMaterial != null) return rawMaterial;
 
         // The fish has no item type specified
         return new ItemStack(Material.COD);
@@ -204,7 +207,19 @@ public class ItemFactory {
      * @return Null if the setting doesn't exist, the item in ItemStack form if it does.
      */
     private ItemStack checkMaterial() {
-        return checkItem(this.configurationFile.getString(configLocation + ".item.material"));
+        // The fish has item: material selected
+        String mValue = this.configurationFile.getString(configLocation + ".item.material");
+        if (mValue == null) {
+            return null;
+        }
+
+        Material material = Material.getMaterial(mValue.toUpperCase());
+        if (material == null) {
+            EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s", configLocation, mValue));
+            material = Material.COD;
+        }
+
+        return new ItemStack(material);
     }
 
     //Need to impl oraxen, ecoitems, denizen & ItemsAdder addons
@@ -221,6 +236,7 @@ public class ItemFactory {
             EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s",
                     configLocation,
                     materialID));
+            rawMaterial = false;
             return new ItemStack(Material.COD);
         }
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -245,7 +245,17 @@ public class ItemFactory {
             return null;
         }
 
-        return getItem(materialID);
+        rawMaterial = true;
+
+        try {
+            return getItem(materialID);
+        } catch (Exception e) {
+            EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s",
+                    configLocation,
+                    materialID));
+            rawMaterial = false;
+            return new ItemStack(Material.COD);
+        }
     }
 
     /**
@@ -418,17 +428,25 @@ public class ItemFactory {
         return checkItem(materialID);
     }
 
-    public ItemStack getItem(final @NotNull String materialString) {
+    public @NotNull ItemStack getItem(final @NotNull String materialString) throws Exception{
         if (materialString.contains(":")) {
             //assume this is an addon string
-            rawMaterial = true;
             final String[] split = materialString.split(":", 2);
             final String prefix = split[0];
             final String id = split[1];
             return EvenMoreFish.getInstance().getAddonManager().getItemStack(prefix,id);
         }
-        // Null if it isn't an addon string
-        return null;
+
+
+        Material material = Material.matchMaterial(materialString);
+        if (material == null) {
+            EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s",
+                    configLocation,
+                    materialString));
+            return new ItemStack(Material.COD);
+        }
+
+        return new ItemStack(material);
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -245,17 +245,7 @@ public class ItemFactory {
             return null;
         }
 
-        rawMaterial = true;
-
-        try {
-            return getItem(materialID);
-        } catch (Exception e) {
-            EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s",
-                    configLocation,
-                    materialID));
-            rawMaterial = false;
-            return new ItemStack(Material.COD);
-        }
+        return getItem(materialID);
     }
 
     /**
@@ -428,25 +418,17 @@ public class ItemFactory {
         return checkItem(materialID);
     }
 
-    public @NotNull ItemStack getItem(final @NotNull String materialString) throws Exception{
+    public ItemStack getItem(final @NotNull String materialString) {
         if (materialString.contains(":")) {
             //assume this is an addon string
+            rawMaterial = true;
             final String[] split = materialString.split(":", 2);
             final String prefix = split[0];
             final String id = split[1];
             return EvenMoreFish.getInstance().getAddonManager().getItemStack(prefix,id);
         }
-
-
-        Material material = Material.matchMaterial(materialString);
-        if (material == null) {
-            EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s",
-                    configLocation,
-                    materialString));
-            return new ItemStack(Material.COD);
-        }
-
-        return new ItemStack(material);
+        // Null if it isn't an addon string
+        return null;
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -89,14 +89,11 @@ public class ItemFactory {
         ItemStack rawMaterial = checkRawMaterial();
         if (rawMaterial != null) return rawMaterial;
 
-        ItemStack externalItem = checkItem(this.configurationFile.getString(configLocation + ".item.material"));
-        if (externalItem != null) return externalItem;
+        ItemStack oneMaterial = checkRandomMaterial(-1);
+        if (oneMaterial != null) return oneMaterial;
 
         ItemStack oneHeadDB = checkRandomHeadDB(-1);
         if (oneHeadDB != null) return oneHeadDB;
-
-        ItemStack oneMaterial = checkRandomMaterial(-1);
-        if (oneMaterial != null) return oneMaterial;
 
         ItemStack oneHead64 = checkRandomHead64(-1);
         if (oneHead64 != null) return oneHead64;
@@ -215,6 +212,26 @@ public class ItemFactory {
 
         Material material = Material.getMaterial(mValue.toUpperCase());
         if (material == null) {
+            ItemStack customItemStack = checkMaterial(mValue);
+            if (customItemStack != null) { return customItemStack; }
+            EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s", configLocation, mValue));
+            material = Material.COD;
+        }
+
+        return new ItemStack(material);
+    }
+
+    private ItemStack checkMaterial(String mValue) {
+        if (mValue == null) {
+            return null;
+        }
+
+        Material material = Material.getMaterial(mValue.toUpperCase());
+        if (material == null) {
+            ItemStack customItemStack = checkItem(mValue);
+            if (customItemStack != null) {
+                return customItemStack;
+            }
             EvenMoreFish.logger.severe(() -> String.format("%s has an incorrect assigned material: %s", configLocation, mValue));
             material = Material.COD;
         }
@@ -259,20 +276,20 @@ public class ItemFactory {
                 this.chosenRandomIndex = randomIndex;
             }
 
-            Material m = Material.getMaterial(lValues.get(randomIndex).toUpperCase());
+            ItemStack customItemStack = checkMaterial(lValues.get(randomIndex));
             itemRandom = true;
 
-            if (m == null) {
+            if (customItemStack == null) {
                 EvenMoreFish.logger.log(Level.SEVERE, configLocation + "'s has an incorrect material name in its materials list.");
                 for (String material : lValues) {
-                    if (Material.getMaterial(material.toUpperCase()) != null) {
-                        return new ItemStack(Objects.requireNonNull(Material.getMaterial(material.toUpperCase())));
+                    ItemStack item = checkMaterial(material);
+                    if (item != null) {
+                        return item;
                     }
                 }
-
                 return new ItemStack(Material.COD);
             } else {
-                return new ItemStack(m);
+                return customItemStack;
             }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
 
             library("itemsadder-api", "com.github.LoneDev6:API-ItemsAdder:3.5.0b")
             library("nbt-api", "de.tr7zw:item-nbt-api:2.12.1")
-            library("denizens-api", "com.denizenscript:denizen:1.2.5-SNAPSHOT") // We must use 1.2.6 until we upgrade to java 17
+            library("denizen-api", "com.denizenscript:denizen:1.2.5-SNAPSHOT") // We must use 1.2.6 until we upgrade to java 17
             library("oraxen", "com.github.oraxen:oraxen:1.159.0")
 
             library("ecoitems-api", "com.willfp:EcoItems:5.6.1")


### PR DESCRIPTION
Fixes the following:
- Items showing up as raw materials when they shouldn't
- Denizen item support
- ArrayIndexOutOfBoundsException when you have an invalid potion effect

Adds the following:
- A warning when a fish's potion effect is invalid.
- Support for custom items in the random material lists