### PR TITLE
PlayerPoints Integration

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
     maven("https://repo.spongepowered.org/maven/")
     maven("https://repo.essentialsx.net/releases/")
     maven("https://repo.auxilor.io/repository/maven-public/")
+    maven("https://repo.rosewooddev.io/repository/public/")
 }
 
 dependencies {
@@ -57,6 +58,7 @@ dependencies {
     compileOnly(libs.griefprevention)
     compileOnly(libs.mcmmo)
     compileOnly(libs.headdatabase.api)
+    compileOnly(libs.playerpoints)
 
     implementation(libs.nbt.api)
     implementation(libs.bstats)
@@ -82,8 +84,11 @@ bukkit {
     website = "https://github.com/Oheers/EvenMoreFish"
     foliaSupported = true
 
-    depend = listOf("Vault")
+    depend = listOf(
+        "Vault"
+    )
     softDepend = listOf(
+        "PlayerPoints",
         "WorldGuard",
         "PlaceholderAPI",
         "RedProtect",

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
@@ -17,7 +17,6 @@ public class Economy {
 
     public Economy(EconomyType type) {
         EvenMoreFish emf = EvenMoreFish.getInstance();
-        System.out.println(type.toString());
         switch (type) {
             case VAULT:
                 emf.getLogger().log(Level.INFO, "Attempting to hook into Vault for Economy Handling.");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
@@ -32,7 +32,7 @@ public class Economy {
                 return;
             case PLAYER_POINTS:
                 emf.getLogger().log(Level.INFO, "Attempting to hook into PlayerPoints for Economy Handling.");
-                if (emf.getServer().getPluginManager().isPluginEnabled("PlayerPoints")) {
+                if (EvenMoreFish.usingPlayerPoints) {
                     this.playerPointsEconomy = PlayerPoints.getInstance().getAPI();
                     economyType = type;
                     enabled = true;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
@@ -1,0 +1,114 @@
+package com.oheers.fish;
+
+import org.black_ixx.playerpoints.PlayerPoints;
+import org.black_ixx.playerpoints.PlayerPointsAPI;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.logging.Level;
+
+public class Economy {
+
+    private static EconomyType economyType = EconomyType.NONE;
+    private boolean enabled = false;
+    private net.milkbowl.vault.economy.Economy vaultEconomy = null;
+    private PlayerPointsAPI playerPointsEconomy = null;
+
+    public Economy(EconomyType type) {
+        EvenMoreFish emf = EvenMoreFish.getInstance();
+        System.out.println(type.toString());
+        switch (type) {
+            case VAULT:
+                emf.getLogger().log(Level.INFO, "Attempting to hook into Vault for Economy Handling.");
+                RegisteredServiceProvider<net.milkbowl.vault.economy.Economy> rsp = emf.getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
+                if (rsp == null) {
+                    return;
+                }
+                vaultEconomy = rsp.getProvider();
+                economyType = type;
+                enabled = true;
+                emf.getLogger().log(Level.INFO, "Hooked into Vault for Economy Handling.");
+                return;
+            case PLAYER_POINTS:
+                emf.getLogger().log(Level.INFO, "Attempting to hook into PlayerPoints for Economy Handling.");
+                if (emf.getServer().getPluginManager().isPluginEnabled("PlayerPoints")) {
+                    this.playerPointsEconomy = PlayerPoints.getInstance().getAPI();
+                    economyType = type;
+                    enabled = true;
+                    emf.getLogger().log(Level.INFO, "Hooked into PlayerPoints for Economy Handling.");
+                }
+                return;
+        }
+    }
+
+    public EconomyType getEconomyType() { return economyType; }
+
+    public boolean isEnabled() { return enabled; }
+
+    public void deposit(@NotNull OfflinePlayer player, double amount) {
+        switch (economyType) {
+            case VAULT:
+                vaultEconomy.depositPlayer(player, amount);
+                return;
+            case PLAYER_POINTS:
+                // PlayerPoints doesn't support doubles, so we need to cast to int
+                playerPointsEconomy.give(player.getUniqueId(), (int) amount);
+                return;
+        }
+    }
+
+    public boolean withdraw(@NotNull OfflinePlayer player, double amount) {
+        switch (economyType) {
+            case VAULT:
+                return vaultEconomy.withdrawPlayer(player, amount).transactionSuccess();
+            case PLAYER_POINTS:
+                // PlayerPoints doesn't support doubles, so we need to cast to int
+                return playerPointsEconomy.take(player.getUniqueId(), (int) amount);
+            default:
+                return true;
+        }
+    }
+
+    public boolean has(@NotNull OfflinePlayer player, double amount) {
+        switch (economyType) {
+            case VAULT:
+                return vaultEconomy.has(player, amount);
+            case PLAYER_POINTS:
+                // PlayerPoints doesn't seem to have a method to check this
+                return playerPointsEconomy.look(player.getUniqueId()) >= amount;
+            default:
+                return true;
+        }
+    }
+
+    public double get(@NotNull OfflinePlayer player) {
+        switch (economyType) {
+            case VAULT:
+                return vaultEconomy.getBalance(player);
+            case PLAYER_POINTS:
+                // PlayerPoints doesn't seem to have a method to check this
+                return playerPointsEconomy.look(player.getUniqueId());
+            default:
+                return 0;
+        }
+    }
+
+    public static double prepareValue(double value) {
+        switch (economyType) {
+            case VAULT:
+                return value;
+            case PLAYER_POINTS:
+                return Math.floor(value);
+            default:
+                return 0;
+        }
+    }
+
+    public enum EconomyType {
+        PLAYER_POINTS,
+        VAULT,
+        NONE
+    }
+
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -99,6 +99,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     public static boolean usingPAPI;
     public static boolean usingMcMMO;
     public static boolean usingHeadsDB;
+    public static boolean usingPlayerPoints;
 
     public static WorldGuardPlugin wgPlugin;
     public static String guardPL;
@@ -135,6 +136,8 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         logger = getLogger();
         pluginManager = getServer().getPluginManager();
 
+        usingPlayerPoints = Bukkit.getPluginManager().isPluginEnabled("PlayerPoints");
+        
         getConfig().options().copyDefaults();
         saveDefaultConfig();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -496,17 +496,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
         if (msgs.configVersion() < MSG_CONFIG_VERSION) {
             ConfigUpdater.updateMessages(msgs.configVersion());
-            getLogger().log(Level.WARNING, "Your messages.yml config is not up to date. The plugin may have automatically added the extra features but you may wish to" +
-                    " modify them to suit your server.");
-
             msgs.reload();
         }
 
         if (mainConfig.configVersion() < MAIN_CONFIG_VERSION) {
             ConfigUpdater.updateConfig(mainConfig.configVersion());
-            getLogger().log(Level.WARNING, "Your config.yml config is not up to date. The plugin may have automatically added the extra features but you may wish to" +
-                    " modify them to suit your server.");
-
             reloadConfig();
         }
 
@@ -514,7 +508,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             getLogger().log(Level.WARNING, "Your competitions.yml config is not up to date. Certain new configurable features may have been added, and without" +
                     " an updated config, you won't be able to modify them. To update, either delete your competitions.yml file and restart the server to create a new" +
                     " fresh one, or go through the recent updates, adding in missing values. https://www.spigotmc.org/resources/evenmorefish.91310/updates/");
-
             competitionConfig.reload();
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -60,7 +60,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
     public static final int METRIC_ID = 11054;
     public static final int MSG_CONFIG_VERSION = 16;
-    public static final int MAIN_CONFIG_VERSION = 14;
+    public static final int MAIN_CONFIG_VERSION = 15;
     public static final int COMP_CONFIG_VERSION = 1;
     public static FishFile fishFile;
     public static RaritiesFile raritiesFile;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -34,7 +34,6 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import de.tr7zw.changeme.nbtapi.NBTCompound;
 import de.tr7zw.changeme.nbtapi.NBTItem;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
-import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.permission.Permission;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
@@ -73,7 +72,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     public static GUIConfig guiConfig;
     public static List<String> competitionWorlds = new ArrayList<>();
     public static Permission permission = null;
-    public static Economy econ = null;
+    public static Economy economy;
     public static Map<Integer, Set<String>> fish = new HashMap<>();
     public static Map<String, Bait> baits = new HashMap<>();
     public static Map<Rarity, List<Fish>> fishCollection = new HashMap<>();
@@ -368,16 +367,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
     private boolean setupEconomy() {
         if (mainConfig.isEconomyEnabled()) {
-            RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
-            if (rsp == null) {
-                return false;
-            }
-            econ = rsp.getProvider();
-            return econ != null;
+            economy = new Economy(mainConfig.economyType());
+            return economy.isEnabled();
         } else {
             return false;
         }
-
     }
 
     // gets called on server shutdown to simulate all player's closing their /emf shop GUIs

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
@@ -7,6 +7,8 @@ import com.oheers.fish.api.EMFRewardEvent;
 import com.oheers.fish.config.messages.OldMessage;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.apache.commons.lang.StringUtils;
+import org.black_ixx.playerpoints.PlayerPoints;
+import org.black_ixx.playerpoints.PlayerPointsAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -129,6 +131,11 @@ public class Reward {
                 Economy economy = EvenMoreFish.economy;
                 if (economy.isEnabled()) { economy.deposit(player, Integer.parseInt(action)); }
                 break;
+            // Specifically for when using Vault but also wanting to give points
+            case PLAYER_POINTS:
+                if (EvenMoreFish.usingPlayerPoints) {
+                    PlayerPoints.getInstance().getAPI().give(player.getUniqueId(), Integer.parseInt(action));
+                }
             case OTHER:
                 PluginManager pM = Bukkit.getPluginManager();
                 EMFRewardEvent event = new EMFRewardEvent(this, p, fishVelocity, hookLocation);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.competition.reward;
 
+import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.api.EMFRewardEvent;
@@ -125,7 +126,8 @@ public class Reward {
 
                 break;
             case MONEY:
-                if (EvenMoreFish.econ != null) EvenMoreFish.econ.depositPlayer(player, Integer.parseInt(action));
+                Economy economy = EvenMoreFish.economy;
+                if (economy.isEnabled()) { economy.deposit(player, Integer.parseInt(action)); }
                 break;
             case OTHER:
                 PluginManager pM = Bukkit.getPluginManager();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/RewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/RewardType.java
@@ -2,8 +2,7 @@ package com.oheers.fish.competition.reward;
 
 public enum RewardType {
 
-    COMMAND, EFFECT, ITEM, MESSAGE, MONEY, HUNGER, HEALTH,
+    COMMAND, EFFECT, ITEM, MESSAGE, MONEY, HUNGER, HEALTH, PLAYER_POINTS,
     OTHER, BAD_FORMAT
-
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigUpdater.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigUpdater.java
@@ -217,7 +217,7 @@ public class ConfigUpdater {
             getMessageUpdates(13);
             return;
         }
-        File messagesFile = new File(EvenMoreFish.getProvidingPlugin(EvenMoreFish.class).getDataFolder().getPath() + "\\messages.yml");
+        File messagesFile = new File(EvenMoreFish.getInstance().getDataFolder(), "messages.yml");
         if (messagesFile.exists()) {
             try (BufferedReader file = new BufferedReader(new FileReader(messagesFile))) {
 
@@ -241,7 +241,7 @@ public class ConfigUpdater {
     }
 
     public static void updateConfig(int version) throws IOException {
-        File messagesFile = new File(EvenMoreFish.getProvidingPlugin(EvenMoreFish.class).getDataFolder().getPath() + "\\config.yml");
+        File messagesFile = new File(EvenMoreFish.getInstance().getDataFolder(), "config.yml");
         if (messagesFile.exists()) {
             try (BufferedReader file = new BufferedReader(new FileReader(messagesFile))) {
 
@@ -270,19 +270,26 @@ public class ConfigUpdater {
         switch (version) {
             case 7:
                 update.append(MSG_UPDATE_8);
+                logMessageUpdate(version + 1);
             case 8:
                 update.append(MSG_UPDATE_9);
+                logMessageUpdate(version + 1);
             case 9:
                 update.append(MSG_UPDATE_10);
+                logMessageUpdate(version + 1);
             case 10:
                 update.append(MSG_UPDATE_11);
+                logMessageUpdate(version + 1);
             case 11:
                 update.append(MSG_UPDATE_12);
+                logMessageUpdate(version + 1);
             case 12:
                 update.append(MSG_UPDATE_13);
+                logMessageUpdate(version + 1);
             case 13:
                 try {
                     insertCurrencySymbol(13);
+                    logMessageUpdate(version + 1);
                 } catch (IOException exception) {
                     EvenMoreFish.logger.log(Level.WARNING, "Could not update messages.yml");
                 }
@@ -290,6 +297,7 @@ public class ConfigUpdater {
                 update.append(MSG_UPDATE_15);
             case 15:
                 update.append(MSG_UPDATE_16);
+                logMessageUpdate(version + 1);
         }
 
         update.append(UPDATE_ALERT);
@@ -300,26 +308,48 @@ public class ConfigUpdater {
     private static String getConfigUpdates(int version) {
         StringBuilder update = new StringBuilder();
         update.append(UPDATE_ALERT);
+
         switch (version) {
             case 7:
                 update.append(CONFIG_UPDATE_8);
+                logConfigUpdate(version + 1);
             case 8:
                 update.append(CONFIG_UPDATE_9);
+                logConfigUpdate(version + 1);
             case 9:
                 update.append(CONFIG_UPDATE_10);
+                logConfigUpdate(version + 1);
             case 10:
                 update.append(CONFIG_UPDATE_11);
+                logConfigUpdate(version + 1);
             case 11:
                 update.append(CONFIG_UPDATE_12);
+                logConfigUpdate(version + 1);
             case 12:
                 update.append(CONFIG_UPDATE_13);
+                logConfigUpdate(version + 1);
             case 13:
                 update.append(CONFIG_UPDATE_14);
+                logConfigUpdate(version + 1);
         }
 
         update.append(UPDATE_ALERT);
 
         return update.toString();
+    }
+
+    private static void logConfigUpdate(int version) {
+        EvenMoreFish.getInstance().getLogger().log(
+                Level.WARNING,
+                "Updated config.yml to Version " + version + ". This warning exists in case you wish to modify these new values."
+        );
+    }
+
+    private static void logMessageUpdate(int version) {
+        EvenMoreFish.getInstance().getLogger().log(
+                Level.WARNING,
+                "Updated messages.yml to Version " + version + ". This warning exists in case you wish to modify these new values."
+        );
     }
 
     private static void insertCurrencySymbol(int version) throws IOException {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigUpdater.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigUpdater.java
@@ -360,7 +360,7 @@ public class ConfigUpdater {
     }
 
     private static void insertCurrencySymbol(int version) throws IOException {
-        File messagesFile = new File(EvenMoreFish.getProvidingPlugin(EvenMoreFish.class).getDataFolder().getPath() + "\\messages.yml");
+        File messagesFile = new File(EvenMoreFish.getInstance().getDataFolder(), "messages.yml");
         if (messagesFile.exists()) {
             try (BufferedReader file = new BufferedReader(new FileReader(messagesFile))) {
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigUpdater.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigUpdater.java
@@ -9,6 +9,10 @@ public class ConfigUpdater {
 
     private final static String UPDATE_ALERT = "\n###################### THIS IS AUTOMATICALLY UPDATED BY THE PLUGIN, IT IS RECOMMENDED TO MOVE THESE VALUES TO THEIR APPROPRIATE PLACES. ######################\n";
 
+    private static String CONFIG_UPDATE_15 = "\n" +
+            "# Choose which economy plugin you wish to use\n" +
+            "# Supported values are: Vault, PlayerPoints, None\n" +
+            "economy-type: Vault";
     private static String MSG_UPDATE_16 = "\n" +
             "# Shown when the emf %emf_competition_place_fish_*% placeholder requests a position in the leaderboard that doesn't exist\n" +
             "no-fish-in-place: \"Start fishing to take this place\"\n" +
@@ -331,6 +335,9 @@ public class ConfigUpdater {
             case 13:
                 update.append(CONFIG_UPDATE_14);
                 logConfigUpdate(version + 1);
+            case 14:
+                update.append(CONFIG_UPDATE_15);
+                logConfigUpdate(version + 1);
         }
 
         update.append(UPDATE_ALERT);
@@ -396,5 +403,6 @@ public class ConfigUpdater {
         CONFIG_UPDATE_12 = null;
         CONFIG_UPDATE_13 = null;
         CONFIG_UPDATE_14 = null;
+        CONFIG_UPDATE_15 = null;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.config;
 
+import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -71,6 +72,18 @@ public class MainConfig {
 
     public boolean isEconomyEnabled() {
         return config.getBoolean("enable-economy", true);
+    }
+
+    public Economy.EconomyType economyType() {
+        String economyString = config.getString("economy-type", "Vault");
+        switch (economyString) {
+            case "Vault":
+                return Economy.EconomyType.VAULT;
+            case "PlayerPoints":
+                return Economy.EconomyType.PLAYER_POINTS;
+            default:
+                return Economy.EconomyType.NONE;
+        }
     }
     
     public boolean isVanillaFishing() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellGUI.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellGUI.java
@@ -1,6 +1,7 @@
 package com.oheers.fish.selling;
 
 import com.devskiller.friendly_id.FriendlyId;
+import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.NbtUtils;
@@ -319,8 +320,10 @@ public class SellGUI implements InventoryHolder {
         }
         this.value = totalValue;
         this.fishCount = count;
-        
-        return Math.floor(totalValue * 10) / 10;
+
+        // Run this through the Economy#prepareValue method so the value is correct
+        // double for Vault, int for PlayerPoints, 0 when there is no economy plugin
+        return Economy.prepareValue(Math.floor(totalValue * 10) / 10);
     }
 
     public double getTotalWorth(boolean inventory) {
@@ -388,8 +391,9 @@ public class SellGUI implements InventoryHolder {
         double sellPrice = Math.floor(totalWorth * 10) / 10;
 
         if (sellType.equals("money")) {
-            if (EvenMoreFish.econ != null) {
-                EvenMoreFish.econ.depositPlayer(this.player, totalWorth);
+            Economy economy = EvenMoreFish.economy;
+            if (economy != null && economy.isEnabled()) {
+                economy.deposit(this.player, totalWorth);
             }
         } else if (sellType.equals("claimblocks")) {
             PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(this.player.getUniqueId());

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -39,6 +39,10 @@ random-durability: true
 # you'll want to do this, but it is possible.
 enable-economy: true
 
+# Choose which economy plugin you wish to use
+# Supported values are: Vault, PlayerPoints, None
+economy-type: Vault
+
 # Setting this to change the boosbar style
 # you can use like: SEGMENTED_6 SEGMENTED_10 SEGMENTED_12 SEGMENTED_20 SOLID
 barstyle: 'SEGMENTED_10'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,7 @@ dependencyResolutionManagement {
             library("json-simple", "com.googlecode.json-simple:json-simple:1.1.1")
 
             library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
+            library("playerpoints", "org.black_ixx:playerpoints:3.2.6")
         }
     }
 }


### PR DESCRIPTION
Suggested in #271 

Due to the way PlayerPoints works, we can only give it ints. Everything I've done here should account for that.

- Adds the Economy class and an EconomyType enum so we can use the correct provider.
- Adds a method to the Economy class which will format values so players don't get the wrong information. 
> To be specific, this will floor any doubles when PlayerPoints is used and return 0.0 when there is no Economy provider.
- Fixes the ConfigUpdater because it wasn't working properly.
- Adds better logging to the ConfigUpdater so admins know exactly what's going on.

This was designed in a way that should make adding other economy types quite easy, so i might add more if i feel like it / see requests for it.