### PR TITLE
Allow lore-override in fish config

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -244,11 +244,17 @@ public class Fish implements Cloneable {
      * @return A lore to be used by fetching data from the old messages.yml set-up.
      */
     private List<String> getFishLore() {
-        Message newLoreLine = new Message(ConfigMessage.FISH_LORE);
+        List<String> loreOverride = this.fishConfig.getStringList("fish." + this.rarity.getValue() + "." + this.name + ".lore-override");
+        Message newLoreLine;
+        if (!loreOverride.isEmpty()) {
+            newLoreLine = new Message(loreOverride);
+        } else {
+            newLoreLine = new Message(ConfigMessage.FISH_LORE);
+        }
         newLoreLine.setRarityColour(rarity.getColour());
 
         newLoreLine.addLore(
-            "{fish_lore}",
+                "{fish_lore}",
                 this.fishConfig.getStringList("fish." + this.rarity.getValue() + "." + this.name + ".lore")
         );
 


### PR DESCRIPTION
This aims to allow server owners to set completely custom lore for certain fish. It's configured exactly the same as the global lore but it only applies for that fish.

Example config:
```
    Penguin Feather:
      item:
        material: FEATHER
      lore-override:
        - "&7&oTest Lore"
        - "{rarity_colour}&l{rarity}"
        - ""
        - "{fish_lore}"
      lore:
        - "&7&oExtra Lore"
```
And a screenshot to show it working:
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/0c6c6776-e14b-47ac-929d-d6e30d4d8d61)
