### PR TITLE
Bump NBT-API to Version 2.13.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,7 +31,7 @@ dependencyResolutionManagement {
             library("caffeine", "com.github.ben-manes.caffeine:caffeine:2.9.3")//We must use 2.9.3 until we upgrade to java 17
 
             library("itemsadder-api", "com.github.LoneDev6:API-ItemsAdder:3.6.1")
-            library("nbt-api", "de.tr7zw:item-nbt-api:2.12.4")
+            library("nbt-api", "de.tr7zw:item-nbt-api:2.13.0")
             library("denizen-api", "com.denizenscript:denizen:1.3.0-SNAPSHOT") // Java 17 addon
             library("oraxen", "com.github.oraxen:oraxen:1.171.0")
 


### PR DESCRIPTION
2.13.0 adds support for Minecraft 1.21.

Things appear to work fine, tested on a Spigot 1.21 server.