### PR TITLE
Support custom biomes in RequirementTypes

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -27,6 +27,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.*;
+import org.bukkit.block.Biome;
 import org.bukkit.block.Skull;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -437,4 +438,27 @@ public class FishUtils {
             return defaultChar;
         }
     }
+
+    public static Biome getBiome(@NotNull String keyString) {
+        // Force lowercase
+        keyString = keyString.toLowerCase();
+        // If no namespace, assume minecraft
+        if (!keyString.contains(":")) {
+            keyString = "minecraft:" + keyString;
+        }
+        // Get the key and check if null
+        NamespacedKey key = NamespacedKey.fromString(keyString);
+        if (key == null) {
+            EvenMoreFish.getInstance().getLogger().severe(keyString + " is not a valid biome.");
+            return null;
+        }
+        // Get the biome and check if null
+        Biome biome = Registry.BIOME.get(key);
+        if (biome == null) {
+            EvenMoreFish.getInstance().getLogger().severe(keyString + " is not a valid biome.");
+            return null;
+        }
+        return biome;
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -2,6 +2,7 @@ package com.oheers.fish.config;
 
 import com.oheers.fish.Economy;
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.FishUtils;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import dev.dejvokep.boostedyaml.route.Route;
 import org.apache.commons.lang3.LocaleUtils;
@@ -238,11 +239,11 @@ public class MainConfig extends ConfigBase {
         section.getRoutesAsStrings(false).forEach(key -> {
             List<Biome> biomes = new ArrayList<>();
             section.getStringList(key).forEach(biomeString -> {
-                try {
-                    biomes.add(Biome.valueOf(biomeString));
-                } catch (IllegalArgumentException exception) {
+                Biome biome = FishUtils.getBiome(biomeString);
+                if (biome == null) {
                     EvenMoreFish.getInstance().getLogger().severe(biomeString + " is not a valid biome, found when loading in biome set " + key + ".");
                 }
+                biomes.add(biome);
             });
             biomeSetMap.put(key, biomes);
         });

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeRequirementType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeRequirementType.java
@@ -34,8 +34,8 @@ public class BiomeRequirementType implements RequirementType {
                     "default. The player may not have been given a fish if you see this message multiple times.");
             return false;
         }
-        List<Biome> biomes = new ArrayList<>();
-        values.forEach(value -> {
+        Biome hookBiome = location.getBlock().getBiome();
+        for (String value : values) {
             // Force lowercase
             value = value.toLowerCase();
             // If no namespace, assume minecraft
@@ -46,20 +46,19 @@ public class BiomeRequirementType implements RequirementType {
             NamespacedKey key = NamespacedKey.fromString(value);
             if (key == null) {
                 EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
-                return;
+                continue;
             }
             // Get the biome and check if null
             Biome biome = Registry.BIOME.get(key);
             if (biome == null) {
                 EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
-                return;
+                continue;
             }
-            // Add the biome to the check list
-            biomes.add(biome);
-        });
-        Biome hookBiome = location.getBlock().getBiome();
-        System.out.println(hookBiome.getKey());
-        return biomes.contains(hookBiome);
+            if (hookBiome.equals(biome)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeRequirementType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeRequirementType.java
@@ -4,6 +4,8 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.requirement.RequirementContext;
 import com.oheers.fish.api.requirement.RequirementType;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.plugin.Plugin;
@@ -34,13 +36,29 @@ public class BiomeRequirementType implements RequirementType {
         }
         List<Biome> biomes = new ArrayList<>();
         values.forEach(value -> {
-            try {
-                biomes.add(Biome.valueOf(value));
-            } catch (IllegalArgumentException exception) {
-                EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
+            // Force lowercase
+            value = value.toLowerCase();
+            // If no namespace, assume minecraft
+            if (!value.contains(":")) {
+                value = "minecraft:" + value;
             }
+            // Get the key and check if null
+            NamespacedKey key = NamespacedKey.fromString(value);
+            if (key == null) {
+                EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
+                return;
+            }
+            // Get the biome and check if null
+            Biome biome = Registry.BIOME.get(key);
+            if (biome == null) {
+                EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
+                return;
+            }
+            // Add the biome to the check list
+            biomes.add(biome);
         });
         Biome hookBiome = location.getBlock().getBiome();
+        System.out.println(hookBiome.getKey());
         return biomes.contains(hookBiome);
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeRequirementType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/BiomeRequirementType.java
@@ -1,6 +1,7 @@
 package com.oheers.fish.requirements;
 
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.FishUtils;
 import com.oheers.fish.api.requirement.RequirementContext;
 import com.oheers.fish.api.requirement.RequirementType;
 import org.bukkit.Location;
@@ -36,22 +37,8 @@ public class BiomeRequirementType implements RequirementType {
         }
         Biome hookBiome = location.getBlock().getBiome();
         for (String value : values) {
-            // Force lowercase
-            value = value.toLowerCase();
-            // If no namespace, assume minecraft
-            if (!value.contains(":")) {
-                value = "minecraft:" + value;
-            }
-            // Get the key and check if null
-            NamespacedKey key = NamespacedKey.fromString(value);
-            if (key == null) {
-                EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
-                continue;
-            }
-            // Get the biome and check if null
-            Biome biome = Registry.BIOME.get(key);
+            Biome biome = FishUtils.getBiome(value);
             if (biome == null) {
-                EvenMoreFish.getInstance().getLogger().severe(value + " is not a valid biome.");
                 continue;
             }
             if (hookBiome.equals(biome)) {


### PR DESCRIPTION
This change only works on 1.21.3 and above due to Spigot API changes introduced in 1.21.3.

- Adds support for custom biomes in BiomeRequirementType
- Adds support for custom biomes in BiomeSetRequirementType
- Adds FishUtils#getBiome(String) so we don't repeat any code

Example:
```
      requirements:
         biome:
          - jungle
          - minecraft:jungle # This works the same as jungle, you can use either format for vanilla biomes.
          - terralith:yellowstone
```