### PR TITLE
Exclude all Adventure libraries from being minimized

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -237,7 +237,9 @@ tasks {
             attributes["Implementation-Version"] = buildNumberOrDate
         }
 
-        minimize()
+        minimize {
+            exclude(dependency("net.kyori:.*"))
+        }
 
         exclude("META-INF/**")
 


### PR DESCRIPTION
Small fix to stop shadow from removing unused adventure classes, this is required as addon plugins might need to use the classes EMF does not use.