### PR TITLE
Preload NBT-API to catch any problems

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -125,6 +125,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
     @Override
     public void onEnable() {
+
+        if (!NBT.preloadApi()) {
+            throw new RuntimeException("NBT-API wasn't initialized properly, disabling the plugin");
+        }
+
         instance = this;
         scheduler = UniversalScheduler.getScheduler(this);
         this.api = new EMFAPI();


### PR DESCRIPTION
Adds NBT-API's preload method to the plugin's onEnable to disable the plugin if there are any problems.

This should prevent confusion when certain features do not work because NBT-API is having problems.