### PR TITLE
Fixes some exceptions

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -134,7 +134,11 @@ public class FishUtils {
             fish.getFactory().setType(randomIndex);
         }
         if (playerString != null) {
-            fish.setFisherman(UUID.fromString(playerString));
+            try {
+                fish.setFisherman(UUID.fromString(playerString));
+            } catch (IllegalArgumentException ex) {
+                fish.setFisherman(fisher.getUniqueId());
+            }
         } else {
             fish.setFisherman(fisher.getUniqueId());
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/NbtUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/NbtUtils.java
@@ -127,6 +127,14 @@ public class NbtUtils {
         return new NamespacedKey(JavaPlugin.getProvidingPlugin(NbtUtils.class), key);
     }
 
+    public static NBTItem getNBTItem(ItemStack item) {
+        try {
+            return new NBTItem(item);
+        } catch (NullPointerException ex) {
+            return null;
+        }
+    }
+
 
     public enum NbtVersion {
         LEGACY, //pre nbt-api pr

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -190,6 +190,10 @@ public class FishingProcessor implements Listener {
             fish = chooseNonBaitFish(player, location);
         }
 
+        if (fish == null) {
+            return null;
+        }
+
         fish.init();
 
         if (runRewards && fish.hasFishRewards()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/WorthNBT.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/WorthNBT.java
@@ -52,13 +52,14 @@ public class WorthNBT {
     }
 
     public static double getValue(ItemStack item) {
+
+        NBTItem nbtItem = NbtUtils.getNBTItem(item);
+
         // creating the key to check for
-        if (!FishUtils.isFish(item)) {
+        if (nbtItem == null || !FishUtils.isFish(item)) {
             return -1.0;
         }
 
-
-        NBTItem nbtItem = new NBTItem(item);
         // it's a fish so it'll definitely have these NBT values
         Float length = NbtUtils.getFloat(nbtItem, NbtUtils.Keys.EMF_FISH_LENGTH);
         String rarity = NbtUtils.getString(nbtItem, NbtUtils.Keys.EMF_FISH_RARITY);


### PR DESCRIPTION
Adds a catch block in FishUtils#getFish(Skull, Player) which uses the fisher UUID if playerString is invalid.
Should fix the following error:
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/cf7485a1-b115-42b5-834f-0e4b1fc14ee7)

Adds a null check to FishingProcessor#getFish, since that was causing issues:
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/aa94316b-e1b2-403d-a83b-12cc4735bb09)

Adds a method to NbtUtils to get an NBTItem object so we can get null instead of an NPE. This has been used in WorthNBT#getValue to prevent warnings:
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/9e3c04b6-f242-4ba0-a404-656f644c6489)
