### PR TITLE
Leaderboard Cleanup

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
@@ -127,7 +127,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
             }
             
             // getting "place" place in the competition
-            UUID uuid = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getPlayer(place);
+            UUID uuid = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getEntry(place).getPlayer();
             if (uuid != null) {
                 // To be in the leaderboard the player must have joined
                 return Objects.requireNonNull(Bukkit.getOfflinePlayer(uuid)).getName();
@@ -149,7 +149,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
             }
             
             // getting "place" place in the competition
-            float value = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getPlaceValue(place);
+            float value = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getEntry(place).getValue();
             
             if (value != -1.0f) return Float.toString(Math.round(value * 10f) / 10f);
             else return "";
@@ -168,7 +168,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
                 }
                 
                 // getting "place" place in the competition
-                Fish fish = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getPlaceFish(place);
+                Fish fish = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getEntry(place).getFish();
                 if (fish != null) {
                     Message message = new Message(ConfigMessage.PLACEHOLDER_FISH_FORMAT);
                     if (fish.getLength() == -1)
@@ -189,7 +189,8 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
                 
             } else {
                 // checking the leaderboard actually contains the value of place
-                float value = Competition.leaderboard.getPlaceValue(Integer.parseInt(identifier.substring(23)));
+                int place = Integer.parseInt(identifier.substring(23));
+                float value = Competition.leaderboard.getEntry(place).getValue();
                 if (value == -1)
                     return new Message(ConfigMessage.PLACEHOLDER_NO_FISH_IN_PLACE).getRawMessage(false);
                 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -430,16 +430,7 @@ public class Competition {
         StringBuilder builder = new StringBuilder();
         int pos = 0;
 
-        TreeSet<CompetitionEntry> entries = leaderboard.getEntries();
-        Iterator<CompetitionEntry> entryIterator;
-        if (competitionType.equals(CompetitionType.SHORTEST_TOTAL) || competitionType.equals(CompetitionType.SHORTEST_FISH)) {
-            entryIterator = entries.descendingIterator();
-        } else {
-            entryIterator = entries.iterator();
-        }
-
-        while (entryIterator.hasNext()) {
-            CompetitionEntry entry = entryIterator.next();
+        for (CompetitionEntry entry : leaderboard.getEntries()) {
             pos++;
             if (reachingCount) {
                 leaderboardMembers.add(entry.getPlayer());
@@ -622,16 +613,7 @@ public class Competition {
         StringBuilder builder = new StringBuilder();
         int pos = 0;
 
-        TreeSet<CompetitionEntry> entries = leaderboard.getEntries();
-        Iterator<CompetitionEntry> entryIterator;
-        if (competitionType.equals(CompetitionType.SHORTEST_TOTAL) || competitionType.equals(CompetitionType.SHORTEST_FISH)) {
-            entryIterator = entries.descendingIterator();
-        } else {
-            entryIterator = entries.iterator();
-        }
-
-        while (entryIterator.hasNext()) {
-            CompetitionEntry entry = entryIterator.next();
+        for (CompetitionEntry entry : leaderboard.getEntries()) {
             pos++;
             leaderboardMembers.add(entry.getPlayer());
             Message message = new Message(ConfigMessage.LEADERBOARD_LARGEST_FISH);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -582,20 +582,11 @@ public class Competition {
         message.broadcast(player, true);
     }
 
-        private void setPositionColour(int place, Message message) {
-        // Exists for eventual MiniMessage support
-        if (true) {
-            switch (place) {
-                case 0 -> message.setPositionColour("&c» &r");
-                case 1 -> message.setPositionColour("&c_ &r");
-                case 2 -> message.setPositionColour("&c&ko &r");
-            }
-        } else {
-            switch (place) {
-                case 0 -> message.setPositionColour("<red>» <reset>");
-                case 1 -> message.setPositionColour("<red>_ <reset>");
-                case 2 -> message.setPositionColour("<red><obf>o <reset>");
-            }
+    private void setPositionColour(int place, Message message) {
+        switch (place) {
+            case 0 -> message.setPositionColour("&c» &r");
+            case 1 -> message.setPositionColour("&c_ &r");
+            case 2 -> message.setPositionColour("&c&ko &r");
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -7,6 +7,7 @@ import com.oheers.fish.FishUtils;
 import com.oheers.fish.api.EMFCompetitionEndEvent;
 import com.oheers.fish.api.EMFCompetitionStartEvent;
 import com.oheers.fish.api.reward.Reward;
+import com.oheers.fish.competition.leaderboard.Leaderboard;
 import com.oheers.fish.config.CompetitionConfig;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.ConfigMessage;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionEntry.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionEntry.java
@@ -13,7 +13,7 @@ public class CompetitionEntry implements Comparable<CompetitionEntry> {
     private long time;
     private float value;
 
-    CompetitionEntry(UUID player, Fish fish, CompetitionType type) {
+    public CompetitionEntry(UUID player, Fish fish, CompetitionType type) {
         this.player = player;
         this.fish = fish;
         this.time = Instant.now().toEpochMilli();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionEntry.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionEntry.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Instant;
 import java.util.UUID;
 
-public class CompetitionEntry implements Comparable<CompetitionEntry> {
+public class CompetitionEntry {
 
     private final UUID player;
     private final Fish fish;
@@ -55,16 +55,6 @@ public class CompetitionEntry implements Comparable<CompetitionEntry> {
 
     public UUID getPlayer() {
         return player;
-    }
-
-    @Override
-    public int compareTo(@NotNull CompetitionEntry entry) {
-        // if o's value and this's value are equal, use the time caught instead
-        if (entry.getValue() != this.value) {
-            return (entry.getValue() > this.value) ? 1 : -1;
-        } else {
-            return (entry.getTime() > this.time) ? 1 : -1;
-        }
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
@@ -1,11 +1,10 @@
 package com.oheers.fish.competition;
 
 import com.oheers.fish.fishing.items.Fish;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 interface LeaderboardHandler {
 
@@ -21,6 +20,8 @@ interface LeaderboardHandler {
 
     CompetitionEntry getEntry(UUID player);
 
+    CompetitionEntry getEntry(int place);
+
     int getSize();
 
     boolean hasEntry(UUID player);
@@ -28,13 +29,6 @@ interface LeaderboardHandler {
     void removeEntry(CompetitionEntry entry) throws Exception;
 
     CompetitionEntry getTopEntry();
-
-    UUID getPlayer(int i);
-
-    float getPlaceValue(int i);
-
-    Fish getPlaceFish(int i);
-
 }
 
 public class Leaderboard implements LeaderboardHandler {
@@ -48,6 +42,7 @@ public class Leaderboard implements LeaderboardHandler {
     }
 
     @Override
+    public List<CompetitionEntry> getEntries() {
         // Sort the list so the highest entry value is first
         switch (type) {
             case SHORTEST_FISH, SHORTEST_TOTAL -> {
@@ -96,14 +91,25 @@ public class Leaderboard implements LeaderboardHandler {
     }
 
     @Override
+    public CompetitionEntry getEntry(int place) {
+        try {
+            // Needs to use the sorted list
+            return getEntries().get(place - 1);
+        } catch (IndexOutOfBoundsException exception) {
+            return null;
+        }
+    }
+
+    @Override
     public int getSize() {
         return entries.size();
     }
 
     @Override
     public boolean hasEntry(UUID player) {
+        // Does not need to use the sorted list
         for (CompetitionEntry entry : entries) {
-            if (entry.getPlayer() == player) {
+            if (entry.getPlayer().equals(player)) {
                 return true;
             }
         }
@@ -117,42 +123,8 @@ public class Leaderboard implements LeaderboardHandler {
 
     @Override
     public CompetitionEntry getTopEntry() {
-        return entries.first();
+        // Needs to use the sorted list
+        return getEntries().get(0);
     }
 
-    @Override
-    public UUID getPlayer(int i) {
-        int count = 1;
-        for (CompetitionEntry entry : entries) {
-            if (count == i) {
-                return entry.getPlayer();
-            }
-            count++;
-        }
-        return null;
-    }
-
-    @Override
-    public float getPlaceValue(int i) {
-        int count = 1;
-        for (CompetitionEntry entry : entries) {
-            if (count == i) {
-                return entry.getValue();
-            }
-            count++;
-        }
-        return -1.0f;
-    }
-
-    @Override
-    public Fish getPlaceFish(int i) {
-        int count = 1;
-        for (CompetitionEntry entry : entries) {
-            if (count == i) {
-                return entry.getFish();
-            }
-            count++;
-        }
-        return null;
-    }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 interface LeaderboardHandler {
 
-    TreeSet<CompetitionEntry> getEntries();
+    List<CompetitionEntry> getEntries();
 
     void addEntry(UUID player, Fish fish);
 
@@ -40,16 +40,27 @@ interface LeaderboardHandler {
 public class Leaderboard implements LeaderboardHandler {
 
     CompetitionType type;
-    TreeSet<CompetitionEntry> entries;
+    List<CompetitionEntry> entries;
 
     Leaderboard(CompetitionType type) {
         this.type = type;
-        entries = new TreeSet<>();
+        entries = new ArrayList<>();
     }
 
     @Override
-    public TreeSet<CompetitionEntry> getEntries() {
-        return entries;
+        // Sort the list so the highest entry value is first
+        switch (type) {
+            case SHORTEST_FISH, SHORTEST_TOTAL -> {
+                return entries.stream()
+                        .sorted((e1, e2) -> Float.compare(e1.getValue(), e2.getValue()))
+                        .toList();
+            }
+            default -> {
+                return entries.stream()
+                        .sorted((e1, e2) -> Float.compare(e2.getValue(), e1.getValue()))
+                        .toList();
+            }
+        }
     }
 
     @Override
@@ -75,6 +86,7 @@ public class Leaderboard implements LeaderboardHandler {
 
     @Override
     public CompetitionEntry getEntry(UUID player) {
+        // Does not need to use the sorted list
         for (CompetitionEntry entry : entries) {
             if (entry.getPlayer().equals(player)) {
                 return entry;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 interface LeaderboardHandler {
 
-    Set<CompetitionEntry> getEntries();
+    TreeSet<CompetitionEntry> getEntries();
 
     void addEntry(UUID player, Fish fish);
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Leaderboard.java
@@ -43,7 +43,6 @@ public class Leaderboard implements LeaderboardHandler {
 
     @Override
     public List<CompetitionEntry> getEntries() {
-        // Sort the list so the highest entry value is first
         switch (type) {
             case SHORTEST_FISH, SHORTEST_TOTAL -> {
                 return entries.stream()

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
@@ -94,7 +94,7 @@ public class Leaderboard implements LeaderboardHandler {
 
     @Override
     public void removeEntry(CompetitionEntry entry) {
-        entries.removeIf(e -> e == entry);
+        entries.remove(entry);
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
@@ -1,42 +1,19 @@
-package com.oheers.fish.competition;
+package com.oheers.fish.competition.leaderboard;
 
+import com.oheers.fish.competition.CompetitionEntry;
+import com.oheers.fish.competition.CompetitionType;
 import com.oheers.fish.fishing.items.Fish;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-interface LeaderboardHandler {
-
-    List<CompetitionEntry> getEntries();
-
-    void addEntry(UUID player, Fish fish);
-
-    void addEntry(CompetitionEntry entry);
-
-    void clear();
-
-    boolean contains(CompetitionEntry entry);
-
-    CompetitionEntry getEntry(UUID player);
-
-    CompetitionEntry getEntry(int place);
-
-    int getSize();
-
-    boolean hasEntry(UUID player);
-
-    void removeEntry(CompetitionEntry entry) throws Exception;
-
-    CompetitionEntry getTopEntry();
-}
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 public class Leaderboard implements LeaderboardHandler {
 
     CompetitionType type;
     List<CompetitionEntry> entries;
 
-    Leaderboard(CompetitionType type) {
+    public Leaderboard(CompetitionType type) {
         this.type = type;
         entries = new ArrayList<>();
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/LeaderboardHandler.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/LeaderboardHandler.java
@@ -1,0 +1,33 @@
+package com.oheers.fish.competition.leaderboard;
+
+import com.oheers.fish.competition.CompetitionEntry;
+import com.oheers.fish.fishing.items.Fish;
+
+import java.util.*;
+
+public interface LeaderboardHandler {
+
+    List<CompetitionEntry> getEntries();
+
+    void addEntry(UUID player, Fish fish);
+
+    void addEntry(CompetitionEntry entry);
+
+    void clear();
+
+    boolean contains(CompetitionEntry entry);
+
+    CompetitionEntry getEntry(UUID player);
+
+    CompetitionEntry getEntry(int place);
+
+    int getSize();
+
+    boolean hasEntry(UUID player);
+
+    void removeEntry(CompetitionEntry entry) throws Exception;
+
+    CompetitionEntry getTopEntry();
+
+}
+

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/CompetitionConfig.java
@@ -114,16 +114,9 @@ public class CompetitionConfig extends ConfigBase {
     }
 
     public List<String> getDefaultPositionColours() {
-        // Exists for eventual MiniMessage support
-        if (true) {
-            return new ArrayList<>(
-                    List.of("&6", "&e", "&7", "&7", "&8"
-            ));
-        } else {
-            return new ArrayList<>(List.of(
-                    "<gold>", "<yellow>", "<gray>", "<gray>", "<dark_gray>"
-            ));
-        }
+        return new ArrayList<>(
+                List.of("&6", "&e", "&7", "&7", "&8"
+                ));
     }
 
     public List<String> getAlertTimes(String competitionName) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/FishFile.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/FishFile.java
@@ -34,7 +34,6 @@ public class FishFile extends ConfigBase {
                     int max = ingameSection.getInt("maxTime");
                     ingameSection.remove("minTime");
                     ingameSection.remove("maxTime");
-                    System.out.println(ingameSection.getRouteAsString());
                     getConfig().set("fish." + rarity + "." + fish + ".requirements.ingame-time", min + "-" + max);
                 }
                 Section irlSection = fishSection.getSection("requirements.irl-time");
@@ -43,7 +42,6 @@ public class FishFile extends ConfigBase {
                     String max = irlSection.getString("maxTime");
                     irlSection.remove("minTime");
                     irlSection.remove("maxTime");
-                    System.out.println(irlSection.getRouteAsString());
                     getConfig().set("fish." + rarity + "." + fish + ".requirements.irl-time", min + "-" + max);
                 }
             });

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/RaritiesFile.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/RaritiesFile.java
@@ -19,7 +19,6 @@ public class RaritiesFile extends ConfigBase {
             return;
         }
         mainSection.getRoutesAsStrings(false).forEach(rarity -> {
-            System.out.println(rarity);
             Section raritySection = getConfig().getSection("rarities." + rarity);
             if (raritySection == null) {
                 return;
@@ -30,7 +29,6 @@ public class RaritiesFile extends ConfigBase {
                 int max = ingameSection.getInt("maxTime");
                 ingameSection.remove("minTime");
                 ingameSection.remove("maxTime");
-                System.out.println(ingameSection.getRouteAsString());
                 getConfig().set("rarities." + rarity + ".requirements.ingame-time", min + "-" + max);
             }
             Section irlSection = raritySection.getSection("requirements.irl-time");
@@ -39,7 +37,6 @@ public class RaritiesFile extends ConfigBase {
                 String max = irlSection.getString("maxTime");
                 irlSection.remove("minTime");
                 irlSection.remove("maxTime");
-                System.out.println(irlSection.getRouteAsString());
                 getConfig().set("rarities." + rarity + ".requirements.irl-time", min + "-" + max);
             }
         });

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/DatabaseV3.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/DatabaseV3.java
@@ -3,7 +3,7 @@ package com.oheers.fish.database;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.CompetitionEntry;
-import com.oheers.fish.competition.Leaderboard;
+import com.oheers.fish.competition.leaderboard.Leaderboard;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.database.connection.ConnectionFactory;
 import com.oheers.fish.database.connection.MySqlConnectionFactory;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/DatabaseV3.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/DatabaseV3.java
@@ -259,7 +259,7 @@ public class DatabaseV3 {
                 prep.setString(1, competition.getCompetitionName());
                 if (leaderboard.getSize() > 0) {
                     prep.setString(2, leaderboard.getTopEntry().getPlayer().toString());
-                    Fish topFish = leaderboard.getPlaceFish(1);
+                    Fish topFish = leaderboard.getEntry(0).getFish();
                     prep.setString(3, topFish.getRarity().getValue() + ":" + topFish.getName());
                     prep.setFloat(4, leaderboard.getTopEntry().getValue());
                     StringBuilder contestants = new StringBuilder();


### PR DESCRIPTION
Cleans up some leaderboard code.

I have tested this, and it seems to work just fine :slightly_smiling_face: 

- Uses an ArrayList instead of a TreeSet
- Sorts that list every time Leaderboard#getEntries is called, instead of making that the responsibility of the Competition class
- Separates the Leaderboard class and LeaderboardHandler interface
- Removes redundant code
- Removes debug messages that were left in by accident