### PR TITLE
Fix config defaults issue

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/ConfigBase.java
@@ -45,7 +45,7 @@ public class ConfigBase {
         }
 
         List<Settings> settingsList = new ArrayList<>(Arrays.asList(
-                GeneralSettings.DEFAULT,
+                GeneralSettings.builder().setUseDefaults(false).build(),
                 DumperSettings.DEFAULT
         ));
 


### PR DESCRIPTION
Stops the BoostedYAML library from loading the config defaults if the key does not exist. This fixes an issue where all default fish were loaded along with all custom ones.