### PR TITLE
Add Raw NBT option for ItemFactory

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -21,6 +21,7 @@ import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.FishManager;
 import com.oheers.fish.fishing.items.Rarity;
 import com.oheers.fish.permissions.AdminPerms;
+import de.tr7zw.changeme.nbtapi.NBT;
 import net.md_5.bungee.api.chat.*;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.Bukkit;
@@ -396,4 +397,22 @@ public class AdminCommand extends BaseCommand {
         }
         EvenMoreFish.getScheduler().runTaskAsynchronously(() -> EvenMoreFish.getInstance().getDatabaseV3().migrateLegacy(sender));
     }
+
+    @Subcommand("rawItem")
+    @Description("Outputs this item's raw NBT form")
+    public void onRawItem(final CommandSender sender) {
+        if (!(sender instanceof Player player)) {
+            new Message(ConfigMessage.ADMIN_CANT_BE_CONSOLE).broadcast(sender);
+            return;
+        }
+        ItemStack handItem = player.getInventory().getItemInMainHand();
+        String handItemNbt = NBT.itemStackToNBT(handItem).toString();
+        TextComponent component = new TextComponent(handItemNbt);
+        component.setHoverEvent(new HoverEvent(
+                HoverEvent.Action.SHOW_TEXT, new Text(TextComponent.fromLegacyText("Click to copy to clipboard."))
+        ));
+        component.setClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, handItemNbt));
+        player.spigot().sendMessage(component);
+    }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -232,7 +232,7 @@ public class ItemFactory {
      */
     private ItemStack checkRaw() {
         // The fish has item.raw selected
-        String rawValue = this.configurationFile.getString(configLocation + "item.raw");
+        String rawValue = this.configurationFile.getString(configLocation + "item.raw-nbt");
         if (rawValue == null) {
             return null;
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -9,6 +9,7 @@ import com.oheers.fish.config.FishFile;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.Message;
 import de.tr7zw.changeme.nbtapi.NBT;
+import de.tr7zw.changeme.nbtapi.NbtApiException;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.bukkit.Material;
@@ -235,7 +236,17 @@ public class ItemFactory {
         if (rawValue == null) {
             return null;
         }
-        return NBT.itemStackFromNBT(NBT.parseNBT(rawValue));
+        ItemStack item = null;
+        try {
+            item = NBT.itemStackFromNBT(NBT.parseNBT(rawValue));
+        } catch (NbtApiException exception) {
+            EvenMoreFish.getInstance().getLogger().severe(configLocation + " has invalid raw NBT: " + rawValue);
+        }
+        if (item == null) {
+            return null;
+        }
+        rawMaterial = true;
+        return item;
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/utils/ItemFactory.java
@@ -8,6 +8,7 @@ import com.oheers.fish.config.BaitFile;
 import com.oheers.fish.config.FishFile;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.Message;
+import de.tr7zw.changeme.nbtapi.NBT;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.bukkit.Material;
@@ -112,6 +113,9 @@ public class ItemFactory {
      * @return The ItemStack of the item, with only skull metadata set if it's a player head.
      */
     public ItemStack getType(OfflinePlayer player) {
+
+        ItemStack raw = checkRaw();
+        if (raw != null) return raw;
 
         ItemStack material = checkMaterial();
         if (material != null) return material;
@@ -218,6 +222,20 @@ public class ItemFactory {
         }
 
         return null;
+    }
+
+    /**
+     * Checks for a value in the item.raw setting for the item.
+     *
+     * @return Null if the setting doesn't exist or is invalid, the item in ItemStack form if it does.
+     */
+    private ItemStack checkRaw() {
+        // The fish has item.raw selected
+        String rawValue = this.configurationFile.getString(configLocation + "item.raw");
+        if (rawValue == null) {
+            return null;
+        }
+        return NBT.itemStackFromNBT(NBT.parseNBT(rawValue));
     }
 
     /**


### PR DESCRIPTION
Closes #267 
This has a chance of breaking on server updates, however that is the server admin's responsibility to fix.

- Adds raw nbt as an option for item factory.
- Adds `/emf admin rawitem` to make raw items easy for server admins to copy.

Config is like this:
```
    Enchanted Sword:
      item:
        raw-nbt: '{components:{"minecraft:enchantments":{levels:{"minecraft:looting":3,"minecraft:mending":1,"minecraft:sharpness":5,"minecraft:unbreaking":3}}},count:1,id:"minecraft:netherite_sword"}'
```