### PR TITLE
Revert "Update CMI-API"

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,7 +61,7 @@ dependencyResolutionManagement {
 
             library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
             library("playerpoints", "org.black_ixx:playerpoints:3.2.7")
-            library("cmi-api", "CMI-API:CMI-API:9.7.4.1")
+            library("cmi-api", "CMI-API:CMI-API:9.7.0.1")
             library("essx-api", "net.essentialsx:EssentialsX:2.20.1")
 
             library("acf", "co.aikar:acf-paper:0.5.1-SNAPSHOT")


### PR DESCRIPTION
Reverts Oheers/EvenMoreFish#414

That version of CMI-API requires Java 21