### PR TITLE
Add a boolean to saveUserData to specify whether it should use the scheduler

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -390,18 +390,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     }
 
     private void saveUserData(boolean scheduler) {
-        if (scheduler) {
-            getScheduler().runTask(() -> {
-                if (!(mainConfig.isDatabaseOnline())) {
-                    return;
-                }
-
-                saveFishReports();
-                saveUserReports();
-
-                DataManager.getInstance().uncacheAll();
-            });
-        } else {
+        Runnable save = () -> {
             if (!(mainConfig.isDatabaseOnline())) {
                 return;
             }
@@ -410,6 +399,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             saveUserReports();
 
             DataManager.getInstance().uncacheAll();
+        };
+        if (scheduler) {
+            getScheduler().runTask(save);
+        } else {
+            save.run();
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -244,7 +244,8 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     @Override
     public void onDisable() {
         terminateSellGUIS();
-        saveUserData();
+        // Don't use the scheduler here because it will throw errors on disable
+        saveUserData(false);
 
         // Ends the current competition in case the plugin is being disabled when the server will continue running
         if (Competition.isActive()) {
@@ -388,8 +389,19 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         });
     }
 
-    private void saveUserData() {
-        getScheduler().runTask(() -> {
+    private void saveUserData(boolean scheduler) {
+        if (scheduler) {
+            getScheduler().runTask(() -> {
+                if (!(mainConfig.isDatabaseOnline())) {
+                    return;
+                }
+
+                saveFishReports();
+                saveUserReports();
+
+                DataManager.getInstance().uncacheAll();
+            });
+        } else {
             if (!(mainConfig.isDatabaseOnline())) {
                 return;
             }
@@ -398,7 +410,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             saveUserReports();
 
             DataManager.getInstance().uncacheAll();
-        });
+        }
     }
 
     private void saveFishReports() {


### PR DESCRIPTION
Fixes a shutdown error by not using the scheduler when the plugin is being disabled