### PR TITLE
Add RewardTypes Command

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/CommandCentre.java
@@ -2,6 +2,7 @@ package com.oheers.fish;
 
 import com.oheers.fish.addons.AddonManager;
 import com.oheers.fish.api.addons.Addon;
+import com.oheers.fish.api.reward.RewardManager;
 import com.oheers.fish.baits.Bait;
 import com.oheers.fish.baits.BaitNBTManager;
 import com.oheers.fish.competition.Competition;
@@ -13,7 +14,6 @@ import com.oheers.fish.config.messages.Messages;
 import com.oheers.fish.config.messages.PrefixType;
 import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.Rarity;
-import com.oheers.fish.gui.FishingGUI;
 import com.oheers.fish.permissions.AdminPerms;
 import com.oheers.fish.permissions.UserPerms;
 import com.oheers.fish.selling.SellGUI;
@@ -48,7 +48,8 @@ public class CommandCentre implements TabCompleter, CommandExecutor {
                 "nbt-rod",
                 "reload",
                 "addons",
-                "version"
+                "version",
+                "rewardtypes"
         );
 
         compTabs = Arrays.asList(
@@ -656,6 +657,23 @@ class Controls {
                 }
 
                 new Message(messageList).broadcast(sender,true,false);
+                break;
+            }
+            case "rewardtypes": {
+                TextComponent message = new TextComponent(new Message(ConfigMessage.ADMIN_LIST_REWARD_TYPES).getRawMessage(true, false));
+                ComponentBuilder builder = new ComponentBuilder(message);
+
+                RewardManager.getInstance().getRegisteredRewardTypes().forEach(rewardType -> {
+                    TextComponent component = new TextComponent(rewardType.getIdentifier());
+                    component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                            TextComponent.fromLegacyText(
+                                    "Author: " + rewardType.getAuthor() + "\n" +
+                                    "Registered Plugin: " + rewardType.getPlugin().getName()
+                            )
+                    ));
+                    builder.append(component).append(", ");
+                });
+                sender.spigot().sendMessage(builder.create());
                 break;
             }
             default:

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
@@ -18,6 +18,7 @@ public enum ConfigMessage {
     ADMIN_NUMBER_RANGE_ERROR("&r{amount} is not a number between 1-64.", PrefixType.ERROR, false, true, "admin.number-range-error"),
     ADMIN_UNKNOWN_PLAYER("&r{player} could not be found.", PrefixType.ERROR, false, true, "admin.player-not-found"),
     ADMIN_UPDATE_AVAILABLE("&rThere is an update available: " + "https://www.spigotmc.org/resources/evenmorefish.91310/updates", PrefixType.ADMIN, false, false, "admin.update-available"),
+    ADMIN_LIST_REWARD_TYPES("&rRegistered Reward Types: ", PrefixType.ADMIN, false, false, "admin.list-reward-types"),
 
     BAITS_CLEARED("&rYou have removed all {amount} baits from your fishing rod.", PrefixType.ADMIN, true, false, "admin.all-baits-cleared"),
     BAIT_CAUGHT("&r&l{player} &rhas caught a {bait_theme}&l{bait} &rbait!", PrefixType.NONE, true, false, "bait-catch"),

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -279,3 +279,5 @@ admin:
   update-available: "&rThere is an update available: https://www.spigotmc.org/resources/evenmorefish.91310/updates"
   # When the plugin is reloaded
   reload: "&rSuccessfully reloaded the plugin."
+  # When checking the list of RewardTypes. The actual list is added to the end of this message.
+  list-reward-types: "&rRegistered Reward Types: "


### PR DESCRIPTION
Adds `/emf admin rewardtypes`, which shows admins which types are registered, who the author is, and which plugin it came from.
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/4df5260d-c4a5-437a-a173-67ecf3514ec9)

I'll admit i'm used to the Adventure API instead of Bungeecord, so I was unable to make this support colors unfortunately.