### PR TITLE
Add a fish permission

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -140,7 +140,6 @@ public class FishingProcessor implements Listener {
         for (List<Fish> fishList : EvenMoreFish.getInstance().getFishCollection().values()) {
             maxChecked += fishList.size();
         }
-        System.out.println("Max: " + maxChecked);
 
         // Keep looping until you've checked every single fish, or you find a valid fish.
         while (true) {
@@ -149,7 +148,6 @@ public class FishingProcessor implements Listener {
                 return null;
             }
             checked++;
-            System.out.println("Checked: " + checked);
             if (fish.hasFishingPermission(player)) {
                 fish.setFisherman(player.getUniqueId());
                 return fish;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -143,7 +143,7 @@ public class FishingProcessor implements Listener {
 
         // Keep looping until you've checked every single fish, or you find a valid fish.
         while (true) {
-            if (checked == maxChecked) {
+            if (checked >= maxChecked) {
                 EvenMoreFish.getInstance().getLogger().severe("Could not determine a fish for " + player.getName() + ". The player doesn't have permission to catch any fish! (See fish.yml)");
                 return null;
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -135,8 +135,31 @@ public class FishingProcessor implements Listener {
             EvenMoreFish.getInstance().getLogger().severe("Could not determine a fish for " + player.getName());
             return null;
         }
-        fish.setFisherman(player.getUniqueId());
-        return fish;
+        int checked = 0;
+        int maxChecked = 0;
+        for (List<Fish> fishList : EvenMoreFish.getInstance().getFishCollection().values()) {
+            maxChecked += fishList.size();
+        }
+        System.out.println("Max: " + maxChecked);
+
+        // Keep looping until you've checked every single fish, or you find a valid fish.
+        while (true) {
+            if (checked == maxChecked) {
+                EvenMoreFish.getInstance().getLogger().severe("Could not determine a fish for " + player.getName() + ". The player doesn't have permission to catch any fish! (See fish.yml)");
+                return null;
+            }
+            checked++;
+            System.out.println("Checked: " + checked);
+            if (fish.hasFishingPermission(player)) {
+                fish.setFisherman(player.getUniqueId());
+                return fish;
+            }
+            fish = getFish(fishRarity, location, player, 1, null, true);
+            if (fish == null) {
+                EvenMoreFish.getInstance().getLogger().severe("Could not determine a fish for " + player.getName());
+                return null;
+            }
+        }
     }
 
     public static ItemStack getFish(Player player, Location location, ItemStack fishingRod, boolean runRewards, boolean sendMessages) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -9,6 +9,7 @@ import com.oheers.fish.config.Xmas2022Config;
 import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
 import com.oheers.fish.exceptions.InvalidFishException;
+import com.oheers.fish.requirements.Permission;
 import com.oheers.fish.requirements.Requirement;
 import com.oheers.fish.selling.WorthNBT;
 import com.oheers.fish.utils.ItemFactory;
@@ -16,11 +17,14 @@ import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.profile.PlayerTextures;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.logging.Level;
@@ -63,6 +67,8 @@ public class Fish implements Cloneable {
 
     private int day = -1;
 
+    private String permission = "";
+
     public Fish(Rarity rarity, String name, boolean isXmas2022Fish) throws InvalidFishException {
         if (rarity == null) {
             throw new InvalidFishException(name + " could not be fetched from the config.");
@@ -75,6 +81,7 @@ public class Fish implements Cloneable {
         this.setFishAndRarityConfig();
         final boolean defaultRarityDisableFisherman = RaritiesFile.getInstance().getConfig().getBoolean("rarities." + this.rarity.getValue() + ".disable-fisherman", false);
         this.disableFisherman = this.fishConfig.getBoolean("fish." + this.rarity.getValue() + "." + this.name + ".disable-fisherman", defaultRarityDisableFisherman);
+        this.permission = this.fishConfig.getString("fish." + this.rarity.getValue() + "." + this.name + ".permission", "");
 
         this.factory = new ItemFactory("fish." + this.rarity.getValue() + "." + this.name, this.xmasFish);
         checkDisplayName();
@@ -93,6 +100,13 @@ public class Fish implements Cloneable {
         checkFishEvent();
 
         checkSellEvent();
+    }
+
+    public boolean hasFishingPermission(@NotNull Player player) {
+        if (permission.isEmpty()) {
+            return true;
+        }
+        return player.hasPermission(permission);
     }
     
     /*


### PR DESCRIPTION
 Adds the ability to lock fish behind a permission.

```
    Shiny Pickle:
      permission: "emf.shiny_pickle"
```
This fish can only be caught if the player has the `emf.shiny_pickle` permission.

It loops over all possible fish until the player has permission, or all fish have been checked.

If the player doesn't have permission for any fish, it prints an error to console:
```
[10:13:39 INFO]: [EvenMoreFish] [STDOUT] Max: 1
[10:13:39 INFO]: [EvenMoreFish] [STDOUT] Checked: 1
[10:13:39 ERROR]: [EvenMoreFish] Could not determine a fish for FireML. The player doesn't have permission to catch any fish! (See fish.yml)
```