### PR TITLE
Update register log message

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/RewardManager.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/RewardManager.java
@@ -52,7 +52,7 @@ public class RewardManager implements Listener {
         if (rewardTypes.containsKey(identifier.toUpperCase())) {
             return false;
         }
-        rewardType.getPlugin().getLogger().info("Registered " + rewardType.getIdentifier() + " RewardType by " + rewardType.getAuthor());
+        getLogger().info("Registered " + rewardType.getIdentifier() + " RewardType by " + rewardType.getAuthor() + " from the plugin " + rewardType.getPlugin().getName());
         rewardTypes.put(identifier.toUpperCase(), rewardType);
         return true;
     }


### PR DESCRIPTION
The log message is now sent as EvenMoreFish, and says which plugin registered the RewardType. It makes the log messages easier to understand.

```
[08:35:27 INFO]: [EvenMoreFish] Registered MONEY RewardType by Oheers from the plugin EvenMoreFish
[08:35:27 INFO]: [EvenMoreFish] Registered PERMISSION RewardType by FireML from the plugin EvenMoreFish
[08:35:29 INFO]: [EvenMoreFish] Registered JOBS_EXP RewardType by FireML from the plugin AdminTools
```