### PR TITLE
Command Updates

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
+
 plugins {
     `java-library`
     id("maven-publish")
@@ -153,7 +155,9 @@ bukkit {
                 "emf.top",
                 "emf.shop",
                 "emf.use_rod",
-                "emf.sellall"
+                "emf.sellall",
+                "emf.help",
+                "emf.next"
             )
         }
 
@@ -175,6 +179,16 @@ bukkit {
         register("emf.use_rod") {
             description = "Allows users to use emf rods."
         }
+
+        register("emf.next") {
+            description = "Allows users to see when the next competition will be."
+        }
+
+        register("emf.help") {
+            description = "Allows users to see the help messages."
+            default = BukkitPluginDescription.Permission.Default.TRUE
+        }
+
     }
 }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -24,6 +24,7 @@ public class EMFCommand extends BaseCommand {
 
     @Subcommand("next")
     @Description("%desc_general_next")
+    @CommandPermission(UserPerms.NEXT)
     public void onNext(final CommandSender sender) {
         Message message = Competition.getNextCompetitionMessage();
         message.usePrefix(PrefixType.DEFAULT);
@@ -51,13 +52,11 @@ public class EMFCommand extends BaseCommand {
         new MainMenuGUI(player).open();
     }
 
-
-
     @Default
     @HelpCommand
+    @CommandPermission(UserPerms.HELP)
     public void onHelp(final CommandHelp help, final CommandSender sender) {
         new Message(ConfigMessage.HELP_GENERAL_TITLE).broadcast(sender, false);
-        help.showHelp();
         help.getHelpEntries().forEach(helpEntry -> {
             Message helpMessage = new Message(ConfigMessage.HELP_FORMAT);
             helpMessage.setVariable("{command}", "/" + helpEntry.getCommand());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -58,6 +58,12 @@ public class EMFCommand extends BaseCommand {
     public void onHelp(final CommandHelp help, final CommandSender sender) {
         new Message(ConfigMessage.HELP_GENERAL_TITLE).broadcast(sender, false);
         help.showHelp();
+        help.getHelpEntries().forEach(helpEntry -> {
+            Message helpMessage = new Message(ConfigMessage.HELP_FORMAT);
+            helpMessage.setVariable("{command}", "/" + helpEntry.getCommand());
+            helpMessage.setVariable("{description}", helpEntry.getDescription());
+            helpMessage.broadcast(sender, true);
+        });
     }
 
     @Subcommand("top")

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
@@ -75,6 +75,13 @@ public enum ConfigMessage {
             "&fMeasures {length}cm"
     ), PrefixType.NONE, false, false, "length-lore"),
     FISH_SALE("&rYou've sold &a{amount} &ffish for &a{sell-price}&f.", PrefixType.DEFAULT, true, true, "fish-sale"),
+    HELP_FORMAT(
+            "[noPrefix]&b{command} &e- {description}",
+            PrefixType.DEFAULT,
+            false,
+            true,
+            "help-format"
+    ),
     HELP_GENERAL_TITLE(
             "[noPrefix]&f&m &#f1ffed&m &#e2ffdb&m &#d3ffc9&m &#c3ffb7&m &#b2ffa5&m &#9fff92&m &#8bff7f&m &#73ff6b&m &a&m &f &a&lEvenMoreFish &a&m &#73ff6b&m&m &#8bff7f&m &#9fff92&m &#b2ffa5&m &#c3ffb7&m &#d3ffc9&m &#e2ffdb&m &#f1ffed&m &f&m &f",
             PrefixType.DEFAULT,

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/UserPerms.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/permissions/UserPerms.java
@@ -1,6 +1,7 @@
 package com.oheers.fish.permissions;
 
 public class UserPerms {
+
     private UserPerms() {
         throw new UnsupportedOperationException();
     }
@@ -12,4 +13,7 @@ public class UserPerms {
     public static final String SELL_ALL = "emf.sellall";
     public static final String XMAS = "emf.xmas";
     public static final String GUI = "emf.gui";
+    public static final String NEXT = "emf.next";
+    public static final String HELP = "emf.help";
+
 }

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -71,9 +71,6 @@ fisherman-lore:
 length-lore:
   - "&fMeasures {length}cm."
 
-# The format of commands in /emf help (this message doesn't support papi placeholders)
-help: "/{command} - {description}"
-
 # The format of the leaderboard after a competition is over (this message doesn't support papi placeholders)
 leaderboard-largest-fish: "&r#{position} | {pos_colour}{player} &r({rarity_colour}&l{rarity} {rarity_colour}{fish}&r, {length}cm&r)"
 leaderboard-largest-total: "&r#{position} | {pos_colour}{player} &r({pos_colour}{amount}cm&r)"
@@ -169,6 +166,8 @@ fish-sale: "&rYou've sold &a{amount} &ffish for &a{sell-price}&f."
 
 # Help messages
 # General help (/emf help) - permission node dependant commands will only show if they are formatted with the forward-slash.
+help-format: "[noPrefix]&b{command} &e- {description}"
+
 help-general:
   title: "[noPrefix]&f&m &#f1ffed&m &#e2ffdb&m &#d3ffc9&m &#c3ffb7&m &#b2ffa5&m &#9fff92&m &#8bff7f&m &#73ff6b&m &a&m &f &a&lEvenMoreFish &a&m &#73ff6b&m&m &#8bff7f&m &#9fff92&m &#b2ffa5&m &#c3ffb7&m &#d3ffc9&m &#e2ffdb&m &#f1ffed&m &f&m &f"
   top: "[noPrefix]Shows an ongoing competition's leaderboard."


### PR DESCRIPTION
Allows the help message to be configured. Instead of using CommandHelp#showHelp, we loop over each help entry and fill in the placeholders of our custom message.
`help-format: "[noPrefix]&b{command} &e- {description}"`

Adds permissions for /emf help and /emf next. the help permission defaults to true