### PR TITLE
Fix deprecation warning when compiling the plugin

### DIFF
--- a/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts
@@ -32,7 +32,7 @@ tasks {
         build {
             doLast {
                 copy {
-                    val sourceFolder = File(project.buildDir, "libs/${addonName}")
+                    val sourceFolder = project.buildDir.resolve("libs/${addonName}")
                     val targetFolder = File(rootProject.project(":even-more-fish-plugin").projectDir, "src/main/resources/addons")
                     from(sourceFolder)
                     into(targetFolder)


### PR DESCRIPTION
Removes the following warning:
```
> Task :buildSrc:compileKotlin
w: file:///home/jenkins/workspace/EvenMoreFish/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts:35:53 'getter for buildDir: File' is deprecated. Deprecated in Java
```