### PR TITLE
Fixes up bugged up rods

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -178,6 +178,12 @@ public class BaitNBTManager {
             }
             NBT.modify(item, nbt -> {
                 ReadWriteNBT emfCompound = nbt.getOrCreateCompound(NbtKeys.EMF_COMPOUND);
+
+                // Fixes malformed nbt data to rods that had enchants, lore, or extra nbt data.
+                // This is only for backwards compatibility to fix bugged rods
+                if (combined.charAt(0) == ',')
+                    combined.deleteCharAt(0);
+
                 if (!combined.isEmpty()) {
                     emfCompound.setString(NbtKeys.EMF_APPLIED_BAIT, combined.toString());
                 } else {


### PR DESCRIPTION
Backwards Compatibility: Fixes bugged up rods. They became bugged up if they encountered a (now fixed) nbt conversion bug. The rod would have been enchanted, had lore, or extra nbt data. It was possible to apply baits to these rods, but it would not show up in the lore. The bait was also not consumed.

Before:
- emf-applied-bait:",Shrimp:5"

After:
- emf-applied-bait:"Shrimp:5"

We shouldn't be expecting a bait name to start with , so this should be fairly safe. 