### PR TITLE
Fix issues on 1.16.5

### DIFF
--- a/even-more-fish-addons-j8/src/main/java/com/oheers/evenmorefish/addons/ItemsAdderItemAddon.java
+++ b/even-more-fish-addons-j8/src/main/java/com/oheers/evenmorefish/addons/ItemsAdderItemAddon.java
@@ -58,7 +58,7 @@ public class ItemsAdderItemAddon extends ItemAddon implements Listener {
         getLogger().info("Reloading EMF.");
         this.itemsAdderLoaded = true;
 
-        ((EMFPlugin) Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("EvenMoreFish"))).reload();
+        ((EMFPlugin) Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("EvenMoreFish"))).reload(null);
     }
 
     /**

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/plugin/EMFPlugin.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/plugin/EMFPlugin.java
@@ -1,11 +1,14 @@
 package com.oheers.fish.api.plugin;
 
 
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.logging.Logger;
 
 public interface EMFPlugin {
 
-    void reload();
+    void reload(@Nullable CommandSender sender);
 
     static Logger getLogger() {
         return Logger.getLogger("EvenMoreFish");

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -88,10 +88,10 @@ dependencies {
     implementation(libs.universalscheduler)
     implementation(libs.acf)
     implementation(libs.inventorygui)
+    implementation(libs.adventure.api)
+    implementation(libs.adventure.minimessage)
+    implementation(libs.adventure.legacy)
 
-    library(libs.adventure.api)
-    library(libs.adventure.minimessage)
-    library(libs.adventure.legacy)
     library(libs.friendlyid)
     library(libs.flyway.core)
     library(libs.flyway.mysql)
@@ -247,6 +247,7 @@ tasks {
         relocate("co.aikar.commands", "com.oheers.fish.libs.acf")
         relocate("co.aikar.locales", "com.oheers.fish.libs.locales")
         relocate("de.themoep.inventorygui", "com.oheers.fish.libs.inventorygui")
+        relocate("net.kyori.adventure", "com.oheers.fish.libs.adventure")
     }
 
     compileJava {

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -50,7 +50,9 @@ dependencies {
     compileOnly(libs.worldguard.core) {
         exclude("com.sk89q.worldedit", "worldedit-core")
     }
-    compileOnly(libs.worldguard.bukkit)
+    compileOnly(libs.worldguard.bukkit) {
+        exclude("org.spigotmc", "spigot-api")
+    }
     compileOnly(libs.worldedit.core)
     compileOnly(libs.worldedit.bukkit)
 
@@ -77,7 +79,9 @@ dependencies {
     compileOnly(libs.headdatabase.api)
     compileOnly(libs.playerpoints)
     compileOnly(libs.cmi.api)
-    compileOnly(libs.essx.api)
+    compileOnly(libs.essx.api) {
+        exclude("org.spigotmc", "spigot-api")
+    }
 
     implementation(libs.nbt.api)
     implementation(libs.bstats)

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -42,6 +42,7 @@ import com.oheers.fish.utils.HeadDBIntegration;
 import com.oheers.fish.utils.ItemFactory;
 import com.oheers.fish.utils.nbt.NbtKeys;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import de.themoep.inventorygui.InventoryGui;
 import de.tr7zw.changeme.nbtapi.NBT;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
 import net.milkbowl.vault.permission.Permission;
@@ -237,7 +238,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
     @Override
     public void onDisable() {
-        terminateSellGUIS();
+        terminateGUIS();
         // Don't use the scheduler here because it will throw errors on disable
         saveUserData(false);
 
@@ -466,11 +467,12 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         }
     }
 
-    // gets called on server shutdown to simulate all player's closing their /emf shop GUIs
-    private void terminateSellGUIS() {
+    // gets called on server shutdown to simulate all players closing their GUIs
+    private void terminateGUIS() {
         getServer().getOnlinePlayers().forEach(player -> {
-            if (player.getOpenInventory().getTopInventory().getHolder() instanceof SellGUI) {
-                player.closeInventory();
+            InventoryGui inventoryGui = InventoryGui.getOpen(player);
+            if (inventoryGui != null) {
+                inventoryGui.close();
             }
         });
     }
@@ -529,7 +531,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
     public void reload() {
 
-        terminateSellGUIS();
+        terminateGUIS();
 
         setupEconomy();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -533,13 +533,23 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
         terminateGUIS();
 
-        setupEconomy();
-
-        fish = new HashMap<>();
-        fishCollection = new HashMap<>();
+        fish.clear();
+        fishCollection.clear();
 
         reloadConfig();
         saveDefaultConfig();
+
+        MainConfig.getInstance().reload();
+        Messages.getInstance().reload();
+        CompetitionConfig.getInstance().reload();
+        Xmas2022Config.getInstance().reload();
+        GUIConfig.getInstance().reload();
+        GUIFillerConfig.getInstance().reload();
+        FishFile.getInstance().reload();
+        RaritiesFile.getInstance().reload();
+        BaitFile.getInstance().reload();
+
+        setupEconomy();
 
         Names names = new Names();
         names.loadRarities(FishFile.getInstance().getConfig(), RaritiesFile.getInstance().getConfig());
@@ -550,13 +560,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         HandlerList.unregisterAll(McMMOTreasureEvent.getInstance());
         optionalListeners();
 
-        MainConfig.getInstance().reload();
-        Messages.getInstance().reload();
-        CompetitionConfig.getInstance().reload();
-        Xmas2022Config.getInstance().reload();
-        GUIConfig.getInstance().reload();
-        GUIFillerConfig.getInstance().reload();
-
         if (MainConfig.getInstance().requireNBTRod()) {
             customNBTRod = createCustomNBTRod();
         }
@@ -566,7 +569,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
     // Checks for updates, surprisingly
     private boolean checkUpdate() {
-
 
         String[] spigotVersion = new UpdateChecker(this, 91310).getVersion().split("\\.");
         String[] serverVersion = getDescription().getVersion().split("\\.");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -50,6 +50,7 @@ import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
 import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
@@ -58,6 +59,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.*;
@@ -529,7 +531,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         return customRod;
     }
 
-    public void reload() {
+    public void reload(@Nullable CommandSender sender) {
 
         terminateGUIS();
 
@@ -565,6 +567,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         }
 
         competitionQueue.load();
+
+        if (sender != null) {
+            new Message(ConfigMessage.RELOAD_SUCCESS).broadcast(sender, false);
+        }
+
     }
 
     // Checks for updates, surprisingly

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -287,7 +287,8 @@ public class FishUtils {
                 ReadWriteNBT profileNbt = nbt.getOrCreateCompound("minecraft:profile");
                 profileNbt.setUUID("id", headUuid);
                 ReadWriteNBT propertiesNbt = profileNbt.getCompoundList("properties").addCompound();
-                propertiesNbt.setString("name", "EMFFish");
+                // This key is required, so we set it to an empty string.
+                propertiesNbt.setString("name", "textures");
                 propertiesNbt.setString("value", base64EncodedString);
             });
         // 1.20.4 and below handling

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -280,7 +280,7 @@ public class FishUtils {
     //gets the item with a custom texture
     public static ItemStack get(String base64EncodedString) {
         final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
-        UUID headUuid = UUID.fromString("8667ba71-b85a-4004-af54-457a9734eed7");
+        UUID headUuid = UUID.randomUUID();
         // 1.20.5+ handling
         if (MinecraftVersion.isNewerThan(MinecraftVersion.MC1_20_R3)) {
             NBT.modifyComponents(skull, nbt -> {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -18,6 +18,8 @@ import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
+import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.ParsingException;
@@ -28,13 +30,7 @@ import org.bukkit.*;
 import org.bukkit.block.Skull;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.SkullMeta;
-import org.bukkit.profile.PlayerProfile;
-import org.bukkit.profile.PlayerTextures;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -284,20 +280,26 @@ public class FishUtils {
     //gets the item with a custom texture
     public static ItemStack get(String base64EncodedString) {
         final ItemStack skull = new ItemStack(Material.PLAYER_HEAD);
-        SkullMeta meta = (SkullMeta) skull.getItemMeta();
-        if (meta != null) {
-            try {
-                String decodedBase64 = new String(Base64.getDecoder().decode(base64EncodedString));
-                URL url = new URL(decodedBase64.substring("{\"textures\":{\"SKIN\":{\"url\":\"".length(), decodedBase64.length() - "\"}}}".length()));
-                PlayerProfile profile = Bukkit.createPlayerProfile(UUID.randomUUID(), "EMFFish");
-                PlayerTextures textures = profile.getTextures();
-                textures.setSkin(url);
-                profile.setTextures(textures);
-                meta.setOwnerProfile(profile);
-            } catch (MalformedURLException ignored) {
-                // If it's malformed, just don't set it.
-            }
-            skull.setItemMeta(meta);
+        UUID headUuid = UUID.fromString("8667ba71-b85a-4004-af54-457a9734eed7");
+        // 1.20.5+ handling
+        if (MinecraftVersion.isNewerThan(MinecraftVersion.MC1_20_R3)) {
+            NBT.modifyComponents(skull, nbt -> {
+                ReadWriteNBT profileNbt = nbt.getOrCreateCompound("minecraft:profile");
+                profileNbt.setUUID("id", headUuid);
+                ReadWriteNBT propertiesNbt = profileNbt.getCompoundList("properties").addCompound();
+                propertiesNbt.setString("name", "EMFFish");
+                propertiesNbt.setString("value", base64EncodedString);
+            });
+        // 1.20.4 and below handling
+        } else {
+            NBT.modify(skull, nbt -> {
+                ReadWriteNBT skullOwnerCompound = nbt.getOrCreateCompound("SkullOwner");
+                skullOwnerCompound.setUUID("Id", headUuid);
+                skullOwnerCompound.getOrCreateCompound("Properties")
+                        .getCompoundList("textures")
+                        .addCompound()
+                        .setString("Value", base64EncodedString);
+            });
         }
         return skull;
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -273,10 +273,7 @@ public class AdminCommand extends BaseCommand {
     @Subcommand("reload")
     @Description("%desc_admin_reload")
     public void onReload(final CommandSender sender) {
-
-        EvenMoreFish.getInstance().reload();
-
-        new Message(ConfigMessage.RELOAD_SUCCESS).broadcast(sender, false);
+        EvenMoreFish.getInstance().reload(sender);
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -62,6 +62,8 @@ public class AdminCommand extends BaseCommand {
             fish.getFishRewards().forEach(fishReward -> fishReward.rewardPlayer(target, target.getLocation()));
         }
 
+        fish.setFisherman(target.getUniqueId());
+
         final ItemStack fishItem = fish.give(-1);
         fishItem.setAmount(quantity);
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -273,9 +273,6 @@ public class AdminCommand extends BaseCommand {
     @Subcommand("reload")
     @Description("%desc_admin_reload")
     public void onReload(final CommandSender sender) {
-        FishFile.getInstance().reload();
-        RaritiesFile.getInstance().reload();
-        BaitFile.getInstance().reload();
 
         EvenMoreFish.getInstance().reload();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
@@ -103,7 +103,6 @@ public class ConfigBase {
             if (!config.isConfigurationSection(key)) {
                 tempConfig.set(key, config.get(key));
             }
-            tempConfig.setComments(key, config.getComments(key));
         });
         try {
             tempConfig.save(file);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -520,7 +520,7 @@ public class ItemFactory {
                 }
             }
 
-            product.setItemMeta(nonDamaged);
+            product.setItemMeta((ItemMeta) nonDamaged);
         }
     }
 


### PR DESCRIPTION
- Excludes Spigot API from some dependencies, as they were providing 1.20.1 API instead of the 1.16.5 we want.
- Removes the code which carries over comments in the config updater. This is not possible in Spigot 1.16.5.
- Fixes a casting issue, caused by 1.16.5 for whatever reason.
- Bukkit#createPlayerProfile does not exist in 1.16.5, so we've gone back to NBT-API skulls. There is a version check so skulls do not break on 1.20.5+.
- Adventure is now relocated, as the 1.16.5 Paper server does not like it being provided via the libraries system.