### PR TITLE
Fixes some problems in the Competition class

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -633,7 +633,7 @@ public class Competition {
             }
             this.selectedFish = selectedFish;
             return true;
-        } catch (IllegalArgumentException exception) {
+        } catch (IllegalArgumentException|IndexOutOfBoundsException exception) {
             EvenMoreFish.getInstance()
                     .getLogger()
                     .severe("Could not load: " + competitionName + " because a random fish could not be chosen. \nIf you need support, please provide the following information:");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -26,6 +26,7 @@ import org.bukkit.entity.Player;
 import java.time.Instant;
 import java.util.*;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 public class Competition {
 
@@ -611,6 +612,13 @@ public class Competition {
                 allowedRarities.add(r);
                 totalWeight += (r.getWeight());
             }
+        }
+
+        if (allowedRarities.isEmpty()) {
+            EvenMoreFish.getInstance().getLogger().severe("The allowed-rarities list found in the " + competitionName + " competition config contains no loaded rarities!");
+            EvenMoreFish.getInstance().getLogger().severe("Configured Rarities: " + configRarities);
+            EvenMoreFish.getInstance().getLogger().severe("Loaded Rarities: " + EvenMoreFish.getInstance().getFishCollection().keySet().stream().map(Rarity::getValue).collect(Collectors.toList()));
+            return false;
         }
 
         int idx = 0;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -25,6 +25,7 @@ import org.bukkit.entity.Player;
 
 import java.time.Instant;
 import java.util.*;
+import java.util.logging.Level;
 
 public class Competition {
 
@@ -638,6 +639,8 @@ public class Competition {
                     .severe("Could not load: " + competitionName + " because a random fish could not be chosen. \nIf you need support, please provide the following information:");
             EvenMoreFish.getInstance().getLogger().severe("fish.size(): " + fish.size());
             EvenMoreFish.getInstance().getLogger().severe("allowedRarities.size(): " + allowedRarities.size());
+            // Also log the exception
+            EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, exception.getMessage(), exception);
             return false;
         }
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -113,7 +113,9 @@ public class Competition {
 
     public void end() {
         // print leaderboard
-        this.timingSystem.cancel();
+        if (this.timingSystem != null) {
+            this.timingSystem.cancel();
+        }
         statusBar.hide();
         EMFCompetitionEndEvent endEvent = new EMFCompetitionEndEvent(this);
         Bukkit.getServer().getPluginManager().callEvent(endEvent);
@@ -610,8 +612,6 @@ public class Competition {
             }
         }
 
-        configRarities = null;
-
         int idx = 0;
         for (double r = Math.random() * totalWeight; idx < allowedRarities.size() - 1; ++idx) {
             r -= allowedRarities.get(idx).getWeight();
@@ -625,14 +625,19 @@ public class Competition {
         }
 
         try {
-            this.selectedFish = FishingProcessor.getFish(allowedRarities.get(idx), null, null, 1.0d, null, false);
+            Fish selectedFish = FishingProcessor.getFish(allowedRarities.get(idx), null, null, 1.0d, null, false);
+            if (selectedFish == null) {
+                // For the catch block to catch.
+                throw new IllegalArgumentException();
+            }
+            this.selectedFish = selectedFish;
             return true;
         } catch (IllegalArgumentException exception) {
             EvenMoreFish.getInstance()
                     .getLogger()
                     .severe("Could not load: " + competitionName + " because a random fish could not be chosen. \nIf you need support, please provide the following information:");
             EvenMoreFish.getInstance().getLogger().severe("fish.size(): " + fish.size());
-            EvenMoreFish.getInstance().getLogger().severe("allowedRarities.size(): " + configRarities.size());
+            EvenMoreFish.getInstance().getLogger().severe("allowedRarities.size(): " + allowedRarities.size());
             return false;
         }
     }


### PR DESCRIPTION
- Adds a check for the selectedFish variable being null.
> https://pastebin.com/nkNsLL9H

- Only cancels the timingSystem task if it is not null.
> https://pastebin.com/1t6v1Kih

- Now also logs the exception if a random fish cannot be found.
> https://pastebin.com/YL1NqAcr

- Adds a check for allowedRarities being empty, and tells console what the problem is.
```
[20:12:41 INFO]: FireML issued server command: /emf admin competition start 100 SPECIFIC_FISH
[20:12:41 ERROR]: [EvenMoreFish] The allowed-rarities list found in the [admin_started] competition config contains no loaded rarities!
[20:12:41 ERROR]: [EvenMoreFish] Configured Rarities: [Uncommon, Epic, Legendary]
[20:12:41 ERROR]: [EvenMoreFish] Loaded Rarities: [Common]
```

- Catches an IndexOutOfBoundsException