### PR TITLE
Small cleanup of the CompetitionType enum

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
@@ -39,17 +39,7 @@ public class Bar {
     }
 
     public void setPrefix(String prefix, CompetitionType type) {
-        String typeString = switch (type) {
-            case SPECIFIC_RARITY -> "Specific Rarity";
-            case MOST_FISH -> "Most Fish";
-            case LARGEST_FISH -> "Largest Fish";
-            case LARGEST_TOTAL -> "Largest Total";
-            case SPECIFIC_FISH -> "Specific Fish";
-            case RANDOM -> "Random";
-            case SHORTEST_FISH -> "Shortest Fish";
-            case SHORTEST_TOTAL -> "Shortest Total";
-        };
-        this.prefix = prefix.replace("{type}", typeString);
+        this.prefix = prefix.replace("{type}", type.getBarPrefix());
     }
 
     public void setPrefix(String prefix) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionType.java
@@ -1,12 +1,99 @@
 package com.oheers.fish.competition;
 
+import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.config.messages.ConfigMessage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
+
 public enum CompetitionType {
-    LARGEST_FISH,
-    SPECIFIC_FISH,
-    MOST_FISH,
-    SPECIFIC_RARITY,
-    LARGEST_TOTAL,
-    RANDOM,
-    SHORTEST_FISH,
-    SHORTEST_TOTAL
+    LARGEST_FISH(
+            ConfigMessage.COMPETITION_TYPE_LARGEST,
+            "Largest Fish",
+            false,
+            null
+    ),
+    SPECIFIC_FISH(
+            ConfigMessage.COMPETITION_TYPE_SPECIFIC,
+            "Specific Fish",
+            false,
+            Competition::chooseFish
+    ),
+    MOST_FISH(
+            ConfigMessage.COMPETITION_TYPE_MOST,
+            "Most Fish",
+            false,
+            null
+    ),
+    SPECIFIC_RARITY(
+            ConfigMessage.COMPETITION_TYPE_SPECIFIC_RARITY,
+            "Specific Rarity",
+            false,
+            Competition::chooseRarity
+    ),
+    LARGEST_TOTAL(
+            ConfigMessage.COMPETITION_TYPE_LARGEST_TOTAL,
+            "Largest Total",
+            false,
+            null
+    ),
+    RANDOM(
+            // Use largest here, as there's no option for RANDOM
+            ConfigMessage.COMPETITION_TYPE_LARGEST,
+            "Random",
+            false,
+            competition -> {
+                competition.competitionType = getRandomType();
+                Competition.originallyRandom = true;
+                return true;
+            }
+    ),
+    SHORTEST_FISH(
+            ConfigMessage.COMPETITION_TYPE_SHORTEST,
+            "Shortest Fish",
+            true,
+            null
+    ),
+    SHORTEST_TOTAL(
+            ConfigMessage.COMPETITION_TYPE_SHORTEST_TOTAL,
+            "Shortest Total",
+            true,
+            null
+    );
+
+    private final ConfigMessage typeVariable;
+    private final String barPrefix;
+    private final boolean shouldReverseLeaderboard;
+    private final Function<Competition, @NotNull Boolean> beginLogic;
+
+    CompetitionType(ConfigMessage typeVariable, String barPrefix, boolean shouldReverseLeaderboard, Function<Competition, @NotNull Boolean> beginLogic) {
+        this.typeVariable = typeVariable;
+        this.barPrefix = barPrefix;
+        this.shouldReverseLeaderboard = shouldReverseLeaderboard;
+        this.beginLogic = beginLogic;
+    }
+
+    public ConfigMessage getTypeVariable() {
+        return this.typeVariable;
+    }
+
+    public String getBarPrefix() {
+        return this.barPrefix;
+    }
+
+    public boolean shouldReverseLeaderboard() {
+        return this.shouldReverseLeaderboard;
+    }
+
+    public @Nullable Function<Competition, @NotNull Boolean> getBeginLogic() {
+        return this.beginLogic;
+    }
+
+    public static CompetitionType getRandomType() {
+        // -1 from the length so that the RANDOM isn't chosen as the random value.
+        int type = EvenMoreFish.getInstance().getRandom().nextInt(values().length - 1);
+        return values()[type];
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
@@ -20,18 +20,14 @@ public class Leaderboard implements LeaderboardHandler {
 
     @Override
     public List<CompetitionEntry> getEntries() {
-        switch (type) {
-            case SHORTEST_FISH, SHORTEST_TOTAL -> {
-                return entries.stream()
-                        .sorted((e1, e2) -> Float.compare(e1.getValue(), e2.getValue()))
-                        .toList();
-            }
-            default -> {
-                return entries.stream()
-                        .sorted((e1, e2) -> Float.compare(e2.getValue(), e1.getValue()))
-                        .toList();
-            }
+        if (type.shouldReverseLeaderboard()) {
+            return entries.stream()
+                    .sorted((e1, e2) -> Float.compare(e1.getValue(), e2.getValue()))
+                    .toList();
         }
+        return entries.stream()
+                .sorted((e1, e2) -> Float.compare(e2.getValue(), e1.getValue()))
+                .toList();
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/leaderboard/Leaderboard.java
@@ -1,10 +1,12 @@
 package com.oheers.fish.competition.leaderboard;
 
+import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.CompetitionEntry;
 import com.oheers.fish.competition.CompetitionType;
 import com.oheers.fish.fishing.items.Fish;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,13 +22,11 @@ public class Leaderboard implements LeaderboardHandler {
 
     @Override
     public List<CompetitionEntry> getEntries() {
-        if (type.shouldReverseLeaderboard()) {
-            return entries.stream()
-                    .sorted((e1, e2) -> Float.compare(e1.getValue(), e2.getValue()))
-                    .toList();
-        }
+        Comparator<CompetitionEntry> entryComparator = type.shouldReverseLeaderboard() ?
+                (e1, e2) -> Float.compare(e1.getValue(), e2.getValue()) :
+                (e1, e2) -> Float.compare(e2.getValue(), e1.getValue());
         return entries.stream()
-                .sorted((e1, e2) -> Float.compare(e2.getValue(), e1.getValue()))
+                .sorted(entryComparator)
                 .toList();
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -499,15 +499,7 @@ public class Message {
      * @param type The competition type.
      */
     public void setCompetitionType(@NotNull final CompetitionType type) {
-        switch (type) {
-            case MOST_FISH -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_MOST).getRawMessage(false));
-            case SPECIFIC_FISH -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_SPECIFIC).getRawMessage(false));
-            case SPECIFIC_RARITY -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_SPECIFIC_RARITY).getRawMessage(false));
-            case LARGEST_TOTAL -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_LARGEST_TOTAL).getRawMessage(false));
-            case SHORTEST_FISH -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_SHORTEST).getRawMessage(false));
-            case SHORTEST_TOTAL -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_SHORTEST_TOTAL).getRawMessage(false));
-            default -> setVariable("{type}", new Message(ConfigMessage.COMPETITION_TYPE_LARGEST).getRawMessage(false));
-        }
+        setVariable("{type}", new Message(type.getTypeVariable()).getRawMessage(false));
     }
 
     /**


### PR DESCRIPTION
Moves some type-specific code to the enum itself, like the bossbar prefix, or the checks at the start of a competition.

I have tested these changes and they seem to be working correctly.