### PR TITLE
Add config for biome sets

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -6,12 +6,10 @@ import dev.dejvokep.boostedyaml.block.implementation.Section;
 import dev.dejvokep.boostedyaml.dvs.versioning.AutomaticVersioning;
 import dev.dejvokep.boostedyaml.route.Route;
 import org.apache.commons.lang3.LocaleUtils;
+import org.bukkit.block.Biome;
 
 import java.text.NumberFormat;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 public class MainConfig extends ConfigBase {
 
@@ -226,13 +224,23 @@ public class MainConfig extends ConfigBase {
         return getConfig().getBoolean("give-straight-to-inventory");
     }
 
-    public Map<String, List<String>> getBiomeSets() {
-        Map<String, List<String>> biomeSetMap = new HashMap<>();
+    public Map<String, List<Biome>> getBiomeSets() {
+        Map<String, List<Biome>> biomeSetMap = new HashMap<>();
         Section section = getConfig().getSection("biome-sets");
         if (section == null) {
             return Map.of();
         }
-        section.getRoutesAsStrings(false).forEach(key -> biomeSetMap.put(key, section.getStringList(key)));
+        section.getRoutesAsStrings(false).forEach(key -> {
+            List<Biome> biomes = new ArrayList<>();
+            section.getStringList(key).forEach(biomeString -> {
+                try {
+                    biomes.add(Biome.valueOf(biomeString));
+                } catch (IllegalArgumentException exception) {
+                    EvenMoreFish.getInstance().getLogger().severe(biomeString + " is not a valid biome, found when loading in biome set " + key + ".");
+                }
+            });
+            biomeSetMap.put(key, biomes);
+        });
         return biomeSetMap;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -2,13 +2,16 @@ package com.oheers.fish.config;
 
 import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
 import dev.dejvokep.boostedyaml.dvs.versioning.AutomaticVersioning;
 import dev.dejvokep.boostedyaml.route.Route;
 import org.apache.commons.lang3.LocaleUtils;
 
 import java.text.NumberFormat;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 public class MainConfig extends ConfigBase {
 
@@ -222,4 +225,15 @@ public class MainConfig extends ConfigBase {
     public boolean giveStraightToInventory() {
         return getConfig().getBoolean("give-straight-to-inventory");
     }
+
+    public Map<String, List<String>> getBiomeSets() {
+        Map<String, List<String>> biomeSetMap = new HashMap<>();
+        Section section = getConfig().getSection("biome-sets");
+        if (section == null) {
+            return Map.of();
+        }
+        section.getRoutesAsStrings(false).forEach(key -> biomeSetMap.put(key, section.getStringList(key)));
+        return biomeSetMap;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Names.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Names.java
@@ -192,6 +192,7 @@ public class Names {
             for (String s : requirementSection.getRoutesAsStrings(false)) {
                 switch (s.toLowerCase()) {
                     case "biome" -> currentRequirements.add(new Biome(configLocator + ".requirements.biome", config));
+                    case "biome-set" -> currentRequirements.add(new BiomeSet(configLocator + ".requirements.biome-set", config));
                     case "irl-time" -> currentRequirements.add(new IRLTime(configLocator + ".requirements.irl-time", config));
                     case "ingame-time" -> currentRequirements.add(new InGameTime(configLocator + ".requirements.ingame-time", config));
                     case "moon-phase" -> currentRequirements.add(new MoonPhase(configLocator + ".requirements.moon-phase", config));

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeSet.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeSet.java
@@ -1,0 +1,58 @@
+package com.oheers.fish.requirements;
+
+import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.config.FishFile;
+import com.oheers.fish.config.MainConfig;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class BiomeSet implements Requirement {
+
+    public final String configLocation;
+    public final YamlDocument fileConfig;
+    public final List<org.bukkit.block.Biome> biomes = new ArrayList<>();
+
+    /**
+     * Checks the world for the current biome the player is stood in to figure out whether to give the player the fish
+     * or not. Will not work if the world is null. It also takes the biomes in as a list, so you can have multiple be
+     * whitelisted for the user.
+     *
+     * @param configLocation The location that data regarding this should be found. It should cut off after "biome:"
+     *                       for example, "fish.Common.Herring.requirements.biome".
+     * @param fileConfig The file configuration to fetch file data from, this is either the rarities or fish.yml file,
+     *                   but it would be possible to use any file, as long as the configLocation is correct.
+     */
+    public BiomeSet(@NotNull final String configLocation, @NotNull final YamlDocument fileConfig) {
+        this.configLocation = configLocation;
+        this.fileConfig = fileConfig;
+        fetchData();
+    }
+
+    @Override
+    public boolean requirementMet(RequirementContext context) {
+        if (context.getWorld() != null) {
+            return biomes.contains(context.getWorld().getBiome(context.getLocation().getBlockX(), context.getLocation().getBlockY(), context.getLocation().getBlockZ()));
+        }
+        EvenMoreFish.getInstance().getLogger().severe("Could not get world for " + configLocation + ", returning false by " +
+                "default. The player may not have been given a fish if you see this message multiple times.");
+        return false;
+    }
+
+    @Override
+    public void fetchData() {
+        // returns the biomes from the sets found in the "biome-sets:" section of the fish.yml
+        Map<String, List<org.bukkit.block.Biome>> biomeSets = MainConfig.getInstance().getBiomeSets();
+        for (String biomeSet : FishFile.getInstance().getConfig().getStringList(configLocation)) {
+            List<org.bukkit.block.Biome> biomeList = biomeSets.get(biomeSet);
+            if (biomeList == null) {
+                EvenMoreFish.getInstance().getLogger().severe(biomeSet + " is not a valid biome set, found when loading in one of your fish.");
+                return;
+            }
+            this.biomes.addAll(biomeList);
+        }
+    }
+}

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -134,6 +134,18 @@ command:
   aliases:
     - "evenmorefish"
 
+# Customizable sets of biomes for fish.yml configuration
+biome-sets:
+  # oceans biome set. you can add more sets as you please.
+  oceans:
+    - COLD_OCEAN
+    - DEEP_COLD_OCEAN
+    - DEEP_LUKEWARM_OCEAN
+    - DEEP_OCEAN
+    - LUKEWARM_OCEAN
+    - OCEAN
+    - WARM_OCEAN
+
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 3
+config-version: 4


### PR DESCRIPTION
- Adds a biome-sets key to config.yml, where sets of biomes can be specified for use in requirements.
- Adds a biome-set requirement, which uses the values defined in config.yml

This is a less confusing method of creating biome sets.