### PR TITLE
Move GriefPrevention support to an EconomyType

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -102,7 +102,8 @@ bukkit {
         "Denizen",
         "EcoItems",
         "Oraxen",
-        "HeadDatabase"
+        "HeadDatabase",
+        "GriefPrevention"
     )
     loadBefore = listOf("AntiAC")
     apiVersion = "1.16"

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -99,6 +99,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     private boolean usingMcMMO;
     private boolean usingHeadsDB;
     private boolean usingPlayerPoints;
+    private boolean usingGriefPrevention;
 
     private WorldGuardPlugin wgPlugin;
     private String guardPL;
@@ -135,6 +136,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         logger = getLogger();
         pluginManager = getServer().getPluginManager();
 
+        usingGriefPrevention = Bukkit.getPluginManager().isPluginEnabled("GriefPrevention");
         usingPlayerPoints = Bukkit.getPluginManager().isPluginEnabled("PlayerPoints");
         
         getConfig().options().copyDefaults();
@@ -524,7 +526,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             usingPAPI = true;
             new PlaceholderReceiver(this).register();
         }
-
     }
 
     private boolean checkRP() {
@@ -671,6 +672,8 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     public boolean isUsingPlayerPoints() {
         return usingPlayerPoints;
     }
+
+    public boolean isUsingGriefPrevention() { return usingGriefPrevention; }
 
     public WorldGuardPlugin getWgPlugin() {
         return wgPlugin;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -70,6 +70,8 @@ public class MainConfig extends ConfigBase {
                 return Economy.EconomyType.VAULT;
             case "PlayerPoints":
                 return Economy.EconomyType.PLAYER_POINTS;
+            case "GriefPrevention":
+                return Economy.EconomyType.GRIEF_PREVENTION;
             default:
                 return Economy.EconomyType.NONE;
         }
@@ -80,8 +82,6 @@ public class MainConfig extends ConfigBase {
     public boolean isVanillaFishing() {
         return getConfig().getBoolean("vanilla-fishing", true);
     }
-
-    public String getSellType() {return getConfig().getString("sell-type", "money");}
 
     public String getFiller() {
         return getConfig().getString("gui.filler", "GRAY_STAINED_GLASS_PANE");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellGUI.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellGUI.java
@@ -334,11 +334,25 @@ public class SellGUI implements InventoryHolder {
     }
 
     public String formatWorth(double totalWorth) {
-        if (MainConfig.getInstance().getSellType().equals("money")) {
-            DecimalFormat format = new DecimalFormat(new Message(ConfigMessage.SELL_PRICE_FORMAT).getRawMessage(false, false));
-            return format.format(totalWorth);
-        } else {
-            return (int) totalWorth + " Claim Blocks";
+        switch (EvenMoreFish.getInstance().getEconomy().getEconomyType()) {
+            case GRIEF_PREVENTION:
+                if ((int) totalWorth == 1) {
+                    return (int) totalWorth + " Claim Block";
+                } else {
+                    return (int) totalWorth + " Claim Blocks";
+                }
+            case PLAYER_POINTS:
+                if ((int) totalWorth == 1) {
+                    return (int) totalWorth + " Player Point";
+                } else {
+                    return (int) totalWorth + " Player Points";
+                }
+            case VAULT:
+                DecimalFormat format = new DecimalFormat(new Message(ConfigMessage.SELL_PRICE_FORMAT).getRawMessage(false, false));
+                return format.format(totalWorth);
+            // Includes NONE type
+            default:
+                return String.valueOf(totalWorth);
         }
     }
 
@@ -390,17 +404,11 @@ public class SellGUI implements InventoryHolder {
     public boolean sell(boolean sellAll) {
         List<SoldFish> soldFish = getTotalSoldFish(sellAll);
         double totalWorth = getTotalWorth(soldFish);
-        String sellType = MainConfig.getInstance().getSellType();
         double sellPrice = Math.floor(totalWorth * 10) / 10;
 
-        if (sellType.equals("money")) {
-            Economy economy = EvenMoreFish.getInstance().getEconomy();
-            if (economy != null && economy.isEnabled()) {
-                economy.deposit(this.player, totalWorth);
-            }
-        } else if (sellType.equals("claimblocks")) {
-            PlayerData playerData = GriefPrevention.instance.dataStore.getPlayerData(this.player.getUniqueId());
-            playerData.setBonusClaimBlocks((int) (playerData.getBonusClaimBlocks() + sellPrice));
+        Economy economy = EvenMoreFish.getInstance().getEconomy();
+        if (economy != null && economy.isEnabled()) {
+            economy.deposit(this.player, totalWorth);
         }
 
         // sending the sell message to the player

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -44,7 +44,7 @@ random-durability: true
 enable-economy: true
 
 # Choose which economy plugin you wish to use
-# Supported values are: Vault, PlayerPoints, None
+# Supported values are: Vault, PlayerPoints, GriefPrevention, None
 economy-type: Vault
 
 # Setting this to change the boosbar style
@@ -118,10 +118,6 @@ disable-mcmmo-loot: true
 
 # Prevents AureliumSkills from overriding fishing loot, this means treasure won't appear when fish can.
 disable-aureliumskills-loot: true
-
-# Should the shop give you money or claim blocks?
-# Currently: money, claimblocks
-sell-type: money
 
 # When set to true, players won't be able to place fish that are heads, like head-64 or head-uuid.
 place-head-fish: false


### PR DESCRIPTION
Removes the config entry that does pretty much the same thing in favor of the new EconomyType system.

![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/0392b390-5301-46e1-9fc6-098614bcabac)
