### PR TITLE
Prevent NPEs when configs don't load properly.

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.config;
 
+import com.oheers.fish.EvenMoreFish;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -69,7 +70,13 @@ public class ConfigBase {
         return configFile;
     }
 
-    public FileConfiguration getConfig() { return this.config; }
+    public FileConfiguration getConfig() {
+        if (this.config == null) {
+            EvenMoreFish.getInstance().getLogger().warning(getFileName() + " has not loaded properly. Please check for earlier errors.");
+            return new YamlConfiguration();
+        }
+        return this.config;
+    }
 
     public File getFile() { return file; }
 


### PR DESCRIPTION
If the config variable is null, caused by an issue with the config, the plugin will provide an empty YamlConfiguration so it can use the defaults.

It will tell console every time getConfig() is called so a broken config cannot be missed:
```
[16:03:09 INFO]: FireML issued server command: /emf admin competition start 10
[16:03:09 WARN]: [EvenMoreFish] competitions.yml has not loaded properly. Please check for earlier errors.
[16:03:09 WARN]: [EvenMoreFish] competitions.yml has not loaded properly. Please check for earlier errors.
[16:03:09 WARN]: [EvenMoreFish] competitions.yml has not loaded properly. Please check for earlier errors.
[16:03:09 WARN]: [EvenMoreFish] competitions.yml has not loaded properly. Please check for earlier errors.
[16:03:09 WARN]: [EvenMoreFish] competitions.yml has not loaded properly. Please check for earlier errors.
[16:03:09 WARN]: [EvenMoreFish] competitions.yml has not loaded properly. Please check for earlier errors.
```