### PR TITLE
Implements #160

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -104,6 +104,59 @@ bukkit {
             aliases = listOf("emf")
         }
     }
+
+    permissions {
+        register("emf.*") {
+            children = listOf(
+                "emf.admin",
+                "emf.user"
+            )
+        }
+
+        register("emf.admin") {
+            children = listOf(
+                "emf.admin.update.notify",
+                "emf.admin.migrate"
+            )
+        }
+
+        register("emf.admin.update.notify") {
+            description = "Allows users to be notified about updates."
+        }
+
+        register("emf.admin.migrate") {
+            description = "Allows users to use the migrate command."
+        }
+
+        register("emf.user") {
+            children = listOf(
+                "emf.toggle",
+                "emf.top",
+                "emf.shop",
+                "emf.use_rod",
+                "emf.sellall"
+            )
+        }
+
+        register("emf.sellall") {
+            description = "Allows users to use sellall."
+        }
+        register("emf.toggle") {
+            description = "Allows users to toggle emf."
+        }
+
+        register("emf.top") {
+            description = "Allows users to use /emf top."
+        }
+
+        register("emf.shop") {
+            description = "Allows users to use /emf shop."
+        }
+
+        register("emf.use_rod") {
+            description = "Allows users to use emf rods."
+        }
+    }
 }
 
 tasks {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
@@ -10,6 +10,8 @@ import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
 import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.Rarity;
+import com.oheers.fish.permissions.AdminPerms;
+import com.oheers.fish.permissions.UserPerms;
 import com.oheers.fish.selling.SellGUI;
 import com.oheers.fish.xmas2022.XmasGUI;
 import net.md_5.bungee.api.chat.*;
@@ -91,7 +93,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
         // we've already checked that that args exist
         switch (args[0].toLowerCase()) {
             case "top":
-                if (EvenMoreFish.permission.has(sender, "emf.top")) {
+                if (EvenMoreFish.permission.has(sender, UserPerms.TOP)) {
                     if (!Competition.isActive()) {
                         new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(sender, true, true);
                     } else {
@@ -108,8 +110,8 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
             case "shop":
                 if (sender instanceof Player || args.length > 1) {
                     if (EvenMoreFish.mainConfig.isEconomyEnabled()) {
-                        if (EvenMoreFish.permission.has(sender, "emf.shop")) {
-                            if (EvenMoreFish.permission.has(sender, "emf.admin") && args.length == 2) {
+                        if (EvenMoreFish.permission.has(sender, UserPerms.SHOP)) {
+                            if (EvenMoreFish.permission.has(sender, AdminPerms.ADMIN) && args.length == 2) {
                                 Player p = Bukkit.getPlayer(args[1]);
                                 if (p != null) {
                                     new SellGUI(p, true);
@@ -150,7 +152,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 }
                 Player p = (Player) sender;
                 if (EvenMoreFish.mainConfig.isEconomyEnabled()) {
-                    if (EvenMoreFish.permission.has(p, "emf.sellall")) {
+                    if (EvenMoreFish.permission.has(p, UserPerms.SELL_ALL)) {
                         SellGUI gui = new SellGUI(p, false);
                         gui.sell(true);
                     } else {
@@ -166,7 +168,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                     break;
                 }
 
-                if (!(EvenMoreFish.permission.has(sender, "emf.toggle"))) {
+                if (!(EvenMoreFish.permission.has(sender, UserPerms.TOGGLE))) {
                     new Message(ConfigMessage.NO_PERMISSION).broadcast(sender, true, false);
                     break;
                 }
@@ -180,14 +182,14 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 }
                 break;
             case "admin":
-                if (EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     Controls.adminControl(this.plugin, args, sender);
                 } else {
                     new Message(ConfigMessage.NO_PERMISSION).broadcast(sender, true, false);
                 }
                 break;
             case "migrate":
-                if (!EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (!EvenMoreFish.permission.has(sender, AdminPerms.MIGRATE)) {
                     new Message(ConfigMessage.NO_PERMISSION).broadcast(sender, true, false);
                 } else {
                     EvenMoreFish.getScheduler().runTaskAsynchronously(() -> EvenMoreFish.databaseV3.migrateLegacy(sender));
@@ -195,7 +197,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 break;
             case "xmas":
                 if (!EvenMoreFish.xmas2022Config.isAvailable()) break;
-                if (!EvenMoreFish.permission.has(sender, "emf.xmas")) {
+                if (!EvenMoreFish.permission.has(sender, UserPerms.XMAS)) {
                     new Message(ConfigMessage.NO_PERMISSION).broadcast(sender, true, false);
                 } else {
                     new XmasGUI(((Player) sender).getUniqueId()).display((Player) sender);
@@ -211,7 +213,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
 
         if (args.length > 2 && args[args.length - 1].startsWith("-p:")) {
             if (args[1].equalsIgnoreCase("fish") || args[1].equalsIgnoreCase("bait")) {
-                if (EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     List<String> playerNames = new ArrayList<>();
                     for (Player p : Bukkit.getOnlinePlayers()) {
                         playerNames.add("-p:" + p.getName());
@@ -223,7 +225,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
 
         switch (args.length) {
             case 1:
-                if (EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
 
                     // creates a temp version of tablist where only the qualified completes go through
                     List<String> TEMP_townTabCompletes = l(args[args.length - 1], emfTabs);
@@ -237,28 +239,28 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 }
             case 2:
                 // checks player has admin perms and has actually used "/emf admin" prior to the 2nd arg
-                if (args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     return l(args[args.length - 1], adminTabs);
                 } else {
                     return empty;
                 }
             case 3:
-                if (args[1].equalsIgnoreCase("competition") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (args[1].equalsIgnoreCase("competition") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     return l(args[args.length - 1], compTabs);
-                } else if (args[1].equalsIgnoreCase("fish") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, "emf.admin")) {
+                } else if (args[1].equalsIgnoreCase("fish") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     List<String> returning = new ArrayList<>();
                     for (Rarity r : EvenMoreFish.fishCollection.keySet()) {
                         returning.add(r.getValue().replace(" ", "_"));
                     }
 
                     return l(args[args.length - 1], returning);
-                } else if (args[1].equalsIgnoreCase("bait") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, "emf.admin")) {
+                } else if (args[1].equalsIgnoreCase("bait") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     return l(args[args.length - 1], new ArrayList<>(EvenMoreFish.baits.keySet()));
                 } else {
                     return empty;
                 }
             case 4:
-                if (args[1].equalsIgnoreCase("fish") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, "emf.admin")) {
+                if (args[1].equalsIgnoreCase("fish") && args[0].equalsIgnoreCase("admin") && EvenMoreFish.permission.has(sender, AdminPerms.ADMIN)) {
                     for (Rarity r : EvenMoreFish.fishCollection.keySet()) {
                         if (r.getValue().equalsIgnoreCase(args[2].replace("_", " "))) {
                             List<String> fish = new ArrayList<>();
@@ -272,7 +274,7 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 }
                 return empty;
             case 5:
-                if (EvenMoreFish.permission.has(sender, "emf.admin") && args[0].equalsIgnoreCase("admin") && args[1].equalsIgnoreCase("competition") && args[2].equalsIgnoreCase("start")) {
+                if (EvenMoreFish.permission.has(sender, AdminPerms.ADMIN) && args[0].equalsIgnoreCase("admin") && args[1].equalsIgnoreCase("competition") && args[2].equalsIgnoreCase("start")) {
                     return l(args[args.length - 1], compTypes);
                 } else {
                     return empty;
@@ -734,13 +736,13 @@ class Help {
             for (int i = 0; i < commands.size(); i++) {
                 if (i == commands.size() - 1) escape = "";
                 if (commands.get(i).contains("/emf admin")) {
-                    if (EvenMoreFish.permission.has(user, "emf.admin")) out.append(commands.get(i)).append(escape);
+                    if (EvenMoreFish.permission.has(user, AdminPerms.ADMIN)) out.append(commands.get(i)).append(escape);
                 } else if (commands.get(i).contains("/emf top")) {
-                    if (EvenMoreFish.permission.has(user, "emf.top")) out.append(commands.get(i)).append(escape);
+                    if (EvenMoreFish.permission.has(user, UserPerms.TOP)) out.append(commands.get(i)).append(escape);
                 } else if (commands.get(i).contains("/emf shop")) {
-                    if (EvenMoreFish.permission.has(user, "emf.shop")) out.append(commands.get(i)).append(escape);
+                    if (EvenMoreFish.permission.has(user, UserPerms.SHOP)) out.append(commands.get(i)).append(escape);
                 } else if (commands.get(i).contains("/emf toggle")) {
-                    if (EvenMoreFish.permission.has(user, "emf.toggle")) out.append(commands.get(i)).append(escape);
+                    if (EvenMoreFish.permission.has(user, UserPerms.TOGGLE)) out.append(commands.get(i)).append(escape);
                 } else out.append(commands.get(i)).append(escape);
             }
         } else {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/UpdateChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/UpdateChecker.java
@@ -2,6 +2,7 @@ package com.oheers.fish;
 
 import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
+import com.oheers.fish.permissions.AdminPerms;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -24,8 +25,8 @@ public class UpdateChecker {
     }
 
     public String getVersion() {
-        try (final Scanner scanner = new Scanner(new URL("https://api.spigotmc.org/simple/0.1/index.php?action=getResource&id=" + resourceID).openStream())){
-            return  ((JSONObject) new JSONParser().parse(scanner.nextLine())).get("current_version").toString();
+        try (final Scanner scanner = new Scanner(new URL("https://api.spigotmc.org/simple/0.1/index.php?action=getResource&id=" + resourceID).openStream())) {
+            return ((JSONObject) new JSONParser().parse(scanner.nextLine())).get("current_version").toString();
         } catch (Exception ignored) {
             EvenMoreFish.logger.log(Level.WARNING, "EvenMoreFish failed to check for updates against the spigot website, to check manually go to https://www.spigotmc.org/resources/evenmorefish.91310/updates");
             return plugin.getDescription().getVersion();
@@ -39,11 +40,15 @@ class UpdateNotify implements Listener {
     @EventHandler
     // informs admins with emf.admin permission that the plugin needs updating
     public void playerJoin(PlayerJoinEvent event) {
-        if (EvenMoreFish.isUpdateAvailable) {
-            if (EvenMoreFish.permission.playerHas(event.getPlayer(), "emf.admin")) {
-                new Message(ConfigMessage.ADMIN_UPDATE_AVAILABLE).broadcast(event.getPlayer(), true, false);
-            }
+        if (!EvenMoreFish.isUpdateAvailable) {
+            return;
         }
+
+
+        if (EvenMoreFish.permission.playerHas(event.getPlayer(), AdminPerms.UPDATE_NOTIFY)) {
+            new Message(ConfigMessage.ADMIN_UPDATE_AVAILABLE).broadcast(event.getPlayer(), true, false);
+        }
+
     }
 }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -16,6 +16,7 @@ import com.oheers.fish.exceptions.MaxBaitReachedException;
 import com.oheers.fish.exceptions.MaxBaitsReachedException;
 import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.Rarity;
+import com.oheers.fish.permissions.UserPerms;
 import com.oheers.fish.requirements.Requirement;
 import com.oheers.fish.requirements.RequirementContext;
 import de.tr7zw.changeme.nbtapi.NBTItem;
@@ -56,7 +57,7 @@ public class FishingProcessor implements Listener {
 
         if (EvenMoreFish.mainConfig.requireFishingPermission()) {
             //check if player have permssion to fish emf fishes
-            if (!EvenMoreFish.permission.has(event.getPlayer(), "emf.use_rod")) {
+            if (!EvenMoreFish.permission.has(event.getPlayer(), UserPerms.USE_ROD)) {
                 if (event.getState() == PlayerFishEvent.State.FISHING) {//send msg only when throw the lure
                     new Message(ConfigMessage.NO_PERMISSION_FISHING).broadcast(event.getPlayer(), true, false);
                 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/AdminPerms.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/AdminPerms.java
@@ -1,0 +1,11 @@
+package com.oheers.fish.permissions;
+
+public class AdminPerms {
+    private AdminPerms() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static final String ADMIN = "emf.admin";
+    public static final String UPDATE_NOTIFY = "emf.admin.update.notify";
+    public static final String MIGRATE = "emf.admin.migrate";
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/UserPerms.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/UserPerms.java
@@ -1,0 +1,14 @@
+package com.oheers.fish.permissions;
+
+public class UserPerms {
+    private UserPerms() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static final String USE_ROD = "emf.use_rod";
+    public static final String SHOP = "emf.shop";
+    public static final String TOGGLE = "emf.toggle";
+    public static final String TOP = "emf.top";
+    public static final String SELL_ALL = "emf.sellall";
+    public static final String XMAS = "emf.xmas";
+}


### PR DESCRIPTION
This PR implements & closes #160 

It also adds more "root" permission nodes. As well as a global data class to access them: AdminPerms & UserPerms.

- `emf.admin`:
  - `emf.admin.migrate` - allows users to use the migrate command
  - `emf.admin.update.notify` - allows users to get update notifications
- `emf.user`:
  - `emf.top`
  - `emf.toggle`
  - `emf.shop`
  - `emf.use_rod`
  - `emf.sellall` 
  - `emf.xmas`