### PR TITLE
Fire catch-event when using /emf admin fish

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -52,6 +52,12 @@ public class AdminCommand extends BaseCommand {
 
         fish.init();
 
+        fish.checkFishEvent();
+
+        if (fish.hasFishRewards()) {
+            fish.getFishRewards().forEach(fishReward -> fishReward.rewardPlayer(target, target.getLocation()));
+        }
+
         final ItemStack fishItem = fish.give(-1);
         fishItem.setAmount(quantity);
 


### PR DESCRIPTION
Just something i noticed. All other events appear to work with a fish given by the admin command.