### PR TITLE
Re-add use-this-casing rarity config option and some fixes

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -870,4 +870,9 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         return players;
     }
 
+    @EventHandler
+    public void onServerLoad(ServerLoadEvent event) {
+        Bukkit.getPluginManager().callEvent(new EMFRewardsLoadEvent());
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -870,9 +870,4 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         return players;
     }
 
-    @EventHandler
-    public void onServerLoad(ServerLoadEvent event) {
-        Bukkit.getPluginManager().callEvent(new EMFRewardsLoadEvent());
-    }
-
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 public class FishUtils {
 
     private static final Pattern HEX_PATTERN = Pattern.compile("&#" + "([A-Fa-f0-9]{6})");
-    private static final char COLOR_CHAR = '\u00A7';
+    private static final char COLOR_CHAR = '§';
 
     // checks for the "emf-fish-name" nbt tag, to determine if this ItemStack is a fish or not.
     public static boolean isFish(ItemStack item) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -84,7 +84,7 @@ public class FishUtils {
         // Hunting through the fish collection and creating a rarity that matches the fish's nbt
         for (Rarity r : EvenMoreFish.getInstance().getFishCollection().keySet()) {
             if (r.getValue().equals(rarityString)) {
-                rarity = new Rarity(r.getValue(), r.getColour(), r.getWeight(), r.getAnnounce(), r.overridenLore);
+                rarity = new Rarity(r.getValue(), r.getColour(), r.getWeight(), r.getAnnounce(), r.getUseConfigCasing(), r.overridenLore);
             }
         }
 
@@ -132,7 +132,7 @@ public class FishUtils {
         // Hunting through the fish collection and creating a rarity that matches the fish's nbt
         for (Rarity r : EvenMoreFish.getInstance().getFishCollection().keySet()) {
             if (r.getValue().equals(rarityString)) {
-                rarity = new Rarity(r.getValue(), r.getColour(), r.getWeight(), r.getAnnounce(), r.overridenLore);
+                rarity = new Rarity(r.getValue(), r.getColour(), r.getWeight(), r.getAnnounce(), r.getUseConfigCasing(), r.overridenLore);
             }
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 public class FishUtils {
 
     private static final Pattern HEX_PATTERN = Pattern.compile("&#" + "([A-Fa-f0-9]{6})");
-    private static final char COLOR_CHAR = '§';
+    private static final char COLOR_CHAR = '\u00A7';
 
     // checks for the "emf-fish-name" nbt tag, to determine if this ItemStack is a fish or not.
     public static boolean isFish(ItemStack item) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -89,7 +89,13 @@ public class AdminCommand extends BaseCommand {
         @CommandCompletion("@rarities")
         @Description("%desc_list_fish")
         public void onFish(final CommandSender sender, final Rarity rarity) {
-            BaseComponent baseComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + rarity.getDisplayName()) + " ");
+            String rarityName;
+            if (rarity.getDisplayName() != null) {
+                rarityName = rarity.getDisplayName();
+            } else {
+                rarityName = rarity.getValue();
+            }
+            BaseComponent baseComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + rarityName) + " ");
             for (Fish fish : EvenMoreFish.getInstance().getFishCollection().get(rarity)) {
                 BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + fish.getDisplayName() + rarity.getColour()+ "] "));
                 textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to receive fish")));
@@ -105,8 +111,14 @@ public class AdminCommand extends BaseCommand {
         public void onRarity(final CommandSender sender) {
             BaseComponent baseComponent = new TextComponent("");
             for (Rarity rarity : EvenMoreFish.getInstance().getFishCollection().keySet()) {
-                BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + rarity.getDisplayName() + "] "));
-                textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to view " + rarity.getDisplayName() + " fish.")));
+                String rarityName;
+                if (rarity.getDisplayName() != null) {
+                    rarityName = rarity.getDisplayName();
+                } else {
+                    rarityName = rarity.getValue();
+                }
+                BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + rarityName + "] "));
+                textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to view " + rarityName + " fish.")));
                 textComponent.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/emf admin list fish " + rarity.getValue()));
                 baseComponent.addExtra(textComponent);
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -89,13 +89,7 @@ public class AdminCommand extends BaseCommand {
         @CommandCompletion("@rarities")
         @Description("%desc_list_fish")
         public void onFish(final CommandSender sender, final Rarity rarity) {
-            String rarityName;
-            if (rarity.getDisplayName() != null) {
-                rarityName = rarity.getDisplayName();
-            } else {
-                rarityName = rarity.getValue();
-            }
-            BaseComponent baseComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + rarityName) + " ");
+            BaseComponent baseComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + rarity.getDisplayName()) + " ");
             for (Fish fish : EvenMoreFish.getInstance().getFishCollection().get(rarity)) {
                 BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + fish.getDisplayName() + rarity.getColour()+ "] "));
                 textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to receive fish")));
@@ -111,14 +105,8 @@ public class AdminCommand extends BaseCommand {
         public void onRarity(final CommandSender sender) {
             BaseComponent baseComponent = new TextComponent("");
             for (Rarity rarity : EvenMoreFish.getInstance().getFishCollection().keySet()) {
-                String rarityName;
-                if (rarity.getDisplayName() != null) {
-                    rarityName = rarity.getDisplayName();
-                } else {
-                    rarityName = rarity.getValue();
-                }
-                BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + rarityName + "] "));
-                textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to view " + rarityName + " fish.")));
+                BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + rarity.getDisplayName() + "] "));
+                textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to view " + rarity.getDisplayName() + " fish.")));
                 textComponent.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/emf admin list fish " + rarity.getValue()));
                 baseComponent.addExtra(textComponent);
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -423,7 +423,7 @@ public class Competition {
                             int s = r.nextInt(3);
                             switch (s) {
                                 case 0:
-                                    message.setPositionColour("&c\u00bb &r");
+                                    message.setPositionColour("&c» &r");
                                     break;
                                 case 1:
                                     message.setPositionColour("&c_ &r");
@@ -547,7 +547,7 @@ public class Competition {
                         int s = r.nextInt(3);
                         switch (s) {
                             case 0:
-                                message.setPositionColour("&c\u00bb &r");
+                                message.setPositionColour("&c» &r");
                                 break;
                             case 1:
                                 message.setPositionColour("&c_ &r");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -423,7 +423,7 @@ public class Competition {
                             int s = r.nextInt(3);
                             switch (s) {
                                 case 0:
-                                    message.setPositionColour("&c» &r");
+                                    message.setPositionColour("&c\u00bb &r");
                                     break;
                                 case 1:
                                     message.setPositionColour("&c_ &r");
@@ -547,7 +547,7 @@ public class Competition {
                         int s = r.nextInt(3);
                         switch (s) {
                             case 0:
-                                message.setPositionColour("&c» &r");
+                                message.setPositionColour("&c\u00bb &r");
                                 break;
                             case 1:
                                 message.setPositionColour("&c_ &r");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -767,7 +767,12 @@ public class Competition {
             while (competitionEntryIterator.hasNext()) {
                 CompetitionEntry entry = competitionEntryIterator.next();
                 if (rewardPlace <= rewards.size()) {
-                    rewards.get(rewardPlace).forEach(reward -> reward.rewardPlayer(Objects.requireNonNull(Bukkit.getPlayer(entry.getPlayer())), null));
+                    rewards.get(rewardPlace).forEach(reward -> {
+                        Player player = Bukkit.getPlayer(entry.getPlayer());
+                        if (player != null) {
+                            reward.rewardPlayer(player, null);
+                        }
+                    });
                     rewardPlace++;
                 } else {
                     if (participationRewardsExist) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
@@ -111,7 +111,7 @@ public class CompetitionConfig extends ConfigBase {
     }
 
     public int getBroadcastRange() {
-        return getConfig().getInt("general.broadcast-range", 0);
+        return getConfig().getInt("general.broadcast-range", -1);
     }
 
     public List<String> getPositionColours() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class Message {
 
     private static final Pattern HEX_PATTERN = Pattern.compile("&#" + "([A-Fa-f0-9]{6})");
-    private static final char COLOR_CHAR = '\u00A7';
+    private static final char COLOR_CHAR = '§';
     private final Map<String, String> liveVariables = new LinkedHashMap<>();
     public String message;
     private boolean canSilent, canHidePrefix;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class Message {
 
     private static final Pattern HEX_PATTERN = Pattern.compile("&#" + "([A-Fa-f0-9]{6})");
-    private static final char COLOR_CHAR = '§';
+    private static final char COLOR_CHAR = '\u00A7';
     private final Map<String, String> liveVariables = new LinkedHashMap<>();
     public String message;
     private boolean canSilent, canHidePrefix;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -283,8 +283,7 @@ public class Fish implements Cloneable {
 
         if (length > 0) newLoreLine.setLength(Float.toString(length));
 
-        if (rarity.getDisplayName() != null) newLoreLine.setRarity(rarity.getDisplayName());
-        else newLoreLine.setRarity(this.rarity.getLorePrep());
+        newLoreLine.setRarity(this.rarity.getLorePrep());
 
         List<String> newLore = Arrays.asList(newLoreLine.getRawMessage(true).split("\n"));
         if (getFishermanPlayer() != null && EvenMoreFish.getInstance().isUsingPAPI()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Names.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Names.java
@@ -55,7 +55,7 @@ public class Names {
             fishList.addAll(fishSet);
 
             // creates a rarity object and a fish queue
-            Rarity r = new Rarity(rarity, rarityColour(rarity), rarityWeight(rarity), rarityAnnounce(rarity), rarityOverridenLore(rarity));
+            Rarity r = new Rarity(rarity, rarityColour(rarity), rarityWeight(rarity), rarityAnnounce(rarity), rarityUseConfigCasing(rarity), rarityOverridenLore(rarity));
             if (xmasRarity) {
                 EvenMoreFish.getInstance().setXmasRarity(r);
             }
@@ -174,6 +174,10 @@ public class Names {
 
     private String rarityOverridenLore(String rarity) {
         return this.rarityConfiguration.getString("rarities." + rarity + ".override-lore");
+    }
+
+    private boolean rarityUseConfigCasing(String rarity) {
+        return this.rarityConfiguration.getBoolean("rarities." + rarity + ".use-this-casing");
     }
 
     private String rarityDisplayName(String rarity) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -55,6 +55,9 @@ public class Rarity {
     }
 
     public String getDisplayName() {
+        if (displayName == null) {
+            return value;
+        }
         return displayName;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -83,8 +83,8 @@ public class Rarity {
     public String getLorePrep() {
         if (overridenLore != null) return FishUtils.translateHexColorCodes(overridenLore);
         else {
-            if (this.getDisplayName() != null) {
-                return this.getDisplayName();
+            if (this.displayName != null) {
+                return this.displayName;
             } else {
                 String finalName = this.getValue();
                 if (!useConfigCasing) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -15,15 +15,17 @@ public class Rarity {
     boolean announce;
     boolean fishWeighted;
     boolean hasCompExemptFish;
+    boolean useConfigCasing;
     String displayName;
     List<Requirement> requirements = new ArrayList<>();
 
-    public Rarity(String value, String colour, double weight, boolean announce, String overridenLore) {
+    public Rarity(String value, String colour, double weight, boolean announce, boolean useConfigCasing, String overridenLore) {
         this.value = value;
         this.colour = colour;
         this.weight = weight;
         this.announce = announce;
         this.overridenLore = overridenLore;
+        this.useConfigCasing = useConfigCasing;
     }
 
     public String getValue() {
@@ -41,6 +43,8 @@ public class Rarity {
     public boolean getAnnounce() {
         return this.announce;
     }
+
+    public boolean getUseConfigCasing() { return this.useConfigCasing; }
 
     public boolean isFishWeighted() {
         return fishWeighted;
@@ -82,7 +86,11 @@ public class Rarity {
             if (this.getDisplayName() != null) {
                 return this.getDisplayName();
             } else {
-                return this.getColour() + "&l" + this.getValue().toUpperCase();
+                String finalName = this.getValue();
+                if (!useConfigCasing) {
+                    finalName = finalName.toUpperCase();
+                }
+                return this.getColour() + "&l" + finalName;
             }
 
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -2,7 +2,6 @@ package com.oheers.fish.fishing.items;
 
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.requirements.Requirement;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,7 +54,7 @@ public class Rarity {
         this.fishWeighted = fishWeighted;
     }
 
-    public @Nullable String getDisplayName() {
+    public String getDisplayName() {
         return displayName;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -55,9 +55,6 @@ public class Rarity {
     }
 
     public String getDisplayName() {
-        if (displayName == null) {
-            return value;
-        }
         return displayName;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -2,6 +2,7 @@ package com.oheers.fish.fishing.items;
 
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.requirements.Requirement;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +55,7 @@ public class Rarity {
         this.fishWeighted = fishWeighted;
     }
 
-    public String getDisplayName() {
+    public @Nullable String getDisplayName() {
         return displayName;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/Permission.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/Permission.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.requirements;
 
+import com.oheers.fish.EvenMoreFish;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/Permission.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/Permission.java
@@ -1,6 +1,5 @@
 package com.oheers.fish.requirements;
 
-import com.oheers.fish.EvenMoreFish;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/even-more-fish-plugin/src/main/resources/competitions.yml
+++ b/even-more-fish-plugin/src/main/resources/competitions.yml
@@ -98,7 +98,7 @@ general:
   broadcast-only-rods: true
 
   # Broadcast range, in blocks squared, for example value 100 means 10 blocks in each direction. Set to -1 to disable.
-  broadcast-range: 100
+  broadcast-range: -1
 
   # This is the allowed-rarities value used for /emf admin competition start <time> specific_fish
   allowed-rarities:


### PR DESCRIPTION
I'm not sure why this was removed, but we've had multiple people mention it in the discord server.

Also updates the default competition config to make sure we don't "break" servers updating from 1.6.11.17 (broadcast-range defaulted to 100, when it was global in 1.6.11.17)