### PR TITLE
Remove hard-dependency on Vault

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -95,10 +95,9 @@ bukkit {
     website = "https://github.com/Oheers/EvenMoreFish"
     foliaSupported = true
 
-    depend = listOf(
-        "Vault"
-    )
+    depend = listOf()
     softDepend = listOf(
+        "Vault",
         "PlayerPoints",
         "WorldGuard",
         "PlaceholderAPI",

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
@@ -13,12 +13,13 @@ import java.util.logging.Level;
 public class Economy {
 
     private static EconomyType economyType = EconomyType.NONE;
-    private boolean enabled = false;
+    private boolean enabled;
     private net.milkbowl.vault.economy.Economy vaultEconomy = null;
     private PlayerPointsAPI playerPointsEconomy = null;
     private GriefPrevention griefPreventionEconomy = null;
 
     public Economy(EconomyType type) {
+        enabled = false;
         EvenMoreFish emf = EvenMoreFish.getInstance();
         switch (type) {
             case VAULT:

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/Economy.java
@@ -23,14 +23,16 @@ public class Economy {
         switch (type) {
             case VAULT:
                 emf.getLogger().log(Level.INFO, "Attempting to hook into Vault for Economy Handling.");
-                RegisteredServiceProvider<net.milkbowl.vault.economy.Economy> rsp = emf.getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
-                if (rsp == null) {
-                    return;
+                if (EvenMoreFish.getInstance().isUsingVault()) {
+                    RegisteredServiceProvider<net.milkbowl.vault.economy.Economy> rsp = emf.getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
+                    if (rsp == null) {
+                        return;
+                    }
+                    vaultEconomy = rsp.getProvider();
+                    economyType = type;
+                    enabled = true;
+                    emf.getLogger().log(Level.INFO, "Hooked into Vault for Economy Handling.");
                 }
-                vaultEconomy = rsp.getProvider();
-                economyType = type;
-                enabled = true;
-                emf.getLogger().log(Level.INFO, "Hooked into Vault for Economy Handling.");
                 return;
             case PLAYER_POINTS:
                 emf.getLogger().log(Level.INFO, "Attempting to hook into PlayerPoints for Economy Handling.");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -96,6 +96,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     // it's a work-in-progress solution and probably won't stick.
     private Map<UUID, Rarity> decidedRarities;
     private boolean isUpdateAvailable;
+    private boolean usingVault;
     private boolean usingPAPI;
     private boolean usingMcMMO;
     private boolean usingHeadsDB;
@@ -137,6 +138,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         logger = getLogger();
         pluginManager = getServer().getPluginManager();
 
+        usingVault = Bukkit.getPluginManager().isPluginEnabled("Vault");
         usingGriefPrevention = Bukkit.getPluginManager().isPluginEnabled("GriefPrevention");
         usingPlayerPoints = Bukkit.getPluginManager().isPluginEnabled("PlayerPoints");
 
@@ -741,6 +743,8 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
     public boolean isUpdateAvailable() {
         return isUpdateAvailable;
     }
+
+    public boolean isUsingVault() { return usingVault; }
 
     public boolean isUsingPAPI() {
         return usingPAPI;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -175,10 +175,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             }
         }
 
-        if (!setupPermissions()) {
-            EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, "EvenMoreFish couldn't hook into Vault permissions. Disabling to prevent serious problems.");
-            getServer().getPluginManager().disablePlugin(this);
-        }
+        setupPermissions();
 
         // checks against both support region plugins and sets an active plugin (worldguard is priority)
         if (checkWG()) {
@@ -451,6 +448,9 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
 
     private boolean setupPermissions() {
+        if (!usingVault) {
+            return false;
+        }
         RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
         permission = rsp.getProvider();
         return permission != null;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -143,11 +143,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         getConfig().options().copyDefaults();
         saveDefaultConfig();
 
-        loadRewardManager();
-
-        RewardManager.getInstance().load();
-        getServer().getPluginManager().registerEvents(RewardManager.getInstance(), this);
-
         new MainConfig();
         new Messages();
 
@@ -236,6 +231,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             });
 
         }
+
+        loadRewardManager();
+
+        RewardManager.getInstance().load();
+        getServer().getPluginManager().registerEvents(RewardManager.getInstance(), this);
 
         logger.log(Level.INFO, "EvenMoreFish by Oheers : Enabled");
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -22,10 +22,7 @@ import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.CompetitionQueue;
 import com.oheers.fish.competition.JoinChecker;
 import com.oheers.fish.competition.rewardtypes.*;
-import com.oheers.fish.competition.rewardtypes.external.AuraSkillsXPRewardType;
-import com.oheers.fish.competition.rewardtypes.external.GPClaimBlocksRewardType;
-import com.oheers.fish.competition.rewardtypes.external.McMMOXPRewardType;
-import com.oheers.fish.competition.rewardtypes.external.PlayerPointsRewardType;
+import com.oheers.fish.competition.rewardtypes.external.*;
 import com.oheers.fish.config.*;
 import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
@@ -804,7 +801,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         new ItemRewardType().register();
         new MessageRewardType().register();
         new MoneyRewardType().register();
-        new PermissionRewardType().register();
         new EXPRewardType().register();
         loadExternalRewardTypes();
     }
@@ -822,6 +818,10 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         }
         if (pm.isPluginEnabled("mcMMO")) {
             new McMMOXPRewardType().register();
+        }
+        // Only enable the PERMISSION type if Vault perms is found.
+        if (getPermission() != null) {
+            new PermissionRewardType().register();
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -800,7 +800,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         new HungerRewardType().register();
         new ItemRewardType().register();
         new MessageRewardType().register();
-        new MoneyRewardType().register();
         new EXPRewardType().register();
         loadExternalRewardTypes();
     }
@@ -822,6 +821,10 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         // Only enable the PERMISSION type if Vault perms is found.
         if (getPermission() != null) {
             new PermissionRewardType().register();
+        }
+        // Only enable the MONEY type if the economy is loaded.
+        if (getEconomy() != null && getEconomy().isEnabled()) {
+            new MoneyRewardType().register();
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/UpdateChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/UpdateChecker.java
@@ -43,7 +43,7 @@ class UpdateNotify implements Listener {
             return;
         }
 
-        if (EvenMoreFish.getInstance().getPermission().playerHas(event.getPlayer(), AdminPerms.UPDATE_NOTIFY)) {
+        if (event.getPlayer().hasPermission(AdminPerms.UPDATE_NOTIFY)) {
             new Message(ConfigMessage.ADMIN_UPDATE_AVAILABLE).broadcast(event.getPlayer(), false);
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -89,7 +89,7 @@ public class EMFCommand extends BaseCommand {
             return;
         }
 
-        if (EvenMoreFish.getInstance().getPermission().has(sender, AdminPerms.ADMIN)) {
+        if (sender.hasPermission(AdminPerms.ADMIN)) {
             new SellGUI(onlinePlayer.player, true);
             Message message = new Message(ConfigMessage.ADMIN_OPEN_FISH_SHOP);
             message.setPlayer(onlinePlayer.player.getName());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/MoneyRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/MoneyRewardType.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.competition.rewardtypes.external;
 
+import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.reward.RewardType;
 import org.bukkit.Location;
@@ -11,6 +12,7 @@ public class MoneyRewardType implements RewardType {
 
     @Override
     public void doReward(@NotNull Player player, @NotNull String key, @NotNull String value, Location hookLocation) {
+        Economy economy = EvenMoreFish.getInstance().getEconomy();
         int amount;
         try {
             amount = Integer.parseInt(value);
@@ -18,7 +20,9 @@ public class MoneyRewardType implements RewardType {
             EvenMoreFish.getInstance().getLogger().warning("Invalid number specified for RewardType " + getIdentifier() + ": " + value);
             return;
         }
-        EvenMoreFish.getInstance().getEconomy().deposit(player, amount);
+        if (economy.isEnabled()) {
+            economy.deposit(player, amount);
+        }
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/MoneyRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/MoneyRewardType.java
@@ -1,6 +1,5 @@
-package com.oheers.fish.competition.rewardtypes;
+package com.oheers.fish.competition.rewardtypes.external;
 
-import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.reward.RewardType;
 import org.bukkit.Location;
@@ -12,7 +11,6 @@ public class MoneyRewardType implements RewardType {
 
     @Override
     public void doReward(@NotNull Player player, @NotNull String key, @NotNull String value, Location hookLocation) {
-        Economy economy = EvenMoreFish.getInstance().getEconomy();
         int amount;
         try {
             amount = Integer.parseInt(value);
@@ -20,9 +18,7 @@ public class MoneyRewardType implements RewardType {
             EvenMoreFish.getInstance().getLogger().warning("Invalid number specified for RewardType " + getIdentifier() + ": " + value);
             return;
         }
-        if (economy.isEnabled()) {
-            economy.deposit(player, amount);
-        }
+        EvenMoreFish.getInstance().getEconomy().deposit(player, amount);
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/PermissionRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/PermissionRewardType.java
@@ -1,4 +1,4 @@
-package com.oheers.fish.competition.rewardtypes;
+package com.oheers.fish.competition.rewardtypes.external;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.reward.RewardType;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/PermissionRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/external/PermissionRewardType.java
@@ -2,6 +2,7 @@ package com.oheers.fish.competition.rewardtypes.external;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.reward.RewardType;
+import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -11,7 +12,10 @@ public class PermissionRewardType implements RewardType {
 
     @Override
     public void doReward(@NotNull Player player, @NotNull String key, @NotNull String value, Location hookLocation) {
-        EvenMoreFish.getInstance().getPermission().playerAdd(player.getPlayer(), value);
+        Permission permission = EvenMoreFish.getInstance().getPermission();
+        if (permission != null) {
+            permission.playerAdd(player.getPlayer(), value);
+        }
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -59,7 +59,7 @@ public class FishingProcessor implements Listener {
 
         if (MainConfig.getInstance().requireFishingPermission()) {
             //check if player have permssion to fish emf fishes
-            if (!EvenMoreFish.getInstance().getPermission().has(event.getPlayer(), UserPerms.USE_ROD)) {
+            if (!event.getPlayer().hasPermission(UserPerms.USE_ROD)) {
                 if (event.getState() == PlayerFishEvent.State.FISHING) {//send msg only when throw the lure
                     new Message(ConfigMessage.NO_PERMISSION_FISHING).broadcast(event.getPlayer(), false);
                 }
@@ -290,14 +290,14 @@ public class FishingProcessor implements Listener {
         /* If allowed rarities has objects, it means we've run through and removed the Christmas rarity. Don't run
            through again */
         if (allowedRarities.isEmpty()) {
-            if (fisher != null && EvenMoreFish.getInstance().getPermission() != null) {
+            if (fisher != null) {
                 rarityLoop:
                 for (Rarity rarity : EvenMoreFish.getInstance().getFishCollection().keySet()) {
                     if (boostedRarities != null && boostRate == -1 && !boostedRarities.contains(rarity)) {
                         continue;
                     }
 
-                    if (!(rarity.getPermission() == null || EvenMoreFish.getInstance().getPermission().has(fisher, rarity.getPermission()))) {
+                    if (!(rarity.getPermission() == null || fisher.hasPermission(rarity.getPermission()))) {
                         continue;
                     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/Permission.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/Permission.java
@@ -31,7 +31,7 @@ public class Permission implements Requirement {
 
     @Override
     public boolean requirementMet(RequirementContext context) {
-        if (EvenMoreFish.getInstance().getPermission() != null && permissionNodes != null) {
+        if (permissionNodes != null) {
             return context.getPlayer() == null || hasAllPermissions(context.getPlayer());
         }
         
@@ -40,7 +40,7 @@ public class Permission implements Requirement {
     
     private boolean hasAllPermissions(final Player player) {
         for(final String permissionNode: permissionNodes) {
-            if(!EvenMoreFish.getInstance().getPermission().has(player,permissionNode)) {
+            if (!player.hasPermission(permissionNode)) {
                 return false;
             }
         }


### PR DESCRIPTION
The hasPermission checks can be done on the Player itself.

Other changes:
- The MONEY RewardType no longer registers if the economy is disabled.
- The PERMISSION RewardType no longer registers if Vault is not found.
- Moved the above RewardTypes to the external package.
- Added some extra checks to the above RewardTypes to be safe.