### PR TITLE
Add {type} placeholder for competition bossbars

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
@@ -40,6 +40,31 @@ public class Bar {
 
     }
 
+    public void setPrefix(String prefix, CompetitionType type) {
+        String typeString = "";
+        switch (type) {
+            case SPECIFIC_RARITY:
+                typeString = "Specific Rarity";
+                break;
+            case MOST_FISH:
+                typeString = "Most Fish";
+                break;
+            case LARGEST_FISH:
+                typeString = "Largest Fish";
+                break;
+            case LARGEST_TOTAL:
+                typeString = "Largest Total";
+                break;
+            case SPECIFIC_FISH:
+                typeString = "Specific Fish";
+                break;
+            case RANDOM:
+                typeString = "Random";
+                break;
+        }
+        this.prefix = prefix.replace("{type}", typeString);
+    }
+
     public void setPrefix(String prefix) {
         this.prefix = prefix;
     }
@@ -84,6 +109,6 @@ public class Bar {
     }
 
     public void removeAllPlayers() {
-        //bar.sr
+        bar.removeAll();
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -83,6 +83,7 @@ public class Competition {
             this.timeLeft = this.maxDuration;
 
             leaderboard = new Leaderboard(competitionType);
+            statusBar.setPrefix(FishUtils.translateHexColorCodes(EvenMoreFish.competitionConfig.getBarPrefix(competitionName)), competitionType);
             statusBar.show();
             initTimer();
             announceBegin();


### PR DESCRIPTION
Closes #207

Allows admins to put the competition type in the competition bossbar.

Here is an example:
`bossbar-prefix: "&a&lFishing Contest - &b{type}: "`
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/18a3d027-98fe-4924-bbd7-1307c65631d8)
