### PR TITLE
Add support for Folia

### DIFF
--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     compileOnly(libs.spigot.api)
     compileOnly(libs.annotations)
     compileOnly(libs.commons.lang3)
+    compileOnly(libs.universalscheduler)
 }
 
 java {

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/Futures.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/Futures.java
@@ -20,6 +20,7 @@
 
 package com.oheers.fish.api.addons;
 
+import com.github.Anon8281.universalScheduler.UniversalRunnable;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
@@ -45,7 +46,12 @@ public final class Futures {
             if (Bukkit.isPrimaryThread()) {
                 consumer.accept(value, exception);
             } else {
-                Bukkit.getScheduler().runTask(plugin, () -> consumer.accept(value, exception));
+                new UniversalRunnable() {
+                    @Override
+                    public void run() {
+                        consumer.accept(value, exception);
+                    }
+                }.runTask(plugin);
             }
         });
     }

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
 
     implementation(libs.nbt.api)
     implementation(libs.bstats)
+    implementation(libs.universalscheduler)
 
     library(libs.friendlyid)
     library(libs.flyway.core)
@@ -70,7 +71,6 @@ dependencies {
     library(libs.commons.codec)
 
     library(libs.json.simple)
-    library(libs.universalscheduler)
 }
 
 bukkit {

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     library(libs.commons.codec)
 
     library(libs.json.simple)
+    library(libs.universalscheduler)
 }
 
 bukkit {
@@ -79,6 +80,7 @@ bukkit {
     version = project.version.toString()
     description = project.description.toString()
     website = "https://github.com/Oheers/EvenMoreFish"
+    foliaSupported = true
 
     depend = listOf("Vault")
     softDepend = listOf(

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
@@ -19,8 +19,6 @@ import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -174,13 +172,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 if (!EvenMoreFish.permission.has(sender, "emf.admin")) {
                     new Message(ConfigMessage.NO_PERMISSION).broadcast(sender, true, false);
                 } else {
-                    new BukkitRunnable() {
-
-                        @Override
-                        public void run() {
-                            EvenMoreFish.databaseV3.migrateLegacy(sender);
-                        }
-                    }.runTaskAsynchronously(JavaPlugin.getProvidingPlugin(CommandCentre.class));
+                    EvenMoreFish.getScheduler().runTaskAsynchronously(() -> EvenMoreFish.databaseV3.migrateLegacy(sender));
                 }
                 break;
             case "xmas":

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -1,5 +1,7 @@
 package com.oheers.fish;
 
+import com.github.Anon8281.universalScheduler.UniversalScheduler;
+import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
 import com.oheers.fish.addons.AddonManager;
 import com.oheers.fish.addons.DefaultAddons;
 import com.oheers.fish.api.EMFAPI;
@@ -13,7 +15,10 @@ import com.oheers.fish.competition.JoinChecker;
 import com.oheers.fish.config.*;
 import com.oheers.fish.config.messages.Messages;
 import com.oheers.fish.database.*;
-import com.oheers.fish.events.*;
+import com.oheers.fish.events.AureliumSkillsFishingEvent;
+import com.oheers.fish.events.FishEatEvent;
+import com.oheers.fish.events.FishInteractEvent;
+import com.oheers.fish.events.McMMOTreasureEvent;
 import com.oheers.fish.exceptions.InvalidTableException;
 import com.oheers.fish.fishing.FishingProcessor;
 import com.oheers.fish.fishing.items.Fish;
@@ -42,7 +47,6 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
 import java.io.IOException;
@@ -103,6 +107,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     public static DatabaseV3 databaseV3;
     public static HeadDatabaseAPI HDBapi;
     private static EvenMoreFish instance;
+    private static TaskScheduler scheduler;
     public static FillerStyle guiFillerStyle;
     private EMFAPI api;
 
@@ -112,6 +117,8 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         return instance;
     }
 
+    public static TaskScheduler getScheduler() { return scheduler; }
+
     public AddonManager getAddonManager() {
         return addonManager;
     }
@@ -119,6 +126,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     @Override
     public void onEnable() {
         instance = this;
+        scheduler = UniversalScheduler.getScheduler(this);
         this.api = new EMFAPI();
 
 
@@ -189,7 +197,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         competitionQueue.load();
 
         // async check for updates on the spigot page
-        Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+        getScheduler().runTaskAsynchronously(() -> {
             isUpdateAvailable = checkUpdate();
             try {
                 checkConfigVers();
@@ -216,20 +224,17 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
             databaseV3 = new DatabaseV3(this);
             //load user reports into cache
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    EvenMoreFish.databaseV3.createTables(false);
-                    for (Player player : getServer().getOnlinePlayers()) {
-                        UserReport playerReport = databaseV3.readUserReport(player.getUniqueId());
-                        if (playerReport == null) {
-                            EvenMoreFish.logger.warning("Could not read report for player (" + player.getUniqueId() + ")");
-                            continue;
-                        }
-                        DataManager.getInstance().putUserReportCache(player.getUniqueId(), playerReport);
+            getScheduler().runTaskAsynchronously(() -> {
+                EvenMoreFish.databaseV3.createTables(false);
+                for (Player player : getServer().getOnlinePlayers()) {
+                    UserReport playerReport = databaseV3.readUserReport(player.getUniqueId());
+                    if (playerReport == null) {
+                        EvenMoreFish.logger.warning("Could not read report for player (" + player.getUniqueId() + ")");
+                        continue;
                     }
+                    DataManager.getInstance().putUserReportCache(player.getUniqueId(), playerReport);
                 }
-            }.runTaskAsynchronously(this);
+            });
 
         }
 
@@ -384,15 +389,16 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     }
 
     private void saveUserData() {
-        //really slow, we should execute this via a runnable.
-        if (!(mainConfig.isDatabaseOnline())) {
-            return;
-        }
+        getScheduler().runTask(() -> {
+            if (!(mainConfig.isDatabaseOnline())) {
+                return;
+            }
 
-        saveFishReports();
-        saveUserReports();
+            saveFishReports();
+            saveUserReports();
 
-        DataManager.getInstance().uncacheAll();
+            DataManager.getInstance().uncacheAll();
+        });
     }
 
     private void saveFishReports() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -20,8 +20,6 @@ import org.bukkit.*;
 import org.bukkit.block.Skull;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.List;
 import java.util.UUID;
@@ -151,11 +149,7 @@ public class FishUtils {
         player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.5f, 1.5f);
         player.getInventory().addItem(items.toArray(new ItemStack[0]))
                 .values()
-                .forEach(item -> new BukkitRunnable() {
-                    public void run() {
-                        player.getWorld().dropItem(player.getLocation(), item);
-                    }
-                }.runTask(JavaPlugin.getProvidingPlugin(FishUtils.class)));
+                .forEach(item -> EvenMoreFish.getScheduler().runTask(() -> player.getWorld().dropItem(player.getLocation(), item)));
     }
 
     public static boolean checkRegion(Location l, List<String> whitelistedRegions) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/AutoRunner.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/AutoRunner.java
@@ -1,7 +1,6 @@
 package com.oheers.fish.competition;
 
 import com.oheers.fish.EvenMoreFish;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,30 +12,20 @@ public class AutoRunner {
     static int lastMinute;
 
     public static void init() {
-        new BukkitRunnable() {
-            public void run() {
-                // If the minute hasn't been checked against the competition queue.
-                if (!wasMinuteChecked()) {
-                    int weekMinute = getCurrentTimeCode();
+        EvenMoreFish.getScheduler().runTaskTimer(() -> {
+            // If the minute hasn't been checked against the competition queue.
+            if (!wasMinuteChecked()) {
+                int weekMinute = getCurrentTimeCode();
 
-                    // Beginning the competition set for schedule
-                    if (EvenMoreFish.competitionQueue.competitions.containsKey(weekMinute)) {
-                        if (!Competition.isActive()) {
-                            EvenMoreFish.active = EvenMoreFish.competitionQueue.competitions.get(weekMinute);
-                            EvenMoreFish.active.begin(false);
-                        }
+                // Beginning the competition set for schedule
+                if (EvenMoreFish.competitionQueue.competitions.containsKey(weekMinute)) {
+                    if (!Competition.isActive()) {
+                        EvenMoreFish.active = EvenMoreFish.competitionQueue.competitions.get(weekMinute);
+                        EvenMoreFish.active.begin(false);
                     }
                 }
             }
-
-            // delay is set to start at bang on :00 of every minute (assuming the tps to be 20), period is set to run once a minute
-        }.runTaskTimer(
-                // You provide the plugin's main class - the one that inherits from JavaPlugin
-                EvenMoreFish.getProvidingPlugin(EvenMoreFish.class),
-                // how long between this code first running and the first iteration you want (in ticks)
-                (60 - LocalTime.now().getSecond()) * 20,
-                // time between each loop (in ticks)
-                20);
+        }, (60 - LocalTime.now().getSecond()) * 20, 20);
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
@@ -13,8 +13,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,44 +29,38 @@ public class JoinChecker implements Listener {
      */
     public void databaseRegistration(UUID userUUID, String userName) {
         if (EvenMoreFish.mainConfig.isDatabaseOnline()) {
-            new BukkitRunnable() {
-                
-                @Override
-                public void run() {
-                    
-                    List<FishReport> fishReports = new ArrayList<>();
-                    
-                    try {
-                        if (EvenMoreFish.databaseV3.hasUser(userUUID, Table.EMF_FISH_LOG)) {
-                            fishReports = EvenMoreFish.databaseV3.getFishReports(userUUID);
-                        } else {
-                            fishReports = new ArrayList<>();
-                            if (EvenMoreFish.mainConfig.doDBVerbose())
-                                EvenMoreFish.logger.log(Level.INFO, userName + " has joined for the first time, creating new data handle for them.");
-                        }
-                    } catch (InvalidTableException exception) {
-                        EvenMoreFish.logger.log(Level.SEVERE, "Failed to check database existence of user " + userUUID);
-                        exception.printStackTrace();
-                    }
-                    
-                    UserReport userReport;
-                    
-                    userReport = EvenMoreFish.databaseV3.readUserReport(userUUID);
-                    if (userReport == null) {
-                        EvenMoreFish.databaseV3.createUser(userUUID);
-                        userReport = EvenMoreFish.databaseV3.readUserReport(userUUID);
-                    }
-                    
-                    if (fishReports != null && userReport != null) {
-                        DataManager.getInstance().cacheUser(userUUID, userReport, fishReports);
+            EvenMoreFish.getScheduler().runTaskAsynchronously(() -> {
+                List<FishReport> fishReports = new ArrayList<>();
+
+                try {
+                    if (EvenMoreFish.databaseV3.hasUser(userUUID, Table.EMF_FISH_LOG)) {
+                        fishReports = EvenMoreFish.databaseV3.getFishReports(userUUID);
                     } else {
-                        EvenMoreFish.logger.log(Level.SEVERE, "Null value when fetching data for user (" + userName + "),\n" +
+                        fishReports = new ArrayList<>();
+                        if (EvenMoreFish.mainConfig.doDBVerbose())
+                            EvenMoreFish.logger.log(Level.INFO, userName + " has joined for the first time, creating new data handle for them.");
+                    }
+                } catch (InvalidTableException exception) {
+                    EvenMoreFish.logger.log(Level.SEVERE, "Failed to check database existence of user " + userUUID);
+                    exception.printStackTrace();
+                }
+
+                UserReport userReport;
+
+                userReport = EvenMoreFish.databaseV3.readUserReport(userUUID);
+                if (userReport == null) {
+                    EvenMoreFish.databaseV3.createUser(userUUID);
+                    userReport = EvenMoreFish.databaseV3.readUserReport(userUUID);
+                }
+
+                if (fishReports != null && userReport != null) {
+                    DataManager.getInstance().cacheUser(userUUID, userReport, fishReports);
+                } else {
+                    EvenMoreFish.logger.log(Level.SEVERE, "Null value when fetching data for user (" + userName + "),\n" +
                             "UserReport: " + (userReport == null) +
                             ",\nFishReports: " + (fishReports != null && !fishReports.isEmpty()));
-                    }
-                    
                 }
-            }.runTaskAsynchronously(JavaPlugin.getProvidingPlugin(JoinChecker.class));
+            });
         }
     }
     
@@ -79,17 +71,10 @@ public class JoinChecker implements Listener {
             EvenMoreFish.active.getStatusBar().addPlayer(event.getPlayer());
             Message startMessage = EvenMoreFish.active.getStartMessage();
             if (startMessage != null) startMessage.setMessage(ConfigMessage.COMPETITION_JOIN);
-            Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(EvenMoreFish.getPlugin(EvenMoreFish.class),
-                () -> EvenMoreFish.active.getStartMessage().broadcast(event.getPlayer(), true, true), 20 * 3);
+            EvenMoreFish.getScheduler().runTaskLater(() -> EvenMoreFish.active.getStartMessage().broadcast(event.getPlayer(), true, true), 20 * 3);
         }
-        
-        new BukkitRunnable() {
-            
-            @Override
-            public void run() {
-                databaseRegistration(event.getPlayer().getUniqueId(), event.getPlayer().getName());
-            }
-        }.runTaskAsynchronously(EvenMoreFish.getProvidingPlugin(EvenMoreFish.class));
+
+        EvenMoreFish.getScheduler().runTaskAsynchronously(() -> databaseRegistration(event.getPlayer().getUniqueId(), event.getPlayer().getName()));
     }
     
     // Removes the player from the bar list if they leave the server
@@ -101,40 +86,34 @@ public class JoinChecker implements Listener {
         }
         
         if (EvenMoreFish.mainConfig.isDatabaseOnline()) {
-            new BukkitRunnable() {
-                
-                @Override
-                public void run() {
-                    
-                    UUID userUUID = event.getPlayer().getUniqueId();
-                    try {
-                        if (!EvenMoreFish.databaseV3.hasUser(userUUID, Table.EMF_USERS)) {
-                            EvenMoreFish.databaseV3.createUser(userUUID);
-                        }
-                    } catch (InvalidTableException exception) {
-                        EvenMoreFish.logger.log(Level.SEVERE, "Fatal error when running database checks for " + event.getPlayer().getName() + ", deleting data in primary storage.");
-                        exception.printStackTrace();
-                        return;
+            EvenMoreFish.getScheduler().runTaskAsynchronously(() -> {
+                UUID userUUID = event.getPlayer().getUniqueId();
+                try {
+                    if (!EvenMoreFish.databaseV3.hasUser(userUUID, Table.EMF_USERS)) {
+                        EvenMoreFish.databaseV3.createUser(userUUID);
                     }
-                    
-                    List<FishReport> fishReports = DataManager.getInstance().getFishReportsIfExists(userUUID);
-                    if (fishReports != null) {
-                        
-                        EvenMoreFish.databaseV3.writeFishReports(userUUID, fishReports);
-                        
-                    }
-                    
-                    UserReport userReport = DataManager.getInstance().getUserReportIfExists(userUUID);
-                    if (userReport != null) {
-                        
-                        EvenMoreFish.databaseV3.writeUserReport(userUUID, userReport);
-                        
-                    }
-                    
-                    DataManager.getInstance().uncacheUser(userUUID);
-                    
+                } catch (InvalidTableException exception) {
+                    EvenMoreFish.logger.log(Level.SEVERE, "Fatal error when running database checks for " + event.getPlayer().getName() + ", deleting data in primary storage.");
+                    exception.printStackTrace();
+                    return;
                 }
-            }.runTaskAsynchronously(JavaPlugin.getProvidingPlugin(JoinChecker.class));
+
+                List<FishReport> fishReports = DataManager.getInstance().getFishReportsIfExists(userUUID);
+                if (fishReports != null) {
+
+                    EvenMoreFish.databaseV3.writeFishReports(userUUID, fishReports);
+
+                }
+
+                UserReport userReport = DataManager.getInstance().getUserReportIfExists(userUUID);
+                if (userReport != null) {
+
+                    EvenMoreFish.databaseV3.writeUserReport(userUUID, userReport);
+
+                }
+
+                DataManager.getInstance().uncacheUser(userUUID);
+            });
         }
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
@@ -29,7 +29,6 @@ public class Reward {
     String action;
 
     Vector fishVelocity;
-    Plugin plugin = JavaPlugin.getProvidingPlugin(getClass());
 
     public Reward(String value) {
         String[] split = value.split(":");
@@ -58,9 +57,14 @@ public class Reward {
     }
 
     public void run(OfflinePlayer player, Location hookLocation) {
-        Player p = null;
+        Player p;
 
-        if (player.isOnline()) p = (Player) player;
+        // Done like this to make the runnables not complain
+        if (player.isOnline()) {
+            p = (Player) player;
+        } else {
+            p = null;
+        }
 
         switch (type) {
             case COMMAND:

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
@@ -77,15 +77,14 @@ public class Reward {
 
                 // running the command
                 String finalCommand = inputCommand;
-                Bukkit.getScheduler().callSyncMethod(plugin, () ->
+                EvenMoreFish.getScheduler().callSyncMethod(() ->
                         Bukkit.dispatchCommand(Bukkit.getServer().getConsoleSender(), finalCommand));
                 break;
             case EFFECT:
                 if (p != null) {
                     String[] parsedEffect = action.split(",");
                     // Adds a potion effect in accordance to the config.yml "EFFECT:" value
-
-                    p.addPotionEffect(new PotionEffect(Objects.requireNonNull(PotionEffectType.getByName(parsedEffect[0])), Integer.parseInt(parsedEffect[2]) * 20, Integer.parseInt(parsedEffect[1])));
+                    EvenMoreFish.getScheduler().runTask(p, () -> p.addPotionEffect(new PotionEffect(Objects.requireNonNull(PotionEffectType.getByName(parsedEffect[0])), Integer.parseInt(parsedEffect[2]) * 20, Integer.parseInt(parsedEffect[1]))));
                 }
 
                 break;
@@ -93,16 +92,18 @@ public class Reward {
                 // checking the player doesn't have a special effect thingy on
 
                 if (p != null) {
-                    double newhealth = p.getHealth() + Integer.parseInt(action);
-                    // checking the new health won't go above 20
-                    p.setHealth(newhealth > 20 ? 20 : newhealth < 0 ? 0 : newhealth);
+                    EvenMoreFish.getScheduler().runTask(p, () -> {
+                        double newhealth = p.getHealth() + Integer.parseInt(action);
+                        // checking the new health won't go above 20
+                        p.setHealth(newhealth > 20 ? 20 : newhealth < 0 ? 0 : newhealth);
+                    });
                 }
 
                 break;
             case HUNGER:
 
                 if (p != null) {
-                    p.setFoodLevel(p.getFoodLevel() + Integer.parseInt(action));
+                    EvenMoreFish.getScheduler().runTask(p, () -> p.setFoodLevel(p.getFoodLevel() + Integer.parseInt(action)));
                 }
 
                 break;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -30,7 +30,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.*;
 import java.util.logging.Level;
@@ -247,31 +246,26 @@ public class FishingProcessor implements Listener {
 
         if (EvenMoreFish.mainConfig.isDatabaseOnline()) {
             Fish finalFish = fish;
-            new BukkitRunnable() {
-                @Override
-                public void run() {
+            EvenMoreFish.getScheduler().runTaskAsynchronously(() -> {
+                // increases the fish fished count if the fish is already in the db
+                if (EvenMoreFish.databaseV3.hasFishData(finalFish)) {
+                    EvenMoreFish.databaseV3.incrementFish(finalFish);
 
-                   
-                        // increases the fish fished count if the fish is already in the db
-                        if (EvenMoreFish.databaseV3.hasFishData(finalFish)) {
-                            EvenMoreFish.databaseV3.incrementFish(finalFish);
+                    // sets the new leader in top fish, if the player has fished a record fish
+                    if (EvenMoreFish.databaseV3.getLargestFishSize(finalFish) < finalFish.getLength()) {
+                        EvenMoreFish.databaseV3.updateLargestFish(finalFish, player.getUniqueId());
+                    }
+                } else {
+                    EvenMoreFish.databaseV3.createFishData(finalFish, player.getUniqueId());
+                }
 
-                            // sets the new leader in top fish, if the player has fished a record fish
-                            if (EvenMoreFish.databaseV3.getLargestFishSize(finalFish) < finalFish.getLength()) {
-                                EvenMoreFish.databaseV3.updateLargestFish(finalFish, player.getUniqueId());
-                            }
-                        } else {
-                            EvenMoreFish.databaseV3.createFishData(finalFish, player.getUniqueId());
-                        }
+                EvenMoreFish.databaseV3.handleFishCatch(player.getUniqueId(), finalFish);
 
-                        EvenMoreFish.databaseV3.handleFishCatch(player.getUniqueId(), finalFish);
-                    
 //                    catch (SQLException exception) {
 //                        EvenMoreFish.logger.log(Level.SEVERE, "Failed SQL operations whilst writing fish catch data for " + player.getUniqueId() + ". Try restarting or contacting support.");
 //                        exception.printStackTrace();
 //                    }
-                }
-            }.runTaskAsynchronously(EvenMoreFish.getProvidingPlugin(EvenMoreFish.class));
+            });
         }
 
         return fish.give(-1);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/InteractHandler.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/InteractHandler.java
@@ -11,7 +11,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
 public class InteractHandler implements Listener {
 
@@ -38,13 +37,10 @@ public class InteractHandler implements Listener {
         SellGUI gui = (SellGUI) holder;
         ItemStack clickedItem = event.getCurrentItem();
         if (clickedItem == null) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    gui.setSellItem();
-                    gui.setSellAllItem();
-                }
-            }.runTaskAsynchronously(JavaPlugin.getProvidingPlugin(getClass()));
+            EvenMoreFish.getScheduler().runTaskAsynchronously(() -> {
+                gui.setSellItem();
+                gui.setSellAllItem();
+            });
         } else {
             // determines what the player has clicked, or if they've just added an item
             // to the menu
@@ -96,17 +92,14 @@ public class InteractHandler implements Listener {
             } else if (clickedItem.isSimilar(gui.getFiller()) || clickedItem.isSimilar(gui.getErrorFiller())) {
                 event.setCancelled(true);
             } else {
-                new BukkitRunnable() {
-                    @Override
-                    public void run() {
-                        gui.updateSellItem();
-                        gui.updateSellAllItem();
-                        gui.setModified(true);
-                        gui.resetGlassColour();
+                EvenMoreFish.getScheduler().runTaskAsynchronously(() -> {
+                    gui.updateSellItem();
+                    gui.updateSellAllItem();
+                    gui.setModified(true);
+                    gui.resetGlassColour();
 
-                        gui.error = false;
-                    }
-                }.runTaskAsynchronously(JavaPlugin.getProvidingPlugin(getClass()));
+                    gui.error = false;
+                });
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,8 @@ dependencyResolutionManagement {
             library("friendlyid", "com.devskiller.friendly-id:friendly-id:1.1.0")
             library("hikaricp", "com.zaxxer:HikariCP:4.0.3") //We must use 4.0.3 until we upgrade to java 17
             library("json-simple", "com.googlecode.json-simple:json-simple:1.1.1")
+
+            library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
         }
     }
 }


### PR DESCRIPTION
Adds [UniversalScheduler](https://github.com/Anon8281/UniversalScheduler) to make life easy

Adds `EvenMoreFish.getScheduler()`, which will choose the correct schedulers depending on the server software (Spigot, Paper, or Folia)

Replaces all usages of `BukkitRunnable` and `Bukkit.getScheduler()` with `EvenMoreFish.getScheduler()`

Marks the plugin as supported in the plugin.yml