### PR TITLE
Add support for MiniMessage

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -84,10 +84,10 @@ dependencies {
     implementation(libs.universalscheduler)
     implementation(libs.acf)
     implementation(libs.inventorygui)
-    implementation(libs.adventure.api)
-    implementation(libs.adventure.minimessage)
-    implementation(libs.adventure.legacy)
 
+    library(libs.adventure.api)
+    library(libs.adventure.minimessage)
+    library(libs.adventure.legacy)
     library(libs.friendlyid)
     library(libs.flyway.core)
     library(libs.flyway.mysql)
@@ -243,7 +243,6 @@ tasks {
         relocate("co.aikar.commands", "com.oheers.fish.libs.acf")
         relocate("co.aikar.locales", "com.oheers.fish.libs.locales")
         relocate("de.themoep.inventorygui", "com.oheers.fish.libs.inventorygui")
-        relocate("net.kyori.adventure", "com.oheers.fish.libs.adventure")
     }
 
     compileJava {

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -78,6 +78,9 @@ dependencies {
     implementation(libs.universalscheduler)
     implementation(libs.acf)
     implementation(libs.inventorygui)
+    implementation(libs.adventure.api)
+    implementation(libs.adventure.minimessage)
+    implementation(libs.adventure.legacy)
 
     library(libs.friendlyid)
     library(libs.flyway.core)
@@ -225,6 +228,7 @@ tasks {
         relocate("co.aikar.commands", "com.oheers.fish.libs.acf")
         relocate("co.aikar.locales", "com.oheers.fish.libs.locales")
         relocate("de.themoep.inventorygui", "com.oheers.fish.libs.inventorygui")
+        relocate("net.kyori.adventure", "com.oheers.fish.libs.adventure")
     }
 
     compileJava {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -18,6 +18,10 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import de.tr7zw.changeme.nbtapi.NBT;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
@@ -247,7 +251,23 @@ public class FishUtils {
     }
 
     // credit to https://www.spigotmc.org/members/elementeral.717560/
-    public static String translateHexColorCodes(String message) {
+    public static String translateColorCodes(String message) {
+        // Replace all Section symbols with Ampersands so MiniMessage doesn't explode.
+        message = message.replace(ChatColor.COLOR_CHAR, '&');
+
+        try {
+            // Parse MiniMessage
+            LegacyComponentSerializer legacyAmpersandSerializer = LegacyComponentSerializer.builder()
+                    .hexColors()
+                    .useUnusualXRepeatedCharacterHexFormat()
+                    .build();
+            Component component = MiniMessage.builder().strict(true).build().deserialize(message);
+            // Get legacy color codes from MiniMessage
+            message = legacyAmpersandSerializer.serialize(component);
+        } catch (ParsingException exception) {
+            // Ignore. If MiniMessage throws an exception, we'll only use legacy colors.
+        }
+
         Matcher matcher = HEX_PATTERN.matcher(message);
         StringBuffer buffer = new StringBuffer(message.length() + 4 * 8);
         while (matcher.find()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
@@ -45,7 +45,7 @@ public class Bait {
         this.name = name;
 
         if (BaitFile.getInstance().getBaitTheme(name) != null) {
-            this.theme = FishUtils.translateHexColorCodes(BaitFile.getInstance().getBaitTheme(name));
+            this.theme = FishUtils.translateColorCodes(BaitFile.getInstance().getBaitTheme(name));
         } else {
             this.theme = "&e";
         }
@@ -63,7 +63,7 @@ public class Bait {
         this.itemFactory.enableDefaultChecks();
         this.itemFactory.setItemDisplayNameCheck(true);
 
-        this.itemFactory.setDisplayName(FishUtils.translateHexColorCodes("&e" + name));
+        this.itemFactory.setDisplayName(FishUtils.translateColorCodes("&e" + name));
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -364,7 +364,7 @@ public class BaitNBTManager {
 
                 if (BaitFile.getInstance().showUnusedBaitSlots()) {
                     for (int i = baitCount; i < BaitFile.getInstance().getMaxBaits(); i++) {
-                        lore.add(FishUtils.translateHexColorCodes(BaitFile.getInstance().unusedBaitSlotFormat()));
+                        lore.add(FishUtils.translateColorCodes(BaitFile.getInstance().unusedBaitSlotFormat()));
                     }
                 }
             } else {
@@ -446,6 +446,6 @@ public class BaitNBTManager {
      */
     private static String getBaitFormatted(String baitID) {
         Bait bait = EvenMoreFish.getInstance().getBaits().get(baitID);
-        return FishUtils.translateHexColorCodes(bait.getDisplayName());
+        return FishUtils.translateColorCodes(bait.getDisplayName());
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -89,9 +89,9 @@ public class AdminCommand extends BaseCommand {
         @CommandCompletion("@rarities")
         @Description("%desc_list_fish")
         public void onFish(final CommandSender sender, final Rarity rarity) {
-            BaseComponent baseComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + rarity.getDisplayName()) + " ");
+            BaseComponent baseComponent = new TextComponent(FishUtils.translateColorCodes(rarity.getColour() + rarity.getDisplayName()) + " ");
             for (Fish fish : EvenMoreFish.getInstance().getFishCollection().get(rarity)) {
-                BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + fish.getDisplayName() + rarity.getColour()+ "] "));
+                BaseComponent textComponent = new TextComponent(FishUtils.translateColorCodes(rarity.getColour() + "[" + fish.getDisplayName() + rarity.getColour()+ "] "));
                 textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to receive fish")));
                 textComponent.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/emf admin fish " + rarity.getValue() + " " + fish.getName().replace(" ","_")));
                 baseComponent.addExtra(textComponent);
@@ -105,7 +105,7 @@ public class AdminCommand extends BaseCommand {
         public void onRarity(final CommandSender sender) {
             BaseComponent baseComponent = new TextComponent("");
             for (Rarity rarity : EvenMoreFish.getInstance().getFishCollection().keySet()) {
-                BaseComponent textComponent = new TextComponent(FishUtils.translateHexColorCodes(rarity.getColour() + "[" + rarity.getDisplayName() + "] "));
+                BaseComponent textComponent = new TextComponent(FishUtils.translateColorCodes(rarity.getColour() + "[" + rarity.getDisplayName() + "] "));
                 textComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText("Click to view " + rarity.getDisplayName() + " fish.")));
                 textComponent.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/emf admin list fish " + rarity.getValue()));
                 baseComponent.addExtra(textComponent);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
@@ -74,7 +74,7 @@ public class Bar {
     }
 
     public void setTitle(long timeLeft) {
-        bar.setTitle(prefix + ChatColor.RESET + FishUtils.translateHexColorCodes(FishUtils.timeFormat(timeLeft) + ChatColor.RESET + new Message(ConfigMessage.BAR_REMAINING).getRawMessage(false)));
+        bar.setTitle(prefix + ChatColor.RESET + FishUtils.translateColorCodes(FishUtils.timeFormat(timeLeft) + ChatColor.RESET + new Message(ConfigMessage.BAR_REMAINING).getRawMessage(false)));
     }
 
     public void show() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -101,7 +101,7 @@ public class Competition {
             this.timeLeft = this.maxDuration;
 
             leaderboard = new Leaderboard(competitionType);
-            statusBar.setPrefix(FishUtils.translateHexColorCodes(CompetitionConfig.getInstance().getBarPrefix(competitionName)), competitionType);
+            statusBar.setPrefix(FishUtils.translateColorCodes(CompetitionConfig.getInstance().getBarPrefix(competitionName)), competitionType);
             statusBar.show();
             initTimer();
             announceBegin();
@@ -819,7 +819,7 @@ public class Competition {
             EvenMoreFish.getInstance().getLogger().severe(CompetitionConfig.getInstance().getBarColour(competitionName) + " is not a valid bossbar colour, check ");
         }
 
-        this.statusBar.setPrefix(FishUtils.translateHexColorCodes(CompetitionConfig.getInstance().getBarPrefix(competitionName)));
+        this.statusBar.setPrefix(FishUtils.translateColorCodes(CompetitionConfig.getInstance().getBarPrefix(competitionName)));
     }
 
     public void initGetNumbersNeeded(String competitionName) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -4,6 +4,10 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.FishUtils;
 import com.oheers.fish.competition.CompetitionType;
 import me.clip.placeholderapi.PlaceholderAPI;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.ParsingException;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -11,13 +15,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Message {
 
-    private static final Pattern HEX_PATTERN = Pattern.compile("&#" + "([A-Fa-f0-9]{6})");
-    private static final char COLOR_CHAR = '\u00A7';
     private final Map<String, String> liveVariables = new LinkedHashMap<>();
     public String message;
     private boolean canSilent, canHidePrefix;
@@ -101,17 +101,7 @@ public class Message {
      * have been formatted.
      */
     private void colourFormat() {
-        Matcher matcher = HEX_PATTERN.matcher(message);
-        StringBuffer buffer = new StringBuffer(message.length() + 4 * 8);
-        while (matcher.find()) {
-            String group = matcher.group(1);
-            matcher.appendReplacement(buffer, COLOR_CHAR + "x"
-                    + COLOR_CHAR + group.charAt(0) + COLOR_CHAR + group.charAt(1)
-                    + COLOR_CHAR + group.charAt(2) + COLOR_CHAR + group.charAt(3)
-                    + COLOR_CHAR + group.charAt(4) + COLOR_CHAR + group.charAt(5)
-            );
-        }
-        this.message = ChatColor.translateAlternateColorCodes('&', matcher.appendTail(buffer).toString());
+        this.message = FishUtils.translateColorCodes(this.message);
     }
 
     /**
@@ -570,9 +560,9 @@ public class Message {
             // does colour coding, hence why .addAll() isn't used
             for (String line : lore) {
                 if (line.equals(lore.get(lore.size() - 1))) {
-                    customLore.append(FishUtils.translateHexColorCodes(line));
+                    customLore.append(FishUtils.translateColorCodes(line));
                 }
-                else customLore.append(FishUtils.translateHexColorCodes(line)).append("\n");
+                else customLore.append(FishUtils.translateColorCodes(line)).append("\n");
             }
             // Replaces the fish lore with the value
             setVariable(variable, customLore.toString());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/OldMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/OldMessage.java
@@ -117,7 +117,7 @@ public class OldMessage {
             msg = msg.replace(replacement.getKey(), replacement.getValue());
         }
 
-        return FishUtils.translateHexColorCodes(msg);
+        return FishUtils.translateColorCodes(msg);
 
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -211,8 +211,8 @@ public class FishingProcessor implements Listener {
 
             String length = Float.toString(fish.getLength());
             // Translating the colours because some servers store colour in their fish name
-            String name = FishUtils.translateHexColorCodes(fish.getName());
-            String rarity = FishUtils.translateHexColorCodes(fish.getRarity().getValue());
+            String name = FishUtils.translateColorCodes(fish.getName());
+            String rarity = FishUtils.translateColorCodes(fish.getRarity().getValue());
 
             Message message = new Message(ConfigMessage.FISH_CAUGHT);
             message.setPlayer(player.getName());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -128,7 +128,7 @@ public class Fish implements Cloneable {
         if (fishMeta != null) {
             NBT.modify(fish, nbt -> {
                 nbt.modifyMeta((readOnlyNbt, meta) -> {
-                    meta.setDisplayName(FishUtils.translateHexColorCodes(getDisplayName()));
+                    meta.setDisplayName(FishUtils.translateColorCodes(getDisplayName()));
                     if (!this.fishConfig.getBoolean("fish." + this.rarity.getValue() + "." + this.name + ".disable-lore", false)) {
                         meta.setLore(getFishLore());
                     }
@@ -201,7 +201,7 @@ public class Fish implements Cloneable {
 
         if (msg != null) {
             if (Bukkit.getPlayer(fisherman) != null) {
-                Objects.requireNonNull(Bukkit.getPlayer(this.fisherman)).sendMessage(FishUtils.translateHexColorCodes(msg));
+                Objects.requireNonNull(Bukkit.getPlayer(this.fisherman)).sendMessage(FishUtils.translateColorCodes(msg));
             }
         }
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -81,7 +81,7 @@ public class Rarity {
     }
 
     public String getLorePrep() {
-        if (overridenLore != null) return FishUtils.translateHexColorCodes(overridenLore);
+        if (overridenLore != null) return FishUtils.translateColorCodes(overridenLore);
         else {
             if (this.displayName != null) {
                 return this.displayName;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -568,7 +568,7 @@ public class ItemFactory {
                 if (displayName.isEmpty()) {
                     meta.setDisplayName("");
                 } else {
-                    meta.setDisplayName(FishUtils.translateHexColorCodes(displayName));
+                    meta.setDisplayName(FishUtils.translateColorCodes(displayName));
                 }
             }
 

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -1,5 +1,9 @@
 # If a message contains EvenMoreFish placeholders, e.g. {player} or {rarity} it also supports placeholderapi placeholders.
 
+# These messages support the MiniMessage format. You are able to mix this with the existing legacy codes, however you MUST close the tags.
+# Here is the MiniMessage Pull Request for more info: https://github.com/Oheers/EvenMoreFish/pull/387
+# Here are the MiniMessage Docs: https://docs.advntr.dev/minimessage/format.html
+
 # Sent to players when they fish an EvenMoreFish fish
 fish-caught: "&l{player} &rhas fished a {rarity_colour}{length}cm &l{rarity} {rarity_colour}{fish}!"
 # By setting a fish's minimum-length to less than 0, you can create a lengthless fish. This is used when a player fishes a lengthless fish.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,6 +58,10 @@ dependencyResolutionManagement {
 
             library("acf", "co.aikar:acf-paper:0.5.1-SNAPSHOT")
             library("inventorygui", "de.themoep:inventorygui:1.6.2-SNAPSHOT")
+
+            library("adventure-api", "net.kyori:adventure-api:4.17.0")
+            library("adventure-minimessage", "net.kyori:adventure-text-minimessage:4.17.0")
+            library("adventure-legacy", "net.kyori:adventure-text-serializer-legacy:4.17.0")
         }
     }
 }


### PR DESCRIPTION
Adds MiniMessage support to the messages file.

Legacy and MiniMessage can be mixed in the same message, like so:
`contest-start: '&eA <rainbow>fishing contest</rainbow> &efor {type} has started.'`
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/7ad41014-4fc0-42b7-b9d5-5a280cb53b7d)

MiniMessage is using strict mode, meaning all tags need to be closed in order to be parsed. If it is not closed, it will just show up in the message, and can be fixed by a server admin.
![image](https://github.com/Oheers/EvenMoreFish/assets/106587317/942e0fc8-9ab5-42aa-b58e-c2feb555a08b)
