### PR TITLE
Illegal stacks fix

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -158,6 +158,26 @@ public class FishUtils {
                 .forEach(item -> EvenMoreFish.getScheduler().runTask(() -> player.getWorld().dropItem(player.getLocation(), item)));
     }
 
+    public static void giveItems(ItemStack[] items, Player player) {
+        if (items.length == 0) {
+            return;
+        }
+        player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.5f, 1.5f);
+        player.getInventory().addItem(items)
+                .values()
+                .forEach(item -> EvenMoreFish.getScheduler().runTask(() -> player.getWorld().dropItem(player.getLocation(), item)));
+    }
+
+    public static void giveItem(ItemStack item, Player player) {
+        if (item == null) {
+            return;
+        }
+        player.playSound(player.getLocation(), Sound.ENTITY_ITEM_PICKUP, 0.5f, 1.5f);
+        player.getInventory().addItem(item)
+                .values()
+                .forEach(loopItem -> EvenMoreFish.getScheduler().runTask(() -> player.getWorld().dropItem(player.getLocation(), loopItem)));
+    }
+
     public static boolean checkRegion(Location l, List<String> whitelistedRegions) {
         // if there's any region plugin installed
         if (EvenMoreFish.getInstance().getGuardPL() == null) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/ItemRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/ItemRewardType.java
@@ -22,20 +22,19 @@ public class ItemRewardType implements RewardType {
             EvenMoreFish.getInstance().getLogger().warning("Invalid material specified for RewardType " + getIdentifier() + ": " + parsedItem[0]);
             return;
         }
-        ItemStack item;
-        if (parsedItem.length == 1) {
-            item = new ItemStack(material);
-        } else {
-            int quantity;
+        ItemStack item = new ItemStack(material);
+        int quantity = 1;
+        if (parsedItem.length > 1) {
             try {
                 quantity = Integer.parseInt(parsedItem[1]);
             } catch (NumberFormatException ex) {
                 EvenMoreFish.getInstance().getLogger().warning("Invalid quantity specified for RewardType " + getIdentifier() + ": " + parsedItem[1]);
                 return;
             }
-            item = new ItemStack(material, quantity);
         }
-        FishUtils.giveItems(Collections.singletonList(item), player);
+        for (int i = 0; i < quantity; ++i) {
+            FishUtils.giveItem(item, player);
+        }
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/ItemRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/ItemRewardType.java
@@ -17,9 +17,9 @@ public class ItemRewardType implements RewardType {
     @Override
     public void doReward(@NotNull Player player, @NotNull String key, @NotNull String value, Location hookLocation) {
         String[] parsedItem = value.split(",");
-        Material material = Material.getMaterial(parsedItem[0]);
+        Material material = Material.getMaterial(parsedItem[0].toUpperCase());
         if (material == null) {
-            EvenMoreFish.getInstance().getLogger().warning("Invalid material specified for RewardType " + getIdentifier() + ": " + value);
+            EvenMoreFish.getInstance().getLogger().warning("Invalid material specified for RewardType " + getIdentifier() + ": " + parsedItem[0]);
             return;
         }
         ItemStack item;


### PR DESCRIPTION
- Adds more giveItems methods
- Fixes item rewards being invalid if not uppercased
- Prevents the plugin from rewarding illegal stacks of items by using a loop.

One of the illegal stacks:
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/d9f9dd75-67c8-4961-8d6c-7ca4da64c59d)
