### PR TITLE
Use VanishChecker for vanish checks

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -76,10 +76,6 @@ dependencies {
     compileOnly(libs.mcmmo)
     compileOnly(libs.headdatabase.api)
     compileOnly(libs.playerpoints)
-    compileOnly(libs.cmi.api)
-    compileOnly(libs.essx.api) {
-        exclude("org.spigotmc", "spigot-api")
-    }
 
     implementation(libs.nbt.api)
     implementation(libs.bstats)
@@ -88,6 +84,7 @@ dependencies {
     implementation(libs.inventorygui)
     implementation(libs.bundles.adventure)
     implementation(libs.boostedyaml)
+    implementation(libs.vanishchecker)
 
     library(libs.friendlyid)
     library(libs.flyway.core)
@@ -254,6 +251,7 @@ tasks {
         relocate("de.themoep.inventorygui", "com.oheers.fish.libs.inventorygui")
         relocate("net.kyori.adventure", "com.oheers.fish.libs.adventure")
         relocate("dev.dejvokep.boostedyaml", "com.oheers.fish.libs.boostedyaml")
+        relocate("uk.firedev.vanishchecker", "com.oheers.fish.libs.vanishchecker")
 
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -3,8 +3,6 @@ package com.oheers.fish;
 import co.aikar.commands.ConditionFailedException;
 import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.PaperCommandManager;
-import com.Zrips.CMI.Containers.CMIUser;
-import com.earth2me.essentials.Essentials;
 import com.github.Anon8281.universalScheduler.UniversalScheduler;
 import com.github.Anon8281.universalScheduler.scheduling.schedulers.TaskScheduler;
 import com.oheers.fish.addons.AddonManager;
@@ -779,45 +777,6 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         if (getEconomy() != null && getEconomy().isEnabled()) {
             new MoneyRewardType().register();
         }
-    }
-
-    /**
-     * Retrieves online players excluding those who are vanished.
-     *
-     * @return A list of online players excluding those who are vanished.
-     */
-    public List<Player> getOnlinePlayersExcludingVanish() {
-        List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
-
-        if (!MainConfig.getInstance().shouldRespectVanish()) {
-            return players;
-        }
-
-        // Check Essentials
-        if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
-            Plugin plugin = Bukkit.getPluginManager().getPlugin("Essentials");
-            if (plugin instanceof Essentials essentials) {
-                players = players.stream().filter(player -> !essentials.getUser(player).isVanished()).collect(Collectors.toList());
-            }
-        }
-
-        // Check CMI
-        if (Bukkit.getPluginManager().isPluginEnabled("CMI")) {
-            players = players.stream().filter(player -> !CMIUser.getUser(player).isVanished()).collect(Collectors.toList());
-        }
-
-        // Metadata check - A more generic way of checking if a player is vanished.
-        // SuperVanish, PremiumVanish, and VanishNoPacket support this according to the SuperVanish Spigot page.
-        players = players.stream().filter(player -> {
-            for (MetadataValue meta : player.getMetadata("vanished")) {
-                if (meta.asBoolean()) {
-                    return false;
-                }
-            }
-            return true;
-        }).collect(Collectors.toList());
-
-        return players;
     }
 
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -61,6 +61,7 @@ import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.vanishchecker.VanishChecker;
 
 import java.io.File;
 import java.util.*;
@@ -779,6 +780,9 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         }
     }
 
+    public List<Player> getVisibleOnlinePlayers() {
+        return MainConfig.getInstance().shouldRespectVanish() ? VanishChecker.getVisibleOnlinePlayers() : new ArrayList<>(Bukkit.getOnlinePlayers());
+    }
 
     // FISH TOGGLE METHODS
     // We use Strings here because Spigot 1.16.5 does not have PersistentDataType.BOOLEAN.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -76,7 +76,7 @@ public class Competition {
 
     public void begin(boolean adminStart) {
         try {
-            if (!adminStart && VanishChecker.getVisibleOnlinePlayers().size() < playersNeeded) {
+            if (!adminStart && EvenMoreFish.getInstance().getVisibleOnlinePlayers().size() < playersNeeded) {
                 new Message(ConfigMessage.NOT_ENOUGH_PLAYERS).broadcast();
                 active = false;
                 return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -24,6 +24,8 @@ import org.bukkit.boss.BarColor;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import uk.firedev.vanishchecker.VanishChecker;
+
 import java.util.function.Function;
 
 import java.time.Instant;
@@ -74,7 +76,7 @@ public class Competition {
 
     public void begin(boolean adminStart) {
         try {
-            if (!adminStart && EvenMoreFish.getInstance().getOnlinePlayersExcludingVanish().size() < playersNeeded) {
+            if (!adminStart && VanishChecker.getVisibleOnlinePlayers().size() < playersNeeded) {
                 new Message(ConfigMessage.NOT_ENOUGH_PLAYERS).broadcast();
                 active = false;
                 return;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,8 +60,8 @@ dependencyResolutionManagement {
 
             library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
             library("playerpoints", "org.black_ixx:playerpoints:3.2.7")
-            library("cmi-api", "CMI-API:CMI-API:9.7.0.1")
-            library("essx-api", "net.essentialsx:EssentialsX:2.20.1")
+
+            library("vanishchecker", "uk.firedev:VanishChecker:1.0.2")
 
             library("acf", "co.aikar:acf-paper:0.5.1-SNAPSHOT")
             library("inventorygui", "de.themoep:inventorygui:1.6.4-SNAPSHOT")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,7 +61,7 @@ dependencyResolutionManagement {
             library("universalscheduler", "com.github.Anon8281:UniversalScheduler:0.1.6")
             library("playerpoints", "org.black_ixx:playerpoints:3.2.7")
 
-            library("vanishchecker", "uk.firedev:VanishChecker:1.0.2")
+            library("vanishchecker", "uk.firedev:VanishChecker:1.0.3")
 
             library("acf", "co.aikar:acf-paper:0.5.1-SNAPSHOT")
             library("inventorygui", "de.themoep:inventorygui:1.6.4-SNAPSHOT")


### PR DESCRIPTION
Uses my VanishChecker library to handle competition start code.

I would like to remove CMI-API from my repo, and this change ensures CMI is still checked.