### PR TITLE
Adds more build info to /emf admin version

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -245,7 +245,7 @@ java {
 }
 
 fun getBuildNumberOrDate(): String? {
-    if ("".equals("master", ignoreCase = true)) {
+    if (grgit.branch.current().name.equals("master", ignoreCase = true)) {
         val buildNumber: String? by project
         if (buildNumber == null)
             return "RELEASE"

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -1,8 +1,15 @@
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.*
+
 plugins {
     `java-library`
     id("maven-publish")
     id("net.minecrell.plugin-yml.bukkit") version "0.6.0"
     id("com.github.johnrengelman.shadow") version "8.1.1"
+
+    alias(libs.plugins.grgit)
 }
 
 group = "com.oheers.evenmorefish"
@@ -198,6 +205,15 @@ tasks {
     }
 
     shadowJar {
+        manifest {
+            val buildNumber: String? by project
+
+            attributes["Specification-Title"] = "EvenMoreFish"
+            attributes["Specification-Version"] = project.version
+            attributes["Implementation-Title"] = grgit.branch.current().name
+            attributes["Implementation-Version"] = getBuildNumberOrDate()
+        }
+
         minimize()
 
         exclude("META-INF/**")
@@ -216,6 +232,8 @@ tasks {
     compileJava {
         options.compilerArgs.add("-parameters")
         options.isFork = true
+
+
     }
 }
 
@@ -224,5 +242,21 @@ java {
         languageVersion.set(JavaLanguageVersion.of(8))
         vendor.set(JvmVendorSpec.ADOPTIUM)
     }
+}
+
+fun getBuildNumberOrDate(): String? {
+    if ("".equals("master", ignoreCase = true)) {
+        val buildNumber: String? by project
+        if (buildNumber == null)
+            return "RELEASE"
+
+        return buildNumber
+    }
+
+    val time = DateTimeFormatter.ofPattern("yyyyMMdd-HHmm", Locale.ENGLISH)
+        .withZone(ZoneId.systemDefault())
+        .format(Instant.now())
+
+    return time
 }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -30,10 +30,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 @CommandAlias("%main")
 @Subcommand("admin")
@@ -298,8 +302,10 @@ public class AdminCommand extends BaseCommand {
         for (Rarity r : EvenMoreFish.getInstance().getFishCollection().keySet()) {
             fishCount += EvenMoreFish.getInstance().getFishCollection().get(r).size();
         }
-
+        
         String msgString = Messages.getInstance().getSTDPrefix() + "EvenMoreFish by Oheers " + EvenMoreFish.getInstance().getDescription().getVersion() + "\n" +
+                Messages.getInstance().getSTDPrefix() + "Feature Branch: " + getFeatureBranchName() + "\n" +
+                Messages.getInstance().getSTDPrefix() + "Feature Build/Date: " + getFeatureBranchBuildOrDate() + "\n" +
                 Messages.getInstance().getSTDPrefix() + "MCV: " + Bukkit.getServer().getVersion() + "\n" +
                 Messages.getInstance().getSTDPrefix() + "SSV: " + Bukkit.getServer().getBukkitVersion() + "\n" +
                 Messages.getInstance().getSTDPrefix() + "Online: " + Bukkit.getServer().getOnlineMode() + "\n" +
@@ -311,6 +317,40 @@ public class AdminCommand extends BaseCommand {
 
         Message msg = new Message(msgString);
         msg.broadcast(sender, false);
+    }
+
+    private String getFeatureBranchName() {
+        try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF")) {
+
+            if (inputStream != null) {
+                Manifest manifest = new Manifest(inputStream);
+
+                // Access attributes from the manifest file
+                return manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_TITLE);
+            } else {
+                return "main";
+            }
+
+        } catch (IOException e) {
+            return "main";
+        }
+    }
+
+    private String getFeatureBranchBuildOrDate() {
+        try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF")) {
+
+            if (inputStream != null) {
+                Manifest manifest = new Manifest(inputStream);
+
+                // Access attributes from the manifest file
+                return manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+            } else {
+                return "";
+            }
+
+        } catch (IOException e) {
+            return "";
+        }
     }
 
     private String getDatabaseVersion() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,6 +58,8 @@ dependencyResolutionManagement {
 
             library("acf", "co.aikar:acf-paper:0.5.1-SNAPSHOT")
             library("inventorygui", "de.themoep:inventorygui:1.6.2-SNAPSHOT")
+
+            plugin("grgit", "org.ajoberstar.grgit").version("5.2.2")
         }
     }
 }


### PR DESCRIPTION
This adds additional build information to the /emf admin version command.
Users will now be able to tell what dev version they are running from within the game. As well if it's a custom fix by a developer or something similar.
![WindowsTerminal_l33vgjv3si](https://github.com/Oheers/EvenMoreFish/assets/4803946/2aa3d706-eaa6-4eb9-9f47-446ab8b198e3)

If it's a release version, the "Implementation-Version" will be RELEASE.

This is done via the `MANIFEST.mf` file. For example, the file for this branch is:
```
Manifest-Version: 1.0
Specification-Title: EvenMoreFish
Specification-Version: 1.7.2
Implementation-Title: build-info
Implementation-Version: 20240708-2138
```