### PR TITLE
Message Optimization

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -359,31 +359,31 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         manager.getCommandReplacements().addReplacement("duration", String.valueOf(MainConfig.getInstance().getCompetitionDuration() * 60));
         //desc_admin_<command>_<id>
         manager.getCommandReplacements().addReplacements(
-                "desc_admin_bait", new Message(ConfigMessage.HELP_ADMIN_BAIT).getRawMessage(true),
-                "desc_admin_competition", new Message(ConfigMessage.HELP_ADMIN_COMPETITION).getRawMessage(true),
-                "desc_admin_clearbaits", new Message(ConfigMessage.HELP_ADMIN_CLEARBAITS).getRawMessage(true),
-                "desc_admin_fish", new Message(ConfigMessage.HELP_ADMIN_FISH).getRawMessage(true),
-                "desc_admin_nbtrod", new Message(ConfigMessage.HELP_ADMIN_NBTROD).getRawMessage(true),
-                "desc_admin_reload", new Message(ConfigMessage.HELP_ADMIN_RELOAD).getRawMessage(true),
-                "desc_admin_version", new Message(ConfigMessage.HELP_ADMIN_VERSION).getRawMessage(true),
-                "desc_admin_migrate", new Message(ConfigMessage.HELP_ADMIN_MIGRATE).getRawMessage(true),
-                "desc_admin_rewardtypes", new Message(ConfigMessage.HELP_ADMIN_REWARDTYPES).getRawMessage(true),
-                "desc_admin_addons", new Message(ConfigMessage.HELP_ADMIN_ADDONS).getRawMessage(true),
+                "desc_admin_bait", new Message(ConfigMessage.HELP_ADMIN_BAIT).getRawMessage(),
+                "desc_admin_competition", new Message(ConfigMessage.HELP_ADMIN_COMPETITION).getRawMessage(),
+                "desc_admin_clearbaits", new Message(ConfigMessage.HELP_ADMIN_CLEARBAITS).getRawMessage(),
+                "desc_admin_fish", new Message(ConfigMessage.HELP_ADMIN_FISH).getRawMessage(),
+                "desc_admin_nbtrod", new Message(ConfigMessage.HELP_ADMIN_NBTROD).getRawMessage(),
+                "desc_admin_reload", new Message(ConfigMessage.HELP_ADMIN_RELOAD).getRawMessage(),
+                "desc_admin_version", new Message(ConfigMessage.HELP_ADMIN_VERSION).getRawMessage(),
+                "desc_admin_migrate", new Message(ConfigMessage.HELP_ADMIN_MIGRATE).getRawMessage(),
+                "desc_admin_rewardtypes", new Message(ConfigMessage.HELP_ADMIN_REWARDTYPES).getRawMessage(),
+                "desc_admin_addons", new Message(ConfigMessage.HELP_ADMIN_ADDONS).getRawMessage(),
 
-                "desc_list_fish", new Message(ConfigMessage.HELP_LIST_FISH).getRawMessage(true),
-                "desc_list_rarities", new Message(ConfigMessage.HELP_LIST_RARITIES).getRawMessage(true),
+                "desc_list_fish", new Message(ConfigMessage.HELP_LIST_FISH).getRawMessage(),
+                "desc_list_rarities", new Message(ConfigMessage.HELP_LIST_RARITIES).getRawMessage(),
 
-                "desc_competition_start", new Message(ConfigMessage.HELP_COMPETITION_START).getRawMessage(true),
-                "desc_competition_end", new Message(ConfigMessage.HELP_COMPETITION_END).getRawMessage(true),
+                "desc_competition_start", new Message(ConfigMessage.HELP_COMPETITION_START).getRawMessage(),
+                "desc_competition_end", new Message(ConfigMessage.HELP_COMPETITION_END).getRawMessage(),
 
-                "desc_general_top", new Message(ConfigMessage.HELP_GENERAL_TOP).getRawMessage(true),
-                "desc_general_help", new Message(ConfigMessage.HELP_GENERAL_HELP).getRawMessage(true),
-                "desc_general_shop", new Message(ConfigMessage.HELP_GENERAL_SHOP).getRawMessage(true),
-                "desc_general_toggle", new Message(ConfigMessage.HELP_GENERAL_TOGGLE).getRawMessage(true),
-                "desc_general_gui", new Message(ConfigMessage.HELP_GENERAL_GUI).getRawMessage(true),
-                "desc_general_admin", new Message(ConfigMessage.HELP_GENERAL_ADMIN).getRawMessage(true),
-                "desc_general_next", new Message(ConfigMessage.HELP_GENERAL_NEXT).getRawMessage(true),
-                "desc_general_sellall", new Message(ConfigMessage.HELP_GENERAL_SELLALL).getRawMessage(true)
+                "desc_general_top", new Message(ConfigMessage.HELP_GENERAL_TOP).getRawMessage(),
+                "desc_general_help", new Message(ConfigMessage.HELP_GENERAL_HELP).getRawMessage(),
+                "desc_general_shop", new Message(ConfigMessage.HELP_GENERAL_SHOP).getRawMessage(),
+                "desc_general_toggle", new Message(ConfigMessage.HELP_GENERAL_TOGGLE).getRawMessage(),
+                "desc_general_gui", new Message(ConfigMessage.HELP_GENERAL_GUI).getRawMessage(),
+                "desc_general_admin", new Message(ConfigMessage.HELP_GENERAL_ADMIN).getRawMessage(),
+                "desc_general_next", new Message(ConfigMessage.HELP_GENERAL_NEXT).getRawMessage(),
+                "desc_general_sellall", new Message(ConfigMessage.HELP_GENERAL_SELLALL).getRawMessage()
         );
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -318,20 +318,20 @@ public class FishUtils {
         if (hours > 0) {
             Message message = new Message(ConfigMessage.BAR_HOUR);
             message.setVariable("{hour}", String.valueOf(hours));
-            returning += message.getRawMessage(true) + " ";
+            returning += message.getRawMessage() + " ";
         }
 
         if (minutes > 0) {
             Message message = new Message(ConfigMessage.BAR_MINUTE);
             message.setVariable("{minute}", String.valueOf(minutes));
-            returning += message.getRawMessage(true) + " ";
+            returning += message.getRawMessage() + " ";
         }
 
         // Shows remaining seconds if seconds > 0 or hours and minutes are 0, e.g. "1 minutes and 0 seconds left" and "5 seconds left"
         if (seconds > 0 | (minutes == 0 & hours == 0)) {
             Message message = new Message(ConfigMessage.BAR_SECOND);
             message.setVariable("{second}", String.valueOf(seconds));
-            returning += message.getRawMessage(true) + " ";
+            returning += message.getRawMessage() + " ";
         }
 
         return returning;
@@ -356,7 +356,7 @@ public class FishUtils {
 
     public static void broadcastFishMessage(Message message, Player referencePlayer, boolean actionBar) {
 
-        String formatted = message.getRawMessage(true);
+        String formatted = message.getRawMessage();
 
         if (formatted.isEmpty()) {
             return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
@@ -1,7 +1,6 @@
 package com.oheers.fish;
 
 import com.oheers.fish.competition.Competition;
-import com.oheers.fish.competition.CompetitionEntry;
 import com.oheers.fish.competition.CompetitionType;
 import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
@@ -110,7 +109,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
 
         if (identifier.equalsIgnoreCase("competition_type")) {
             if (!Competition.isActive()) {
-                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING).getRawMessage();
             }
             return EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType().name();
         }
@@ -118,13 +117,13 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
         // %emf_competition_place_player_1% would return the player in first place of any possible competition.
         if (identifier.startsWith("competition_place_player_")) {
             if (!Competition.isActive()) {
-                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING).getRawMessage();
             }
             
             // checking the leaderboard actually contains the value of place
             int place = Integer.parseInt(identifier.substring(25));
             if (!leaderboardContainsPlace(place)) {
-                return new Message(ConfigMessage.PLACEHOLDER_NO_PLAYER_IN_PLACE).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_NO_PLAYER_IN_PLACE).getRawMessage();
             }
             
             // getting "place" place in the competition
@@ -142,17 +141,17 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
 
         if (identifier.startsWith("competition_place_size_")) {
             if (!Competition.isActive()) {
-                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING_SIZE).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING_SIZE).getRawMessage();
             }
             if (!(EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType() == CompetitionType.LARGEST_FISH ||
                 EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType() == CompetitionType.LARGEST_TOTAL)) {
-                return new Message(ConfigMessage.PLACEHOLDER_SIZE_DURING_MOST_FISH).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_SIZE_DURING_MOST_FISH).getRawMessage();
             }
             
             // checking the leaderboard actually contains the value of place
             int place = Integer.parseInt(identifier.substring(23));
             if (!leaderboardContainsPlace(place)) {
-                return new Message(ConfigMessage.PLACEHOLDER_NO_SIZE_IN_PLACE).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_NO_SIZE_IN_PLACE).getRawMessage();
             }
             
             // getting "place" place in the competition
@@ -172,14 +171,14 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
 
         if (identifier.startsWith("competition_place_fish_")) {
             if (!Competition.isActive()) {
-                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING_FISH).getRawMessage(false);
+                return new Message(ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING_FISH).getRawMessage();
             }
 
             int place = Integer.parseInt(identifier.substring(23));
             if (EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType() == CompetitionType.LARGEST_FISH) {
                 // checking the leaderboard actually contains the value of place
                 if (!leaderboardContainsPlace(place)) {
-                    return new Message(ConfigMessage.PLACEHOLDER_NO_FISH_IN_PLACE).getRawMessage(false);
+                    return new Message(ConfigMessage.PLACEHOLDER_NO_FISH_IN_PLACE).getRawMessage();
                 }
                 
                 // getting "place" place in the competition
@@ -211,7 +210,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
                         message.setRarity(fish.getRarity().getValue());
                     }
                     
-                    return message.getRawMessage(true);
+                    return message.getRawMessage();
                 }
                 
             } else {
@@ -224,12 +223,12 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
                 }
 
                 if (value == -1) {
-                    return new Message(ConfigMessage.PLACEHOLDER_NO_FISH_IN_PLACE).getRawMessage(false);
+                    return new Message(ConfigMessage.PLACEHOLDER_NO_FISH_IN_PLACE).getRawMessage();
                 }
                 
                 Message message = new Message(ConfigMessage.PLACEHOLDER_FISH_MOST_FORMAT);
                 message.setAmount(Integer.toString((int) value));
-                return message.getRawMessage(true);
+                return message.getRawMessage();
             }
             
         }
@@ -261,7 +260,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
         }
         
         if (identifier.equals("competition_time_left")) {
-            return Competition.getNextCompetitionMessage().getRawMessage(true);
+            return Competition.getNextCompetitionMessage().getRawMessage();
         }
 
         if (identifier.equals("competition_active")) {
@@ -274,9 +273,9 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
 
         if (identifier.equals("custom_fishing_status")) {
             if (plugin.isCustomFishing(player)) {
-                return new Message(ConfigMessage.CUSTOM_FISHING_ENABLED).getRawMessage(false);
+                return new Message(ConfigMessage.CUSTOM_FISHING_ENABLED).getRawMessage();
             } else {
-                return new Message(ConfigMessage.CUSTOM_FISHING_DISABLED).getRawMessage(false);
+                return new Message(ConfigMessage.CUSTOM_FISHING_DISABLED).getRawMessage();
             }
         }
         

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/Bait.java
@@ -123,25 +123,25 @@ public class Bait {
                     }
                     message.setAmount(Integer.toString(rarityList.size()));
                     message.setBaitTheme(theme);
-                    lore.add(message.getRawMessage(true));
+                    lore.add(message.getRawMessage());
                 }
 
                 if (!fishList.isEmpty()) {
                     Message message = new Message(BaitFile.getInstance().getBoostFishFormat());
                     message.setAmount(Integer.toString(fishList.size()));
                     message.setBaitTheme(theme);
-                    lore.add(message.getRawMessage(true));
+                    lore.add(message.getRawMessage());
                 }
 
             } else if (lineAddition.equals("{lore}")) {
                 BaitFile.getInstance().getLore(this.name).forEach(line -> {
                     Message message = new Message(line);
-                    lore.add(message.getRawMessage(true));
+                    lore.add(message.getRawMessage());
                 });
             } else {
                 Message message = new Message(lineAddition);
                 message.setBaitTheme(theme);
-                lore.add(message.getRawMessage(true));
+                lore.add(message.getRawMessage());
             }
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -365,7 +365,7 @@ public class BaitNBTManager {
                     Message message = new Message(BaitFile.getInstance().getBaitFormat());
                     message.setAmount(bait.split(":")[1]);
                     message.setBait(getBaitFormatted(bait.split(":")[0]));
-                    lore.add(message.getRawMessage(true));
+                    lore.add(message.getRawMessage());
                 }
 
                 if (BaitFile.getInstance().showUnusedBaitSlots()) {
@@ -377,7 +377,7 @@ public class BaitNBTManager {
                 Message message = new Message(lineAddition);
                 message.setCurrentBaits(Integer.toString(getNumBaitsApplied(itemStack)));
                 message.setMaxBaits(Integer.toString(BaitFile.getInstance().getMaxBaits()));
-                lore.add(message.getRawMessage(true));
+                lore.add(message.getRawMessage());
             }
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -362,7 +362,7 @@ public class AdminCommand extends BaseCommand {
     @Subcommand("rewardtypes")
     @Description("%desc_admin_rewardtypes")
     public void onRewardTypes(final CommandSender sender) {
-        TextComponent message = new TextComponent(new Message(ConfigMessage.ADMIN_LIST_REWARD_TYPES).getRawMessage(false));
+        TextComponent message = new TextComponent(new Message(ConfigMessage.ADMIN_LIST_REWARD_TYPES).getRawMessage());
         ComponentBuilder builder = new ComponentBuilder(message);
 
         RewardManager.getInstance().getRegisteredRewardTypes().forEach(rewardType -> {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Bar.java
@@ -54,8 +54,8 @@ public class Bar {
         Message layoutMessage = new Message(ConfigMessage.BAR_LAYOUT);
         layoutMessage.setVariable("{prefix}", prefix);
         layoutMessage.setVariable("{time-formatted}", FishUtils.translateColorCodes(FishUtils.timeFormat(timeLeft)));
-        layoutMessage.setVariable("{remaining}", new Message(ConfigMessage.BAR_REMAINING).getRawMessage(false));
-        bar.setTitle(layoutMessage.getRawMessage(true));
+        layoutMessage.setVariable("{remaining}", new Message(ConfigMessage.BAR_REMAINING).getRawMessage());
+        bar.setTitle(layoutMessage.getRawMessage());
     }
 
     public void show() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -487,7 +487,7 @@ public class Competition {
                         message.setAmount(Integer.toString((int) entry.getValue()));
                     }
                 }
-                builder.append(message.getRawMessage(true));
+                builder.append(message.getRawMessage());
 
                 if (pos == Messages.getInstance().getConfig().getInt("leaderboard-count")) {
                     if (Messages.getInstance().getConfig().getBoolean("always-show-pos")) {
@@ -562,7 +562,7 @@ public class Competition {
                         }
                     }
 
-                    builder.append("\n").append(message.getRawMessage(true));
+                    builder.append("\n").append(message.getRawMessage());
                 }
             }
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -118,7 +118,7 @@ public class Message {
      */
     public void broadcast() {
         // We need to create copies here to keep the original placeholders intact. Placeholders will now be parsed per-player.
-        Bukkit.getOnlinePlayers().forEach(player -> createCopy().broadcast(player));
+        Bukkit.getOnlinePlayers().forEach(this::broadcast);
     }
 
     /**
@@ -131,6 +131,8 @@ public class Message {
             return;
         }
 
+        String originalMessage = this.message;
+
         if (sender instanceof Player player) {
             setPlayer(player);
         }
@@ -142,6 +144,8 @@ public class Message {
         colourFormat();
 
         sender.sendMessage(this.message);
+
+        this.message = originalMessage;
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Message.java
@@ -191,11 +191,10 @@ public class Message {
      * This fetches the message straight from the messages.yml file and sends it back. It won't have been formatted unless
      * specified.
      *
-     * @param doVariables If variables should be formatted or not.
      * @return The raw value from messages.yml or the raw value passed through.
      */
-    public String getRawMessage(final boolean doVariables) {
-        if (doVariables) variableFormat();
+    public String getRawMessage() {
+        variableFormat();
 
         formatPlaceholderAPI();
 
@@ -210,11 +209,10 @@ public class Message {
      * the existing "message" string by \n characters to make a list which is then returned as a colour/variable formatted
      * list of strings (if requested to be formatted).
      *
-     * @param doVariables If variables should be formatted or not.
      * @return A list of formatted strings in the form of an ArrayList.
      */
-    public List<String> getRawListMessage(final boolean doVariables) {
-        if (doVariables) variableFormat();
+    public List<String> getRawListMessage() {
+        variableFormat();
         colourFormat();
 
         String[] list = this.message.split("\n");
@@ -503,7 +501,7 @@ public class Message {
      * @param type The competition type.
      */
     public void setCompetitionType(@NotNull final CompetitionType type) {
-        setVariable("{type}", new Message(type.getTypeVariable()).getRawMessage(false));
+        setVariable("{type}", new Message(type.getTypeVariable()).getRawMessage());
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/PrefixType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/PrefixType.java
@@ -29,7 +29,7 @@ public enum PrefixType {
     public String getPrefix() {
         if (id == null) return "";
         else {
-            return new Message(Messages.getInstance().getConfig().getString(id, normal)).getRawMessage(false);
+            return new Message(Messages.getInstance().getConfig().getString(id, normal)).getRawMessage();
         }
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -260,7 +260,7 @@ public class Fish implements Cloneable {
 
         newLoreLine.setVariable("{fisherman_lore}",
             !disableFisherman && getFishermanPlayer() != null ?
-                (new Message(ConfigMessage.FISHERMAN_LORE)).getRawMessage(false)
+                (new Message(ConfigMessage.FISHERMAN_LORE)).getRawMessage()
                 : ""
         );
 
@@ -268,7 +268,7 @@ public class Fish implements Cloneable {
 
         newLoreLine.setVariable("{length_lore}",
             length > 0 ?
-                (new Message(ConfigMessage.LENGTH_LORE)).getRawMessage(false)
+                (new Message(ConfigMessage.LENGTH_LORE)).getRawMessage()
                 : ""
         );
 
@@ -276,7 +276,7 @@ public class Fish implements Cloneable {
 
         newLoreLine.setRarity(this.rarity.getLorePrep());
 
-        List<String> newLore = Arrays.asList(newLoreLine.getRawMessage(true).split("\n"));
+        List<String> newLore = Arrays.asList(newLoreLine.getRawMessage().split("\n"));
         if (getFishermanPlayer() != null && EvenMoreFish.getInstance().isUsingPAPI()) {
             return newLore.stream().map(l -> PlaceholderAPI.setPlaceholders(getFishermanPlayer(), l)).collect(Collectors.toList());
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/GUIUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/GUIUtils.java
@@ -117,13 +117,13 @@ public class GUIUtils {
         if (section == null) {
             return new InventoryGui(
                     EvenMoreFish.getInstance(),
-                    new Message("&cBroken GUI! Please tell an admin!").getRawMessage(false),
+                    new Message("&cBroken GUI! Please tell an admin!").getRawMessage(),
                     new String[0]
             );
         }
         return new InventoryGui(
                 EvenMoreFish.getInstance(),
-                new Message(section.getString("title", "EvenMoreFish Inventory")).getRawMessage(false),
+                new Message(section.getString("title", "EvenMoreFish Inventory")).getRawMessage(),
                 section.getStringList("layout").toArray(new String[0])
         );
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
@@ -188,7 +188,7 @@ public class SellHelper {
             }
             case VAULT -> {
                 DecimalFormatSymbols symbols = new DecimalFormatSymbols(MainConfig.getInstance().getDecimalLocale());
-                DecimalFormat format = new DecimalFormat(new Message(ConfigMessage.SELL_PRICE_FORMAT).getRawMessage(false), symbols);
+                DecimalFormat format = new DecimalFormat(new Message(ConfigMessage.SELL_PRICE_FORMAT).getRawMessage(), symbols);
                 yield format.format(totalWorth);
             }
             // Includes NONE type

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemBuilder.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemBuilder.java
@@ -69,10 +69,10 @@ public class ItemBuilder {
             return stack;
         }
         if (this.display != null) {
-            meta.setDisplayName(new Message(this.display).getRawMessage(false));
+            meta.setDisplayName(new Message(this.display).getRawMessage());
         }
         if (!this.lore.isEmpty()) {
-            meta.setLore(new Message(this.lore).getRawListMessage(false));
+            meta.setLore(new Message(this.lore).getRawListMessage());
         }
         stack.setItemMeta(meta);
         if (this.glowing) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -530,7 +530,7 @@ public class ItemFactory {
         Message lore = new Message(loreConfig);
         lore.setVariables(replacements);
 
-        meta.setLore(lore.getRawListMessage(true));
+        meta.setLore(lore.getRawListMessage());
         product.setItemMeta(meta);
     }
 
@@ -552,7 +552,7 @@ public class ItemFactory {
                 } else {
                     Message display = new Message(displayName);
                     display.setVariables(replacements);
-                    meta.setDisplayName(display.getRawMessage(true));
+                    meta.setDisplayName(display.getRawMessage());
                 }
             }
 


### PR DESCRIPTION
Prevents needing to create a copy of the class when broadcasting to all players. This should be a bit better on performance, as we don't need to make a ton of new Message instances.

I left the createCopy method in case it's useful elsewhere.