### PR TITLE
Fix PlaceholderAPI integration

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -555,7 +555,7 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         competitionQueue.load();
 
         if (sender != null) {
-            new Message(ConfigMessage.RELOAD_SUCCESS).broadcast(sender, false);
+            new Message(ConfigMessage.RELOAD_SUCCESS).broadcast(sender);
         }
 
     }
@@ -830,11 +830,11 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         // If it is enabled, disable it
         if (isCustomFishing(player)) {
             pdc.set(key, PersistentDataType.STRING, "false");
-            new Message(ConfigMessage.TOGGLE_OFF).broadcast(player, false);
+            new Message(ConfigMessage.TOGGLE_OFF).broadcast(player);
         // If it is disabled, enable it
         } else {
             pdc.set(key, PersistentDataType.STRING, "true");
-            new Message(ConfigMessage.TOGGLE_ON).broadcast(player, false);
+            new Message(ConfigMessage.TOGGLE_ON).broadcast(player);
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/SkullSaver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/SkullSaver.java
@@ -76,7 +76,7 @@ public class SkullSaver implements Listener {
         if (FishUtils.isFish(stack)) {
             if (MainConfig.getInstance().blockPlacingHeads()) {
                 event.setCancelled(true);
-                new Message(ConfigMessage.FISH_CANT_BE_PLACED).broadcast(event.getPlayer(), false);
+                new Message(ConfigMessage.FISH_CANT_BE_PLACED).broadcast(event.getPlayer());
                 return;
             }
             

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/UpdateChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/UpdateChecker.java
@@ -44,7 +44,7 @@ class UpdateNotify implements Listener {
         }
 
         if (event.getPlayer().hasPermission(AdminPerms.UPDATE_NOTIFY)) {
-            new Message(ConfigMessage.ADMIN_UPDATE_AVAILABLE).broadcast(event.getPlayer(), false);
+            new Message(ConfigMessage.ADMIN_UPDATE_AVAILABLE).broadcast(event.getPlayer());
         }
 
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
@@ -205,7 +205,7 @@ public class Bait {
         Message message = new Message(ConfigMessage.BAIT_USED);
         message.setBait(this.name);
         message.setBaitTheme(this.theme);
-        message.broadcast(player, true);
+        message.broadcast(player);
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitListener.java
@@ -45,7 +45,7 @@ public class BaitListener implements Listener {
         GameMode gameMode = event.getWhoClicked().getGameMode();
 
         if (!gameMode.equals(GameMode.SURVIVAL) && !gameMode.equals(GameMode.ADVENTURE)) {
-            new Message(ConfigMessage.BAIT_WRONG_GAMEMODE).broadcast(event.getWhoClicked(), false);
+            new Message(ConfigMessage.BAIT_WRONG_GAMEMODE).broadcast(event.getWhoClicked());
             return;
         }
 
@@ -67,14 +67,14 @@ public class BaitListener implements Listener {
             }
 
         } catch (MaxBaitsReachedException exception) {
-            new Message(ConfigMessage.BAITS_MAXED).broadcast(event.getWhoClicked(), false);
+            new Message(ConfigMessage.BAITS_MAXED).broadcast(event.getWhoClicked());
             result = exception.getRecoveryResult();
         } catch (MaxBaitReachedException exception) {
             result = exception.getRecoveryResult();
             Message message = new Message(ConfigMessage.BAITS_MAXED_ON_ROD);
             message.setBaitTheme(bait.getTheme());
             message.setBait(bait.getName());
-            message.broadcast(event.getWhoClicked(), true);
+            message.broadcast(event.getWhoClicked());
         }
 
         if (result == null || result.getFishingRod() == null)
@@ -132,7 +132,7 @@ public class BaitListener implements Listener {
         if (event.getSlot() == 2 && BaitNBTManager.isBaitedRod(inv.getItem(1))) {
             event.setCancelled(true);
             player.closeInventory();
-            new Message(ConfigMessage.BAIT_ROD_PROTECTION).broadcast(player, false);
+            new Message(ConfigMessage.BAIT_ROD_PROTECTION).broadcast(player);
             return true;
         }
         return false;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -46,7 +46,7 @@ public class AdminCommand extends BaseCommand {
     @Description("%desc_admin_fish")
     public void onFish(final CommandSender sender, final Rarity rarity, final Fish fish, @Optional @Default("1") @Conditions("limits:min=1") Integer quantity, @Optional OnlinePlayer player) {
         if (player == null && !(sender instanceof Player)) {
-            new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender, false);
+            new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender);
             return;
         }
 
@@ -70,7 +70,7 @@ public class AdminCommand extends BaseCommand {
         Message message = new Message(ConfigMessage.ADMIN_GIVE_PLAYER_FISH);
         message.setPlayer(target.getName());
         message.setFishCaught(fish.getName());
-        message.broadcast(sender, true);
+        message.broadcast(sender);
         //give fish to target
     }
 
@@ -135,7 +135,7 @@ public class AdminCommand extends BaseCommand {
                             @Default("1") @Conditions("limits:min=1") @Optional Integer amount
         ) {
             if (Competition.isActive()) {
-                new Message(ConfigMessage.COMPETITION_ALREADY_RUNNING).broadcast(sender, false);
+                new Message(ConfigMessage.COMPETITION_ALREADY_RUNNING).broadcast(sender);
                 return;
             }
 
@@ -161,7 +161,7 @@ public class AdminCommand extends BaseCommand {
                 return;
             }
 
-            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(sender, true);
+            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(sender);
         }
 
     }
@@ -170,7 +170,7 @@ public class AdminCommand extends BaseCommand {
     @Description("%desc_admin_nbtrod")
     public void onNbtRod(final CommandSender sender, @Optional Player player) {
         if (!MainConfig.getInstance().requireNBTRod()) {
-            new Message(ConfigMessage.ADMIN_NBT_NOT_REQUIRED).broadcast(sender, false);
+            new Message(ConfigMessage.ADMIN_NBT_NOT_REQUIRED).broadcast(sender);
             return;
         }
 
@@ -179,7 +179,7 @@ public class AdminCommand extends BaseCommand {
         if (player == null) {
             if (!(sender instanceof Player)) {
                 Message errorMessage = new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE);
-                errorMessage.broadcast(sender, false);
+                errorMessage.broadcast(sender);
                 return;
             }
 
@@ -189,7 +189,7 @@ public class AdminCommand extends BaseCommand {
         FishUtils.giveItems(Collections.singletonList(EvenMoreFish.getInstance().getCustomNBTRod()), player);
         giveMessage = new Message(ConfigMessage.ADMIN_NBT_ROD_GIVEN);
         giveMessage.setPlayer(player.getName());
-        giveMessage.broadcast(sender, true);
+        giveMessage.broadcast(sender);
     }
 
 
@@ -207,7 +207,7 @@ public class AdminCommand extends BaseCommand {
 
         if (player == null) {
             if (!(sender instanceof Player)) {
-                new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender, false);
+                new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender);
                 return;
             }
 
@@ -223,7 +223,7 @@ public class AdminCommand extends BaseCommand {
         Message message = new Message(ConfigMessage.ADMIN_GIVE_PLAYER_BAIT);
         message.setPlayer(player.player.getName());
         message.setBait(baitId);
-        message.broadcast(sender, true);
+        message.broadcast(sender);
     }
 
     private String getBaitIdFromName(final String baitName) {
@@ -240,7 +240,7 @@ public class AdminCommand extends BaseCommand {
     @Description("%desc_admin_clearbaits")
     public void onClearBaits(final CommandSender sender, @Optional Player player) {
         if (player == null && !(sender instanceof Player)) {
-            new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender, false);
+            new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender);
             return;
         }
 
@@ -249,13 +249,13 @@ public class AdminCommand extends BaseCommand {
         }
 
         if (player.getInventory().getItemInMainHand().getType() != Material.FISHING_ROD) {
-            new Message(ConfigMessage.ADMIN_NOT_HOLDING_ROD).broadcast(player, false);
+            new Message(ConfigMessage.ADMIN_NOT_HOLDING_ROD).broadcast(player);
             return;
         }
 
         ItemStack fishingRod = player.getInventory().getItemInMainHand();
         if (!BaitNBTManager.isBaitedRod(fishingRod)) {
-            new Message(ConfigMessage.NO_BAITS).broadcast(player, false);
+            new Message(ConfigMessage.NO_BAITS).broadcast(player);
             return;
         }
 
@@ -264,7 +264,7 @@ public class AdminCommand extends BaseCommand {
         fishingRod.setItemMeta(meta);
         Message message = new Message(ConfigMessage.BAITS_CLEARED);
         message.setAmount(Integer.toString(BaitNBTManager.deleteAllBaits(fishingRod)));
-        message.broadcast(player, true);
+        message.broadcast(player);
     }
 
 
@@ -286,7 +286,7 @@ public class AdminCommand extends BaseCommand {
             messageList.add(String.format(messageFormat, prefix, addonManager.isLoading(prefix)));
         }
 
-        new Message(messageList).broadcast(sender, false);
+        new Message(messageList).broadcast(sender);
     }
 
     @Subcommand("version")
@@ -310,7 +310,7 @@ public class AdminCommand extends BaseCommand {
         msgString += "Database Engine: " + getDatabaseVersion();
 
         Message msg = new Message(msgString);
-        msg.broadcast(sender, false);
+        msg.broadcast(sender);
     }
 
     private String getFeatureBranchName() {
@@ -384,7 +384,7 @@ public class AdminCommand extends BaseCommand {
     @CommandPermission(AdminPerms.MIGRATE)
     public void onMigrate(final CommandSender sender) {
         if (!MainConfig.getInstance().databaseEnabled()) {
-            new Message("You cannot run migrations when the database is disabled. Please set database.enabled: true. And restart the server.").broadcast(sender, false);
+            new Message("You cannot run migrations when the database is disabled. Please set database.enabled: true. And restart the server.").broadcast(sender);
             return;
         }
         EvenMoreFish.getScheduler().runTaskAsynchronously(() -> EvenMoreFish.getInstance().getDatabaseV3().migrateLegacy(sender));

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -68,7 +68,7 @@ public class AdminCommand extends BaseCommand {
         FishUtils.giveItems(Collections.singletonList(fishItem), target);
 
         Message message = new Message(ConfigMessage.ADMIN_GIVE_PLAYER_FISH);
-        message.setPlayer(target.getName());
+        message.setPlayer(target);
         message.setFishCaught(fish.getName());
         message.broadcast(sender);
         //give fish to target
@@ -188,7 +188,7 @@ public class AdminCommand extends BaseCommand {
 
         FishUtils.giveItems(Collections.singletonList(EvenMoreFish.getInstance().getCustomNBTRod()), player);
         giveMessage = new Message(ConfigMessage.ADMIN_NBT_ROD_GIVEN);
-        giveMessage.setPlayer(player.getName());
+        giveMessage.setPlayer(player);
         giveMessage.broadcast(sender);
     }
 
@@ -221,7 +221,7 @@ public class AdminCommand extends BaseCommand {
         baitItem.setAmount(quantity);
         FishUtils.giveItems(Collections.singletonList(baitItem), player.player);
         Message message = new Message(ConfigMessage.ADMIN_GIVE_PLAYER_BAIT);
-        message.setPlayer(player.player.getName());
+        message.setPlayer(player.player);
         message.setBait(baitId);
         message.broadcast(sender);
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -100,7 +100,7 @@ public class EMFCommand extends BaseCommand {
         if (sender.hasPermission(AdminPerms.ADMIN)) {
             new SellGUI(onlinePlayer.player, SellGUI.SellState.NORMAL, null).open();
             Message message = new Message(ConfigMessage.ADMIN_OPEN_FISH_SHOP);
-            message.setPlayer(onlinePlayer.player.getName());
+            message.setPlayer(onlinePlayer.player);
             message.broadcast(sender);
         }
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -29,7 +29,7 @@ public class EMFCommand extends BaseCommand {
     public void onNext(final CommandSender sender) {
         Message message = Competition.getNextCompetitionMessage();
         message.usePrefix(PrefixType.DEFAULT);
-        message.broadcast(sender, true);
+        message.broadcast(sender);
     }
 
     @Subcommand("toggle")
@@ -51,12 +51,12 @@ public class EMFCommand extends BaseCommand {
     @CommandPermission(UserPerms.HELP)
     @Description("%desc_general_help")
     public void onHelp(final CommandHelp help, final CommandSender sender) {
-        new Message(ConfigMessage.HELP_GENERAL_TITLE).broadcast(sender, false);
+        new Message(ConfigMessage.HELP_GENERAL_TITLE).broadcast(sender);
         help.getHelpEntries().forEach(helpEntry -> {
             Message helpMessage = new Message(ConfigMessage.HELP_FORMAT);
             helpMessage.setVariable("{command}", "/" + helpEntry.getCommand());
             helpMessage.setVariable("{description}", helpEntry.getDescription());
-            helpMessage.broadcast(sender, true);
+            helpMessage.broadcast(sender);
         });
     }
 
@@ -65,7 +65,7 @@ public class EMFCommand extends BaseCommand {
     @Description("%desc_general_top")
     public void onTop(final CommandSender sender) {
         if (!Competition.isActive()) {
-            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(sender, true);
+            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(sender);
             return;
         }
 
@@ -84,13 +84,13 @@ public class EMFCommand extends BaseCommand {
     @Description("%desc_general_shop")
     public void onShop(final CommandSender sender, @Optional final OnlinePlayer onlinePlayer) {
         if (MainConfig.getInstance().isEconomyDisabled()) {
-            new Message(ConfigMessage.ECONOMY_DISABLED).broadcast(sender, false);
+            new Message(ConfigMessage.ECONOMY_DISABLED).broadcast(sender);
             return;
         }
 
         if (onlinePlayer == null) {
             if (!(sender instanceof Player player)) {
-                new Message("&cYou must specify a player when running from console.").broadcast(sender, false);
+                new Message("&cYou must specify a player when running from console.").broadcast(sender);
                 return;
             }
             new SellGUI(player, SellGUI.SellState.NORMAL, null).open();
@@ -101,7 +101,7 @@ public class EMFCommand extends BaseCommand {
             new SellGUI(onlinePlayer.player, SellGUI.SellState.NORMAL, null).open();
             Message message = new Message(ConfigMessage.ADMIN_OPEN_FISH_SHOP);
             message.setPlayer(onlinePlayer.player.getName());
-            message.broadcast(sender, true);
+            message.broadcast(sender);
         }
     }
 
@@ -110,7 +110,7 @@ public class EMFCommand extends BaseCommand {
     @Description("%desc_general_sellall")
     public void onSellAll(final Player sender) {
         if (MainConfig.getInstance().isEconomyDisabled()) {
-            new Message(ConfigMessage.ECONOMY_DISABLED).broadcast(sender, false);
+            new Message(ConfigMessage.ECONOMY_DISABLED).broadcast(sender);
             return;
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -315,7 +315,7 @@ public class Competition {
                         message.setRarityColour(fish.getRarity().getColour());
                         message.setFishCaught(fish.getName());
                         message.setRarity(fish.getRarity().getValue());
-                        message.setPlayer(fisher.getName());
+                        message.setPlayer(fisher);
 
                         FishUtils.broadcastFishMessage(message, fisher.getPlayer(), isDoingFirstPlaceActionBar());
                     }
@@ -363,7 +363,7 @@ public class Competition {
                         message.setRarityColour(fish.getRarity().getColour());
                         message.setFishCaught(fish.getName());
                         message.setRarity(fish.getRarity().getValue());
-                        message.setPlayer(fisher.getName());
+                        message.setPlayer(fisher);
 
                         FishUtils.broadcastFishMessage(message, fisher.getPlayer(), isDoingFirstPlaceActionBar());
                     }
@@ -384,7 +384,7 @@ public class Competition {
                         message.setRarityColour(fish.getRarity().getColour());
                         message.setFishCaught(fish.getName());
                         message.setRarity(fish.getRarity().getValue());
-                        message.setPlayer(fisher.getName());
+                        message.setPlayer(fisher);
 
                         FishUtils.broadcastFishMessage(message, fisher.getPlayer(), isDoingFirstPlaceActionBar());
                     }
@@ -436,7 +436,7 @@ public class Competition {
             if (reachingCount) {
                 leaderboardMembers.add(entry.getPlayer());
                 Message message = new Message(ConfigMessage.LEADERBOARD_LARGEST_FISH);
-                message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()).getName());
+                message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()));
                 message.setPosition(Integer.toString(pos));
                 if (pos > competitionColours.size()) {
                     Random r = EvenMoreFish.getInstance().getRandom();
@@ -517,7 +517,7 @@ public class Competition {
                 if (entry.getPlayer() == player.getUniqueId()) {
                     Message message = new Message(ConfigMessage.LEADERBOARD_LARGEST_FISH);
                     message.setPosition(Integer.toString(pos));
-                    message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()).getName());
+                    message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()));
                     message.setPositionColour("&f");
 
                     switch (competitionType) {
@@ -609,7 +609,7 @@ public class Competition {
             pos++;
             leaderboardMembers.add(entry.getPlayer());
             Message message = new Message(ConfigMessage.LEADERBOARD_LARGEST_FISH);
-            message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()).getName());
+            message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()));
             message.setPosition(Integer.toString(pos));
             if (pos > competitionColours.size()) {
                 Random r = EvenMoreFish.getInstance().getRandom();
@@ -871,7 +871,7 @@ public class Competition {
 
     public void singleReward(Player player) {
         Message message = getTypeFormat(ConfigMessage.COMPETITION_SINGLE_WINNER);
-        message.setPlayer(player.getName());
+        message.setPlayer(player);
         message.setCompetitionType(competitionType);
 
         message.broadcast();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -73,7 +73,7 @@ public class Competition {
     public void begin(boolean adminStart) {
         try {
             if (!adminStart && EvenMoreFish.getInstance().getOnlinePlayersExcludingVanish().size() < playersNeeded) {
-                new Message(ConfigMessage.NOT_ENOUGH_PLAYERS).broadcast(true);
+                new Message(ConfigMessage.NOT_ENOUGH_PLAYERS).broadcast();
                 active = false;
                 return;
             }
@@ -134,7 +134,7 @@ public class Competition {
                 EMFCompetitionEndEvent endEvent = new EMFCompetitionEndEvent(this);
                 Bukkit.getServer().getPluginManager().callEvent(endEvent);
                 for (Player player : Bukkit.getOnlinePlayers()) {
-                    new Message(ConfigMessage.COMPETITION_END).broadcast(player, true);
+                    new Message(ConfigMessage.COMPETITION_END).broadcast(player);
                     sendPlayerLeaderboard(player);
                 }
                 handleRewards();
@@ -183,7 +183,7 @@ public class Competition {
     private boolean processCompetitionSecond(long timeLeft) {
         if (alertTimes.contains(timeLeft)) {
             Message message = getTypeFormat(ConfigMessage.TIME_ALERT);
-            message.broadcast(true);
+            message.broadcast();
         } else if (timeLeft <= 0) {
             end(false);
             return true;
@@ -407,7 +407,7 @@ public class Competition {
 
         startMessage = message;
 
-        message.broadcast(true);
+        message.broadcast();
 
         if (startSound != null) {
             Bukkit.getOnlinePlayers().forEach(player -> player.playSound(player.getLocation(), startSound, 10f, 1f));
@@ -418,12 +418,12 @@ public class Competition {
         boolean reachingCount = true;
 
         if (!active) {
-            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(player, true);
+            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(player);
             return;
         }
 
         if (leaderboard.getSize() == 0) {
-            new Message(ConfigMessage.NO_FISH_CAUGHT).broadcast(player, false);
+            new Message(ConfigMessage.NO_FISH_CAUGHT).broadcast(player);
             return;
         }
 
@@ -580,7 +580,7 @@ public class Competition {
         player.sendMessage(builder.toString());
         Message message = new Message(ConfigMessage.LEADERBOARD_TOTAL_PLAYERS);
         message.setAmount(Integer.toString(leaderboard.getSize()));
-        message.broadcast(player, true);
+        message.broadcast(player);
     }
 
     private void setPositionColour(int place, Message message) {
@@ -593,11 +593,11 @@ public class Competition {
 
     public void sendConsoleLeaderboard(ConsoleCommandSender console) {
         if (!active) {
-            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(console, true);
+            new Message(ConfigMessage.NO_COMPETITION_RUNNING).broadcast(console);
             return;
         }
         if (leaderboard.getSize() == 0) {
-            new Message(ConfigMessage.NO_FISH_CAUGHT).broadcast(console, false);
+            new Message(ConfigMessage.NO_FISH_CAUGHT).broadcast(console);
             return;
         }
 
@@ -675,7 +675,7 @@ public class Competition {
         console.sendMessage(builder.toString());
         Message message = new Message(ConfigMessage.LEADERBOARD_TOTAL_PLAYERS);
         message.setAmount(Integer.toString(leaderboard.getSize()));
-        message.broadcast(console, true);
+        message.broadcast(console);
     }
 
     public boolean chooseFish(String competitionName, boolean adminStart) {
@@ -821,7 +821,7 @@ public class Competition {
     private void handleRewards() {
         if (leaderboard.getSize() == 0) {
             if (!((competitionType == CompetitionType.SPECIFIC_FISH || competitionType == CompetitionType.SPECIFIC_RARITY) && numberNeeded == 1)) {
-                new Message(ConfigMessage.NO_WINNERS).broadcast(false);
+                new Message(ConfigMessage.NO_WINNERS).broadcast();
             }
             return;
         }
@@ -874,7 +874,7 @@ public class Competition {
         message.setPlayer(player.getName());
         message.setCompetitionType(competitionType);
 
-        message.broadcast(true);
+        message.broadcast();
 
         if (!rewards.isEmpty()) {
             for (Reward reward : rewards.get(1)) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
@@ -69,7 +69,7 @@ public class JoinChecker implements Listener {
             if (startMessage != null) {
                 startMessage.setMessage(ConfigMessage.COMPETITION_JOIN);
             }
-            EvenMoreFish.getScheduler().runTaskLater(() -> EvenMoreFish.getInstance().getActiveCompetition().getStartMessage().broadcast(event.getPlayer(), true), 20 * 3);
+            EvenMoreFish.getScheduler().runTaskLater(() -> EvenMoreFish.getInstance().getActiveCompetition().getStartMessage().broadcast(event.getPlayer()), 20 * 3);
         }
 
         EvenMoreFish.getScheduler().runTaskAsynchronously(() -> databaseRegistration(event.getPlayer().getUniqueId(), event.getPlayer().getName()));

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/MessageRewardType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/rewardtypes/MessageRewardType.java
@@ -12,7 +12,7 @@ public class MessageRewardType implements RewardType {
 
     @Override
     public void doReward(@NotNull Player player, @NotNull String key, @NotNull String value, Location hookLocation) {
-        new Message(value).broadcast(player, true);
+        new Message(value).broadcast(player);
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -132,7 +132,7 @@ public class Message {
         }
 
         if (sender instanceof Player player) {
-            this.relevantPlayer = player;
+            setPlayer(player);
         }
 
         variableFormat();
@@ -552,11 +552,20 @@ public class Message {
         } else this.message = this.message.replace("\n"+variable, "");
     }
 
+    public void setCanHidePrefix(boolean canHidePrefix) {
+        this.canHidePrefix = canHidePrefix;
+    }
+
+    public void setCanSilent(boolean canSilent) {
+        this.canSilent = canSilent;
+    }
+
     public Message createCopy() {
         Message newMessage = new Message(this.message);
+        newMessage.setPlayer(this.relevantPlayer);
         newMessage.setVariables(this.liveVariables);
-        newMessage.canHidePrefix = canHidePrefix;
-        newMessage.canSilent = canSilent;
+        newMessage.setCanHidePrefix(this.canHidePrefix);
+        newMessage.setCanSilent(this.canSilent);
         return newMessage;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -5,6 +5,7 @@ import com.oheers.fish.FishUtils;
 import com.oheers.fish.competition.CompetitionType;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -17,7 +18,7 @@ public class Message {
     private final Map<String, String> liveVariables = new LinkedHashMap<>();
     private String message;
     private boolean canSilent, canHidePrefix;
-    private Player relevantPlayer;
+    private OfflinePlayer relevantPlayer;
 
     /**
      * EMF system of sending messages. A raw message with variables is passed through the "message" parameter. Variables
@@ -287,9 +288,9 @@ public class Message {
      *
      * @param playerName The name of the player.
      */
-    public void setPlayer(@NotNull final String playerName) {
-        relevantPlayer = Bukkit.getPlayer(playerName);
-        setVariable("{player}", playerName);
+    public void setPlayer(@NotNull final OfflinePlayer player) {
+        relevantPlayer = player;
+        setVariable("{player}", Objects.requireNonNullElse(player.getName(), "N/A"));
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/migrate/LegacyToV3DatabaseMigration.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/migrate/LegacyToV3DatabaseMigration.java
@@ -136,14 +136,14 @@ public class LegacyToV3DatabaseMigration {
         if (!database.usingVersionV2()) {
             Message msg = new Message("EvenMoreFish is already using the latest V3 database engine.");
             msg.usePrefix(PrefixType.ERROR);
-            msg.broadcast(initiator, false);
+            msg.broadcast(initiator);
             return;
         }
         
         EvenMoreFish.getInstance().getLogger().info(() -> initiator.getName() + " has begun the migration to EMF database V3 from V2.");
         Message msg = new Message("Beginning conversion to V3 database engine.");
         msg.usePrefix(PrefixType.ADMIN);
-        msg.broadcast(initiator, false);
+        msg.broadcast(initiator);
         
         File oldDataFolder = new File(JavaPlugin.getProvidingPlugin(DatabaseV3.class).getDataFolder() + "/data/");
         File dataFolder = new File(JavaPlugin.getProvidingPlugin(DatabaseV3.class).getDataFolder() + "/data-archived/");
@@ -151,17 +151,17 @@ public class LegacyToV3DatabaseMigration {
         if (oldDataFolder.renameTo(dataFolder)) {
             Message message = new Message("Archived /data/ folder.");
             message.usePrefix(PrefixType.ADMIN);
-            message.broadcast(initiator, false);
+            message.broadcast(initiator);
         } else {
             Message message = new Message("Failed to archive /data/ folder. Cancelling migration. [No further information]");
             message.usePrefix(PrefixType.ADMIN);
-            message.broadcast(initiator, false);
+            message.broadcast(initiator);
             return;
         }
         
         Message fishReportMSG = new Message("Beginning FishReport migrations. This may take a while.");
         fishReportMSG.usePrefix(PrefixType.ADMIN);
-        fishReportMSG.broadcast(initiator, false);
+        fishReportMSG.broadcast(initiator);
         
         try {
             translateFishDataV2();
@@ -183,13 +183,13 @@ public class LegacyToV3DatabaseMigration {
                 
                 Message migratedMSG = new Message("Migrated " + reports.size() + " fish for: " + playerUUID);
                 migratedMSG.usePrefix(PrefixType.ADMIN);
-                migratedMSG.broadcast(initiator, false);
+                migratedMSG.broadcast(initiator);
             }
             
         } catch (NullPointerException | FileNotFoundException exception) {
             Message message = new Message("Fatal error whilst upgrading to V3 database engine.");
             message.usePrefix(PrefixType.ERROR);
-            message.broadcast(initiator, false);
+            message.broadcast(initiator);
             
             EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, "Critical SQL/interruption error whilst upgrading to v3 engine.", exception);
         } catch (IOException e) {
@@ -199,12 +199,12 @@ public class LegacyToV3DatabaseMigration {
         
         Message migratedMSG = new Message("Migration completed. Your database is now using the V3 database engine: to complete the migration, it is recommended to restart your server.");
         migratedMSG.usePrefix(PrefixType.ERROR);
-        migratedMSG.broadcast(initiator, false);
+        migratedMSG.broadcast(initiator);
         
         Message thankyou = new Message("Now that migration is complete, you will be able to use functionality in upcoming" +
             " updates such as quests, deliveries and a fish log. - Oheers");
         thankyou.usePrefix(PrefixType.ERROR);
-        thankyou.broadcast(initiator, false);
+        thankyou.broadcast(initiator);
 
         database.setUsingV2(false);
         //Run the rest of the migrations, and ensure it's properly setup.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -61,7 +61,7 @@ public class FishingProcessor implements Listener {
             //check if player have permssion to fish emf fishes
             if (!event.getPlayer().hasPermission(UserPerms.USE_ROD)) {
                 if (event.getState() == PlayerFishEvent.State.FISHING) {//send msg only when throw the lure
-                    new Message(ConfigMessage.NO_PERMISSION_FISHING).broadcast(event.getPlayer(), false);
+                    new Message(ConfigMessage.NO_PERMISSION_FISHING).broadcast(event.getPlayer());
                 }
                 return;
             }
@@ -155,7 +155,7 @@ public class FishingProcessor implements Listener {
                 message.setBaitTheme(caughtBait.getTheme());
                 message.setBait(caughtBait.getName());
                 message.setPlayer(player.getName());
-                message.broadcast(player, true);
+                message.broadcast(player);
 
                 return caughtBait.create(player);
             }
@@ -230,7 +230,7 @@ public class FishingProcessor implements Listener {
                 FishUtils.broadcastFishMessage(message, player, false);
             } else {
                 // sends it to just the fisher
-                message.broadcast(player, true);
+                message.broadcast(player);
             }
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -154,7 +154,7 @@ public class FishingProcessor implements Listener {
                 Message message = new Message(ConfigMessage.BAIT_CAUGHT);
                 message.setBaitTheme(caughtBait.getTheme());
                 message.setBait(caughtBait.getName());
-                message.setPlayer(player.getName());
+                message.setPlayer(player);
                 message.broadcast(player);
 
                 return caughtBait.create(player);
@@ -207,7 +207,7 @@ public class FishingProcessor implements Listener {
             String rarity = FishUtils.translateColorCodes(fish.getRarity().getValue());
 
             Message message = new Message(ConfigMessage.FISH_CAUGHT);
-            message.setPlayer(player.getName());
+            message.setPlayer(player);
             message.setRarityColour(fish.getRarity().getColour());
             message.setRarity(rarity);
             message.setLength(length);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -264,7 +264,7 @@ public class Fish implements Cloneable {
                 : ""
         );
 
-        if (!disableFisherman && getFishermanPlayer() != null) newLoreLine.setPlayer(getFishermanPlayer().getName());
+        if (!disableFisherman && getFishermanPlayer() != null) newLoreLine.setPlayer(getFishermanPlayer());
 
         newLoreLine.setVariable("{length_lore}",
             length > 0 ?

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
@@ -80,7 +80,7 @@ public class SellHelper {
         Message message = new Message(ConfigMessage.FISH_SALE);
         message.setSellPrice(formatWorth(sellPrice));
         message.setAmount(Integer.toString(fishCount));
-        message.setPlayer(this.player.toString());
+        message.setPlayer(this.player);
         message.broadcast(player);
 
         this.player.playSound(this.player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1.06f);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
@@ -81,7 +81,7 @@ public class SellHelper {
         message.setSellPrice(formatWorth(sellPrice));
         message.setAmount(Integer.toString(fishCount));
         message.setPlayer(this.player.toString());
-        message.broadcast(player, true);
+        message.broadcast(player);
 
         this.player.playSound(this.player.getLocation(), Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1.06f);
 


### PR DESCRIPTION
- Removes a redundant method
- The broadcast(CommandSender) method now sets the relevantPlayer variable when broadcasting
- The broadcast() method now creates a copy of the message class, and uses the broadcast(CommandSender) method on the copy

We create a copy when looping over all players to keep the original placeholders intact. All players now get placeholders related to themselves.