### PR TITLE
Support vanished players

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -25,6 +25,8 @@ repositories {
     maven("https://repo.essentialsx.net/releases/")
     maven("https://repo.auxilor.io/repository/maven-public/")
     maven("https://repo.rosewooddev.io/repository/public/")
+    maven("https://repo.firedev.uk/repository/maven-public/")
+    maven("https://repo.essentialsx.net/releases/")
 }
 
 dependencies {
@@ -59,6 +61,8 @@ dependencies {
     compileOnly(libs.mcmmo)
     compileOnly(libs.headdatabase.api)
     compileOnly(libs.playerpoints)
+    compileOnly(libs.cmi.api)
+    compileOnly(libs.essx.api)
 
     implementation(libs.nbt.api)
     implementation(libs.bstats)

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -1,5 +1,11 @@
 package com.oheers.fish;
 
+import com.Zrips.CMI.Containers.CMIUser;
+import com.Zrips.CMI.Modules.Vanish.VanishManager;
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.EssentialsPlayerListener;
+import com.earth2me.essentials.IEssentials;
+import com.earth2me.essentials.User;
 import com.github.Anon8281.universalScheduler.UniversalScheduler;
 import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
 import com.oheers.fish.addons.AddonManager;
@@ -709,6 +715,40 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         new PermissionRewardType().register();
         new PlayerPointsRewardType().register();
         new EXPRewardType().register();
+    }
+
+    /**
+     * Retrieves online players excluding those who are vanished.
+     * @return A list of online players excluding those who are vanished.
+     */
+    public List<Player> getOnlinePlayersExcludingVanish() {
+        List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
+        System.out.println(players.size());
+
+        // Check Essentials
+        System.out.println("Essentials: " + Bukkit.getPluginManager().isPluginEnabled("Essentials"));
+        if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
+            Plugin plugin = Bukkit.getPluginManager().getPlugin("Essentials");
+            System.out.println("Essentials Found? " + (plugin instanceof Essentials));
+            if (plugin instanceof Essentials) {
+                Essentials essentials = (Essentials) plugin;
+                players = players.stream().filter(player -> !essentials.getUser(player).isVanished()).collect(Collectors.toList());
+            }
+        }
+
+        // Check CMI
+        System.out.println("CMI: " + Bukkit.getPluginManager().isPluginEnabled("CMI"));
+        if (Bukkit.getPluginManager().isPluginEnabled("CMI")) {
+            players = players.stream().filter(player -> !CMIUser.getUser(player).isVanished()).collect(Collectors.toList());
+        }
+
+        System.out.println(players.size());
+        return players;
+    }
+
+    @EventHandler
+    public void onServerLoad(ServerLoadEvent event) {
+        Bukkit.getPluginManager().callEvent(new EMFRewardsLoadEvent());
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -723,13 +723,10 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
      */
     public List<Player> getOnlinePlayersExcludingVanish() {
         List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
-        System.out.println(players.size());
 
         // Check Essentials
-        System.out.println("Essentials: " + Bukkit.getPluginManager().isPluginEnabled("Essentials"));
         if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
             Plugin plugin = Bukkit.getPluginManager().getPlugin("Essentials");
-            System.out.println("Essentials Found? " + (plugin instanceof Essentials));
             if (plugin instanceof Essentials) {
                 Essentials essentials = (Essentials) plugin;
                 players = players.stream().filter(player -> !essentials.getUser(player).isVanished()).collect(Collectors.toList());
@@ -737,12 +734,10 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         }
 
         // Check CMI
-        System.out.println("CMI: " + Bukkit.getPluginManager().isPluginEnabled("CMI"));
         if (Bukkit.getPluginManager().isPluginEnabled("CMI")) {
             players = players.stream().filter(player -> !CMIUser.getUser(player).isVanished()).collect(Collectors.toList());
         }
 
-        System.out.println(players.size());
         return players;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -68,7 +68,7 @@ public class Competition {
     }
 
     public void begin(boolean adminStart) {
-        if (Bukkit.getOnlinePlayers().size() >= playersNeeded || adminStart) {
+        if (EvenMoreFish.getInstance().getOnlinePlayersExcludingVanish().size() >= playersNeeded || adminStart) {
             active = true;
 
             if (competitionType == CompetitionType.RANDOM) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,8 @@ dependencyResolutionManagement {
 
             library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
             library("playerpoints", "org.black_ixx:playerpoints:3.2.6")
+            library("cmi-api", "CMI-API:CMI-API:9.7.0.1")
+            library("essx-api", "net.essentialsx:EssentialsX:2.20.1")
         }
     }
 }


### PR DESCRIPTION
Requested by Cloude_Lecaw on the discord server.

Competition player requirements now respect vanished players.
This supports EssentialsX and CMI, as i have access to both.

Some logs of it working:
```
[04:37:00 INFO]: 1
[04:37:00 INFO]: [EvenMoreFish] [STDOUT] Essentials: true
[04:37:00 INFO]: [EvenMoreFish] [STDOUT] Essentials Found? true
[04:37:00 INFO]: [EvenMoreFish] [STDOUT] CMI: false
[04:37:00 INFO]: 0
```
```
[04:40:00 INFO]: 1
[04:40:00 INFO]: [EvenMoreFish] [STDOUT] Essentials: false
[04:40:00 INFO]: [EvenMoreFish] [STDOUT] CMI: true
[04:40:00 INFO]: 0
```