### PR TITLE
Fixed an issue with addons

### DIFF
--- a/even-more-fish-addons-j8/src/main/java/com/oheers/evenmorefish/addons/ItemsAdderItemAddon.java
+++ b/even-more-fish-addons-j8/src/main/java/com/oheers/evenmorefish/addons/ItemsAdderItemAddon.java
@@ -37,8 +37,8 @@ public class ItemsAdderItemAddon extends ItemAddon implements Listener {
         }
 
         String[] splitMaterialValue = id.split(":");
-        if (splitMaterialValue.length != 2) {
-            getLogger().severe(() -> String.format("Incorrect format for ItemsAdderItemAddon, use %s:namespace:id. Got %s",getPrefix(), id));
+        if (!verifyItemsFormat(splitMaterialValue)) {
+            getLogger().severe(() -> String.format("Incorrect format for ItemsAdderItemAddon, use %s:namespace:id. Got %s",getPrefix(), String.join(":", splitMaterialValue)));
             return null;
         }
 
@@ -59,5 +59,18 @@ public class ItemsAdderItemAddon extends ItemAddon implements Listener {
         this.itemsAdderLoaded = true;
 
         ((EMFPlugin) Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("EvenMoreFish"))).reload();
+    }
+
+    /**
+     * Verifies the format of the given item id for the ItemsAdderItemAddon.
+     *
+     * @param splitMaterialValue The item id to verify.
+     * @return {@code true} if the id is in the correct format, {@code false} otherwise.
+     * The expected format is: "itemsadder:namespace:id".
+     * This method is used to ensure that the item id provided by the user is in the correct format
+     * before attempting to retrieve the corresponding ItemStack from ItemsAdder.
+     */
+    public boolean verifyItemsFormat(final String[] splitMaterialValue) {
+        return splitMaterialValue.length == 2;
     }
 }

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/ItemAddon.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/ItemAddon.java
@@ -5,7 +5,7 @@ import org.bukkit.inventory.ItemStack;
 public abstract class ItemAddon implements Addon{
 
     /**
-     * @param id id of the ItemStack
+     * @param id id of the ItemStack without the prefix.
      * @return The ItemStack via the id
      */
     public abstract ItemStack getItemStack(final String id);

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/IncorrectAssignedMaterialException.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/IncorrectAssignedMaterialException.java
@@ -1,0 +1,41 @@
+package com.oheers.fish.api.addons.exceptions;
+
+
+/**
+ * This exception is thrown when an incorrect assigned material is encountered.
+ * It provides information about the configuration location and the ID of the incorrect material.
+ */
+public class IncorrectAssignedMaterialException extends Exception {
+    private final String id;
+    private final String configLocation;
+
+    /**
+     * Constructs a new IncorrectAssignedMaterialException with the specified configuration location and ID.
+     *
+     * @param configLocation the location of the configuration file where the incorrect material is assigned
+     * @param id             the ID of the incorrect material
+     */
+    public IncorrectAssignedMaterialException(String configLocation, String id) {
+        super(String.format("%s has an incorrect assigned material: %s", configLocation, id));
+        this.id = id;
+        this.configLocation = configLocation;
+    }
+
+    /**
+     * Returns the ID of the incorrect material.
+     *
+     * @return the ID of the incorrect material
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the location of the configuration file where the incorrect material is assigned.
+     *
+     * @return the location of the configuration file
+     */
+    public String getConfigLocation() {
+        return configLocation;
+    }
+}

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/JavaVersionException.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/JavaVersionException.java
@@ -5,14 +5,29 @@ import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang3.JavaVersion;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * This exception is thrown when there is a problem with the addon due to a mismatch in the required Java version.
+ */
 public class JavaVersionException extends Exception {
     private final JavaVersion requiredJavaVersion;
 
+    /**
+     * Constructs a new JavaVersionException with the specified plugin name and required Java version.
+     *
+     * @param pluginName          the name of the plugin
+     * @param requiredJavaVersion the required Java version for the addon
+     */
     public JavaVersionException(String pluginName, @NotNull JavaVersion requiredJavaVersion) {
-        super(String.format("There is a problem with the addon for %s %nRequired jvm version is at least %s%n Running JVM version %s",pluginName, requiredJavaVersion, SystemUtils.JAVA_VERSION));
+        super(String.format("There is a problem with the addon for %s %nRequired jvm version is at least %s%n Running JVM version %s",
+                pluginName, requiredJavaVersion, SystemUtils.JAVA_VERSION));
         this.requiredJavaVersion = requiredJavaVersion;
     }
 
+    /**
+     * Returns the required Java version for the addon.
+     *
+     * @return the required Java version
+     */
     public JavaVersion getRequiredJavaVersion() {
         return requiredJavaVersion;
     }

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/NoPrefixException.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/NoPrefixException.java
@@ -1,0 +1,31 @@
+package com.oheers.fish.api.addons.exceptions;
+
+
+/**
+ * This exception is thrown when a prefix is not found.
+ */
+public class NoPrefixException extends Exception {
+    /**
+     * The prefix causing the exception.
+     */
+    private final String prefix;
+
+    /**
+     * Constructs a new `NoPrefixException` with the specified prefix.
+     *
+     * @param prefix the prefix causing the exception
+     */
+    public NoPrefixException(String prefix) {
+        super(String.format("No such prefix: %s, did you install the addon?", prefix));
+        this.prefix = prefix;
+    }
+
+    /**
+     * Returns the prefix causing the exception.
+     *
+     * @return the prefix causing the exception
+     */
+    public String getPrefix() {
+        return prefix;
+    }
+}

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/PluginNotLoadedException.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/addons/exceptions/PluginNotLoadedException.java
@@ -1,0 +1,30 @@
+package com.oheers.fish.api.addons.exceptions;
+
+
+/**
+ * Custom exception class for when a plugin has not been loaded.
+ */
+public class PluginNotLoadedException extends Exception {
+
+    /** The name of the plugin that has not been loaded. */
+    private final String pluginName;
+
+    /**
+     * Constructs a PluginNotLoadedException with the specified plugin name.
+     *
+     * @param pluginName the name of the plugin that has not been loaded
+     */
+    public PluginNotLoadedException(String pluginName) {
+        super(String.format("%s has not loaded yet.", pluginName));
+        this.pluginName = pluginName;
+    }
+
+    /**
+     * Gets the name of the plugin associated with this exception.
+     *
+     * @return the name of the plugin
+     */
+    public String getPluginName() {
+        return pluginName;
+    }
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/addons/AddonManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/addons/AddonManager.java
@@ -8,6 +8,7 @@ import com.oheers.fish.api.addons.FileUtil;
 import com.oheers.fish.api.addons.Futures;
 import com.oheers.fish.api.addons.ItemAddon;
 import com.oheers.fish.api.addons.exceptions.JavaVersionException;
+import com.oheers.fish.api.addons.exceptions.NoPrefixException;
 import com.oheers.fish.api.addons.exceptions.RequiredPluginException;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -41,12 +42,12 @@ public class AddonManager {
         }
     }
 
-
-    public ItemStack getItemStack(final String prefix, final String id) {
+    @Nullable
+    public ItemStack getItemStack(final String prefix, final String id) throws NoPrefixException {
         if (!addonMap.containsKey(prefix)) {
 
             if (!loadingMap.getOrDefault(prefix, true)) {
-                plugin.getLogger().warning(() -> String.format("No such prefix %s, did you install the addon?", prefix));
+                throw new NoPrefixException(prefix);
             }
             return null;
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -2,6 +2,8 @@ package com.oheers.fish.utils;
 
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
+import com.oheers.fish.api.addons.exceptions.IncorrectAssignedMaterialException;
+import com.oheers.fish.api.addons.exceptions.NoPrefixException;
 import com.oheers.fish.config.BaitFile;
 import com.oheers.fish.config.FishFile;
 import com.oheers.fish.config.MainConfig;
@@ -235,28 +237,24 @@ public class ItemFactory {
             if (customItemStack != null) {
                 return customItemStack;
             }
-            EvenMoreFish.getInstance().getLogger().severe(() -> String.format("%s has an incorrect assigned material: %s", configLocation, mValue));
             material = Material.COD;
         }
 
         return new ItemStack(material);
     }
 
-    //Need to impl oraxen, ecoitems, denizen & ItemsAdder addons
-    private ItemStack checkItem(final String materialID) {
-        if (materialID == null) {
+    private ItemStack checkItem(final String materialId) {
+        if (materialId == null) {
             return null;
         }
 
         rawMaterial = true;
 
         try {
-            return getItem(materialID);
-        } catch (Exception e) {
-            EvenMoreFish.getInstance().getLogger().severe(() -> String.format("%s has an incorrect assigned material: %s",
-                    configLocation,
-                    materialID));
+            return getItem(materialId);
+        } catch (NoPrefixException | IncorrectAssignedMaterialException e) {
             rawMaterial = false;
+            EvenMoreFish.getInstance().getLogger().warning(e::getMessage);
             return new ItemStack(Material.COD);
         }
     }
@@ -431,7 +429,7 @@ public class ItemFactory {
         return checkItem(materialID);
     }
 
-    public @NotNull ItemStack getItem(final @NotNull String materialString) throws Exception{
+    public ItemStack getItem(final @NotNull String materialString) throws IncorrectAssignedMaterialException, NoPrefixException {
         if (materialString.contains(":")) {
             //assume this is an addon string
             final String[] split = materialString.split(":", 2);
@@ -443,10 +441,7 @@ public class ItemFactory {
 
         Material material = Material.matchMaterial(materialString);
         if (material == null) {
-            EvenMoreFish.getInstance().getLogger().severe(() -> String.format("%s has an incorrect assigned material: %s",
-                    configLocation,
-                    materialString));
-            return new ItemStack(Material.COD);
+            throw new IncorrectAssignedMaterialException(configLocation, materialString);
         }
 
         return new ItemStack(material);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -248,12 +248,12 @@ public class ItemFactory {
             return null;
         }
 
-        rawMaterial = true;
+        rawMaterial = false;
 
         try {
             return getItem(materialId);
         } catch (NoPrefixException | IncorrectAssignedMaterialException e) {
-            rawMaterial = false;
+            rawMaterial = true;
             EvenMoreFish.getInstance().getLogger().warning(e::getMessage);
             return new ItemStack(Material.COD);
         }


### PR DESCRIPTION
This fixes the itemsadder addon error message i.e.: `fish.Commun.Cod has an incorrect assigned material: itemsadder:fish:morue`.
This was caused due to multiple checks doing the same thing. This PR fixes that.
Adds a couple of new exception for every error, so we can better diagnose the issue.

May fix #257, #240, #243 