### PR TITLE
Allow running commands when a competition starts

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
@@ -707,7 +707,7 @@ class Controls {
             int duration = Integer.parseInt(argsDuration);
             // I've just discovered /emf admin competition start -1 causes some funky stuff - so this prevents that.
             if (duration > 0) {
-                Competition comp = new Competition(duration, type);
+                Competition comp = new Competition(duration, type, new ArrayList<>());
 
                 comp.setCompetitionName("[admin_started]");
                 comp.setAdminStarted(true);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -49,12 +49,14 @@ public class Competition {
     Sound startSound;
     MyScheduledTask timingSystem;
     List<UUID> leaderboardMembers = new ArrayList<>();
+    private List<String> beginCommands;
 
-    public Competition(final Integer duration, final CompetitionType type) {
+    public Competition(final Integer duration, final CompetitionType type, List<String> beginCommands) {
         this.maxDuration = duration;
         this.alertTimes = new ArrayList<>();
         this.rewards = new HashMap<>();
         this.competitionType = type;
+        this.beginCommands = beginCommands;
     }
 
     public static boolean isActive() {
@@ -89,9 +91,10 @@ public class Competition {
             statusBar.show();
             initTimer();
             announceBegin();
-            EMFCompetitionStartEvent startEvent = new EMFCompetitionStartEvent(new Competition(Long.valueOf(this.maxDuration).intValue(), this.competitionType));
+            EMFCompetitionStartEvent startEvent = new EMFCompetitionStartEvent(this);
             Bukkit.getServer().getPluginManager().callEvent(startEvent);
             epochStartTime = Instant.now().getEpochSecond();
+            this.beginCommands.forEach(command -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command));
 
             // Players can have had their rarities decided to be a null rarity if the competition only check is disabled for some rarities
             EvenMoreFish.getInstance().getDecidedRarities().clear();
@@ -105,7 +108,7 @@ public class Competition {
         // print leaderboard
         this.timingSystem.cancel();
         statusBar.hide();
-        EMFCompetitionEndEvent endEvent = new EMFCompetitionEndEvent(new Competition(Long.valueOf(this.maxDuration).intValue(), this.competitionType));
+        EMFCompetitionEndEvent endEvent = new EMFCompetitionEndEvent(this);
         Bukkit.getServer().getPluginManager().callEvent(endEvent);
         for (Player player : Bukkit.getOnlinePlayers()) {
             new Message(ConfigMessage.COMPETITION_END).broadcast(player, true, true);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
@@ -1,6 +1,5 @@
 package com.oheers.fish.competition;
 
-import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.config.CompetitionConfig;
 
 import java.util.*;
@@ -12,12 +11,13 @@ public class CompetitionQueue {
 
     public void load() {
         competitions = new TreeMap<>();
+        CompetitionConfig competitionConfig = CompetitionConfig.getInstance();
         // Competitions exist in the competitions.yml
-        if (CompetitionConfig.getInstance().getCompetitions() != null) {
-            for (String comp : CompetitionConfig.getInstance().getCompetitions()) {
+        if (competitionConfig.getCompetitions() != null) {
+            for (String comp : competitionConfig.getCompetitions()) {
 
-                CompetitionType type = CompetitionConfig.getInstance().getCompetitionType(comp);
-                Competition competition = new Competition(CompetitionConfig.getInstance().getCompetitionDuration(comp) * 60, type);
+                CompetitionType type = competitionConfig.getCompetitionType(comp);
+                Competition competition = new Competition(competitionConfig.getCompetitionDuration(comp) * 60, type, competitionConfig.getCompetitionStartCommands(comp));
 
                 competition.setCompetitionName(comp);
                 competition.setAdminStarted(false);
@@ -27,16 +27,16 @@ public class CompetitionQueue {
                 competition.initGetNumbersNeeded(comp);
                 competition.initStartSound(comp);
 
-                if (CompetitionConfig.getInstance().specificDayTimes(comp)) {
-                    for (String day : CompetitionConfig.getInstance().activeDays(comp)) {
-                        for (String time : CompetitionConfig.getInstance().getDayTimes(comp, day)) {
+                if (competitionConfig.specificDayTimes(comp)) {
+                    for (String day : competitionConfig.activeDays(comp)) {
+                        for (String time : competitionConfig.getDayTimes(comp, day)) {
                             competitions.put(generateTimeCode(day, time), competition);
                         }
                     }
-                } else if (CompetitionConfig.getInstance().doingRepeatedTiming(comp)) {
-                    if (CompetitionConfig.getInstance().hasBlacklistedDays(comp)) {
-                        List<String> blacklistedDays = CompetitionConfig.getInstance().getBlacklistedDays(comp);
-                        for (String time : CompetitionConfig.getInstance().getRepeatedTiming(comp)) {
+                } else if (competitionConfig.doingRepeatedTiming(comp)) {
+                    if (competitionConfig.hasBlacklistedDays(comp)) {
+                        List<String> blacklistedDays = competitionConfig.getBlacklistedDays(comp);
+                        for (String time : competitionConfig.getRepeatedTiming(comp)) {
                             for (String day : days) {
                                 if (!blacklistedDays.contains(day)) {
                                     competitions.put(generateTimeCode(day, time), competition);
@@ -44,7 +44,7 @@ public class CompetitionQueue {
                             }
                         }
                     } else {
-                        for (String time : CompetitionConfig.getInstance().getRepeatedTiming(comp)) {
+                        for (String time : competitionConfig.getRepeatedTiming(comp)) {
                             for (String day : days) {
                                 competitions.put(generateTimeCode(day, time), competition);
                             }
@@ -92,7 +92,7 @@ public class CompetitionQueue {
      * @return The next competition starting timecode.
      */
     public int getNextCompetition() {
-        Competition competition = new Competition(-1, CompetitionType.LARGEST_FISH);
+        Competition competition = new Competition(-1, CompetitionType.LARGEST_FISH, new ArrayList<>());
         int currentTimeCode = AutoRunner.getCurrentTimeCode();
         if (this.competitions.containsKey(currentTimeCode)) return currentTimeCode;
         this.competitions.put(currentTimeCode, competition);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
@@ -52,6 +52,15 @@ public class CompetitionConfig extends ConfigBase {
         return getConfig().getInt("competitions." + competitionName + ".duration");
     }
 
+    public List<String> getCompetitionStartCommands(String competitionName) {
+        String key = "competitions." + competitionName + ".start-commands";
+        if (getConfig().isString(key)) {
+            return Collections.singletonList(getConfig().getString(key));
+        } else {
+            return getConfig().getStringList(key);
+        }
+    }
+
     public CompetitionType getCompetitionType(String competitionName) {
         return CompetitionType.valueOf(getConfig().getString("competitions." + competitionName + ".type"));
     }

--- a/even-more-fish-plugin/src/main/resources/competitions.yml
+++ b/even-more-fish-plugin/src/main/resources/competitions.yml
@@ -17,6 +17,10 @@ competitions:
       - "06:00"
       - "12:00"
       - "18:00"
+    # Allows you to run commands when the competition starts. Uncomment to use
+    #start-commands:
+    #  - "command 1"
+    #  - "command 2"
     # Sets days that this competition type won't run on, this is useful if you want one day to be dominated by another competition type
     blacklisted-days:
       - "Sunday"


### PR DESCRIPTION
The title says it all.
```
  mainCompetition:
    start-commands:
      - "broadcast This is a competition start command"
      - "broadcast This is another competition start command"
```      
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/0724a97d-cf8b-4741-ac2d-11640c853c70)
