### PR TITLE
Remove J9 and J16 addons

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/addons/DefaultAddons.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/addons/DefaultAddons.java
@@ -2,8 +2,6 @@ package com.oheers.fish.addons;
 
 public enum DefaultAddons {
     J8("8"),
-    J9("9"),
-    J16("16"),
     J17("17")
     ;
 


### PR DESCRIPTION
These two addons don't exist, so this will remove the unnecessary startup warning, shown below:
```
[08:04:19 INFO]: [EvenMoreFish] Enabling EvenMoreFish v1.6.11.17
[08:04:19 WARN]: [EvenMoreFish] Default addon EMF-Addons-J9.addon does not exist.
[08:04:19 WARN]: [EvenMoreFish] Default addon EMF-Addons-J16.addon does not exist.
```