### PR TITLE
Hopefully the final competition fix

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/EMFRewardEvent.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/EMFRewardEvent.java
@@ -7,6 +7,10 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @deprecated Use a custom {@link RewardType} instead.
+ */
+@Deprecated
 public class EMFRewardEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
@@ -45,6 +45,7 @@ public class Reward {
     public void rewardPlayer(@NotNull Player player, Location hookLocation) {
         if (getRewardType() == null) {
             EMFPlugin.getLogger().warning("No reward type found for key: " + getKey() + ". Falling back to the deprecated event-based rewards.");
+            // Ignore deprecation warnings, we need to keep this here for any outdated addons.
             EMFRewardEvent event = new EMFRewardEvent(this, player, fishVelocity, hookLocation);
             Bukkit.getPluginManager().callEvent(event);
             return;

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
@@ -19,7 +19,7 @@ public class Reward {
     public Reward(@NotNull String identifier) {
         String[] split = identifier.split(":");
         if (split.length < 2) {
-            EMFPlugin.getLogger().warning(value + " is not formatted correctly. It won't be given as a reward");
+            EMFPlugin.getLogger().warning(identifier + " is not formatted correctly. It won't be given as a reward");
             this.key = "";
             this.value = "";
         } else {
@@ -44,6 +44,7 @@ public class Reward {
 
     public void rewardPlayer(@NotNull Player player, Location hookLocation) {
         if (getRewardType() == null) {
+            EMFPlugin.getLogger().warning("No reward type found for key: " + getKey() + ". Falling back to the deprecated event-based rewards.");
             EMFRewardEvent event = new EMFRewardEvent(this, player, fishVelocity, hookLocation);
             Bukkit.getPluginManager().callEvent(event);
             return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -446,6 +446,9 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
 
         manager.registerCommand(new EMFCommand());
         manager.registerCommand(new AdminCommand());
+
+        // Make server admins aware the deprecation warning is nothing to worry about
+        getLogger().warning("The above warning can safely be ignored for now, we are waiting for a fix from the developers of our command library.");
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -448,7 +448,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         manager.registerCommand(new AdminCommand());
 
         // Make server admins aware the deprecation warning is nothing to worry about
-        getLogger().warning("The above warning can safely be ignored for now, we are waiting for a fix from the developers of our command library.");
+        getLogger().warning("The above warning, if you are on Paper, can safely be ignored for now, we are waiting for a fix from the developers of our command library.");
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -192,6 +192,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             guardPL = null;
         }
 
+        // Do this before anything competition related.
+        loadRewardManager();
+        RewardManager.getInstance().load();
+        getServer().getPluginManager().registerEvents(RewardManager.getInstance(), this);
+
         competitionQueue = new CompetitionQueue();
         competitionQueue.load();
 
@@ -227,11 +232,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
             });
 
         }
-
-        loadRewardManager();
-
-        RewardManager.getInstance().load();
-        getServer().getPluginManager().registerEvents(RewardManager.getInstance(), this);
 
         logger.log(Level.INFO, "EvenMoreFish by Oheers : Enabled");
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -719,11 +719,12 @@ public class Competition {
         String path;
 
         // If the competition is an admin start or doesn't have its own rewards, we use the non-specific rewards, else we use the competition's reward config
-        if (adminStart || CompetitionConfig.getInstance().getRewardPositions(competitionName).isEmpty()) {
+        Set<String> positions = CompetitionConfig.getInstance().getRewardPositions(competitionName);
+        if (adminStart || positions.isEmpty()) {
             chosen = CompetitionConfig.getInstance().getRewardPositions();
             path = "rewards.";
         } else {
-            chosen = CompetitionConfig.getInstance().getRewardPositions(competitionName);
+            chosen = positions;
             path = "competitions." + competitionName + ".rewards.";
         }
 


### PR DESCRIPTION
- Deprecates EMFRewardEvent
- Logs a warning when the Reward class falls back to the deprecated event (kept in for any addons still using it)
- Loads RewardManager before the Competitions
- Adds a note to the brigadier deprecation warning to tell server admins not to worry