### PR TITLE
Fix startup issue on 1.20.3/4 servers

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/GUIConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/GUIConfig.java
@@ -115,7 +115,17 @@ public class GUIConfig {
             for (int j = 0; j < layoutArray.get(i).getAsString().length(); j++) {
                 char materialID = line.charAt(j);
                 if (materialID != 'X') {
-                    fillerDefault.put(((i * 9) + j), new ItemStack(Material.valueOf(planArray.get(Integer.parseInt(String.valueOf(materialID))).getAsString())));
+                    // Sucky code but it does the job
+                    String materialName = planArray.get(Integer.parseInt(String.valueOf(materialID))).getAsString().toUpperCase();
+                    try {
+                        fillerDefault.put(((i * 9) + j), new ItemStack(Material.valueOf(materialName)));
+                    } catch (IllegalArgumentException ex) {
+                        if (materialName.equals("GRASS")) {
+                            fillerDefault.put(((i * 9) + j), new ItemStack(Material.valueOf("SHORT_GRASS")));
+                        } else {
+                            throw ex;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
GUIConfig tried to use GRASS as the default filler material, but the material name was changed to SHORT_GRASS in 1.20.3.
This will catch the error it throws and try to use SHORT_GRASS instead. If grass wasn't the problem, it simply throws the error again.