### PR TITLE
Force a minimum of 1 minute for competition length

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
@@ -49,7 +49,7 @@ public class CompetitionConfig extends ConfigBase {
     }
 
     public int getCompetitionDuration(String competitionName) {
-        return getConfig().getInt("competitions." + competitionName + ".duration");
+        return Math.max(1, getConfig().getInt("competitions." + competitionName + ".duration"));
     }
 
     public List<String> getCompetitionStartCommands(String competitionName) {


### PR DESCRIPTION
Fixes an issue i encountered while testing something else.

I set my duration to the following:
```
    # How long (minutes) the competition should last for
    duration: 0.1
```

The code took that and turned it into an int, which ended up being 0. The competition completely broke because of this.
```
[08:54:54 WARN]: [EvenMoreFish] Global task for EvenMoreFish v1.6.11.17 generated an exception
java.lang.IllegalArgumentException: Progress must be between 0.0 and 1.0 (NaN)
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218) ~[guava-32.1.2-jre.jar:?]
	at org.bukkit.craftbukkit.v1_20_R3.boss.CraftBossBar.setProgress(CraftBossBar.java:158) ~[paper-1.20.4.jar:git-Paper-455]
	at com.oheers.fish.competition.Bar.setProgress(Bar.java:39) ~[even-more-fish-1.6.11.17.jar:?]
	at com.oheers.fish.competition.Bar.timerUpdate(Bar.java:28) ~[even-more-fish-1.6.11.17.jar:?]
	at com.oheers.fish.competition.Competition$1.run(Competition.java:136) ~[even-more-fish-1.6.11.17.jar:?]
	at com.github.Anon8281.universalScheduler.foliaScheduler.FoliaScheduler.lambda$runTaskTimer$2(FoliaScheduler.java:65) ~[even-more-fish-1.6.11.17.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler$GlobalScheduledTask.run(FoliaGlobalRegionScheduler.java:179) ~[paper-1.20.4.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(FoliaGlobalRegionScheduler.java:37) ~[paper-1.20.4.jar:?]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1649) ~[paper-1.20.4.jar:git-Paper-455]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:447) ~[paper-1.20.4.jar:git-Paper-455]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1525) ~[paper-1.20.4.jar:git-Paper-455]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1226) ~[paper-1.20.4.jar:git-Paper-455]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:319) ~[paper-1.20.4.jar:git-Paper-455]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```

My change forces the duration to be at least 1 minute to prevent this.