### PR TITLE
Add permission reward type

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/Reward.java
@@ -136,6 +136,10 @@ public class Reward {
                 if (EvenMoreFish.usingPlayerPoints) {
                     PlayerPoints.getInstance().getAPI().give(player.getUniqueId(), Integer.parseInt(action));
                 }
+                break;
+            case PERMISSION:
+                EvenMoreFish.permission.playerAdd(player.getPlayer(), action);
+                break;
             case OTHER:
                 PluginManager pM = Bukkit.getPluginManager();
                 EMFRewardEvent event = new EMFRewardEvent(this, p, fishVelocity, hookLocation);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/RewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/reward/RewardType.java
@@ -2,7 +2,7 @@ package com.oheers.fish.competition.reward;
 
 public enum RewardType {
 
-    COMMAND, EFFECT, ITEM, MESSAGE, MONEY, HUNGER, HEALTH, PLAYER_POINTS,
+    COMMAND, EFFECT, ITEM, MESSAGE, MONEY, HUNGER, HEALTH, PLAYER_POINTS, PERMISSION,
     OTHER, BAD_FORMAT
 
 }


### PR DESCRIPTION
Allows permission as a reward type, which will simply grant the player that permission

Example config:
```
rewards:
  1:
    - "PERMISSION:test.permission.emf"
```
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/e84574a4-4ee7-47de-87fe-4617b76a78f2)
