### PR TITLE
Initial 1.21.3 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ plugin
 With over 60 custom fish in the default configurations, and the ability to add your own, this is the best competition
 plugin for your server.
 
+---
+
 Supported Versions: 1.16.5, 1.17.1, 1.18.2, 1.19.4, 1.20.6, 1.21.1, 1.21.3 (Experimental, Dev Builds)
+
+If you encounter any issues with the plugin, please do the following before reporting the problem:
+- Create a Spigot or Paper test server using one of the supported versions.
+- Add the latest [dev build](https://ci.codemc.io/job/Oheers/job/EvenMoreFish/) to the server.
+- Test your issue.
+- If your issue is still happening, open a GitHub issue or send a message in the Discord server.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ plugin
 With over 60 custom fish in the default configurations, and the ability to add your own, this is the best competition
 plugin for your server.
 
+Supported Versions: 1.16.5, 1.17.1, 1.18.2, 1.19.4, 1.20.6, 1.21.1, 1.21.3 (Experimental, Dev Builds)
+
 ---
 
 ## ⭐ Features ⭐

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -19,6 +19,8 @@ description = "A fishing extension bringing an exciting new experience to fishin
 
 repositories {
     mavenCentral()
+    // Adventure Snapshots
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
     maven("https://hub.spigotmc.org/nexus/content/groups/public/")
     maven("https://github.com/deanveloper/SkullCreator/raw/mvn-repo/")
     maven("https://jitpack.io")

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/selling/SellHelper.java
@@ -9,6 +9,7 @@ import com.oheers.fish.config.messages.ConfigMessage;
 import com.oheers.fish.config.messages.Message;
 import com.oheers.fish.database.DataManager;
 import com.oheers.fish.fishing.items.Fish;
+import com.oheers.fish.utils.ItemUtils;
 import com.oheers.fish.utils.nbt.NbtKeys;
 import com.oheers.fish.utils.nbt.NbtUtils;
 import de.themoep.inventorygui.GuiStorageElement;
@@ -73,6 +74,10 @@ public class SellHelper {
         Economy economy = EvenMoreFish.getInstance().getEconomy();
         if (economy != null && economy.isEnabled()) {
             economy.deposit(this.player, totalWorth);
+        }
+
+        if (!(inventory instanceof PlayerInventory)) {
+            FishUtils.giveItems(Arrays.stream(inventory.getStorageContents()).filter(Objects::nonNull).toArray(ItemStack[]::new), this.player);
         }
 
         // sending the sell message to the player

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,7 +66,7 @@ dependencyResolutionManagement {
             library("acf", "co.aikar:acf-paper:0.5.1-SNAPSHOT")
             library("inventorygui", "de.themoep:inventorygui:1.6.4-SNAPSHOT")
 
-            plugin("shadow", "com.gradleup.shadow").version("8.3.1")
+            plugin("shadow", "com.gradleup.shadow").version("8.3.3")
             plugin("bukkit-yml", "net.minecrell.plugin-yml.bukkit").version("0.6.0")
 
             version("adventure", "4.17.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ dependencyResolutionManagement {
             library("griefprevention", "com.github.TechFortress:GriefPrevention:16.17.1")
 
             library("itemsadder-api", "com.github.LoneDev6:API-ItemsAdder:3.6.1")
-            library("nbt-api", "de.tr7zw:item-nbt-api:2.13.2")
+            library("nbt-api", "de.tr7zw:item-nbt-api:2.13.3-SNAPSHOT")
             library("denizen-api", "com.denizenscript:denizen:1.3.1-SNAPSHOT")
             library("oraxen", "io.th0rgal:oraxen:1.173.0") // We must use 1.173.0 as later versions require Java 21
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,7 +69,7 @@ dependencyResolutionManagement {
             plugin("shadow", "com.gradleup.shadow").version("8.3.3")
             plugin("bukkit-yml", "net.minecrell.plugin-yml.bukkit").version("0.6.0")
 
-            version("adventure", "4.17.0")
+            version("adventure", "4.18.0-SNAPSHOT")
             library("adventure-api", "net.kyori","adventure-api").versionRef("adventure")
             library("adventure-minimessage", "net.kyori","adventure-text-minimessage").versionRef("adventure")
             library("adventure-legacy", "net.kyori","adventure-text-serializer-legacy").versionRef("adventure")


### PR DESCRIPTION
Adds initial support for 1.21.3. This PR uses snapshot builds, so a release build should not be made with this.

- Updates NBT-API to 2.13.3-SNAPSHOT
- Updates Adventure to 4.18.0-SNAPSHOT
- Lists all supported versions in the README file
- Fixes an issue where non-fish would be deleted after a sale