### PR TITLE
Add config option for respecting vanished players

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -724,6 +724,10 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     public List<Player> getOnlinePlayersExcludingVanish() {
         List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
 
+        if (!MainConfig.getInstance().shouldRespectVanish()) {
+            return players;
+        }
+
         // Check Essentials
         if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
             Plugin plugin = Bukkit.getPluginManager().getPlugin("Essentials");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -74,6 +74,8 @@ public class MainConfig extends ConfigBase {
                 return Economy.EconomyType.NONE;
         }
     }
+
+    public boolean shouldRespectVanish() { return getConfig().getBoolean("respect-vanished", true); }
     
     public boolean isVanillaFishing() {
         return getConfig().getBoolean("vanilla-fishing", true);

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -13,6 +13,10 @@ fish-only-in-competition: false
 # may not work on all servers.
 experimental-features: false
 
+# Should competition player requirements respect vanished players?
+# Supports EssentialsX and CMI.
+respect-vanished: true
+
 # The plugin stores stats about fish caught by players, used in the fish log. Disabling this will disable functionality
 # of this feature.
 # ATTENTION: Toggling this requires a full server restart.


### PR DESCRIPTION
The title says it all. 
Gives server admins a bit more freedom in case they want vanished players to count for some reason.
Enabled by default.