### PR TITLE
Add GroupRequirementType

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/requirement/RequirementContext.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/requirement/RequirementContext.java
@@ -27,7 +27,7 @@ public class RequirementContext {
         this.configPath = configPath;
     }
 
-    public World getWorld() {
+    public @Nullable World getWorld() {
         return world;
     }
 
@@ -35,7 +35,7 @@ public class RequirementContext {
         this.world = world;
     }
 
-    public Location getLocation() {
+    public @Nullable Location getLocation() {
         return location;
     }
 
@@ -43,7 +43,7 @@ public class RequirementContext {
         this.config = config;
     }
 
-    public YamlDocument getConfig() {
+    public @Nullable YamlDocument getConfig() {
         return this.config;
     }
 
@@ -51,7 +51,7 @@ public class RequirementContext {
         this.configPath = configPath;
     }
 
-    public String getConfigPath() {
+    public @Nullable String getConfigPath() {
         return this.configPath;
     }
 
@@ -66,7 +66,7 @@ public class RequirementContext {
         this.world = location.getWorld();
     }
 
-    public Player getPlayer() {
+    public @Nullable Player getPlayer() {
         return player;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -747,6 +747,14 @@ public class EvenMoreFish extends JavaPlugin implements EMFPlugin {
         new RegionRequirementType().register();
         new WeatherRequirementType().register();
         new WorldRequirementType().register();
+
+        // Load Group RequirementType
+        if (isUsingVault()) {
+            RegisteredServiceProvider<Permission> rsp = getServer().getServicesManager().getRegistration(Permission.class);
+            if (rsp != null) {
+                new GroupRequirementType(rsp.getProvider()).register();
+            }
+        }
     }
 
     private void loadExternalRewardTypes() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/GroupRequirementType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/requirements/GroupRequirementType.java
@@ -1,0 +1,50 @@
+package com.oheers.fish.requirements;
+
+import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.api.requirement.RequirementContext;
+import com.oheers.fish.api.requirement.RequirementType;
+import net.milkbowl.vault.permission.Permission;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class GroupRequirementType implements RequirementType {
+
+    private final @NotNull Permission permission;
+
+    public GroupRequirementType(@NotNull Permission permission) {
+        this.permission = permission;
+    }
+
+    @Override
+    public boolean checkRequirement(@NotNull RequirementContext context, @NotNull List<String> values) {
+        Player player = context.getPlayer();
+        if (player == null) {
+            return false;
+        }
+        for (String value : values) {
+            if (permission.playerInGroup(player, value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "GROUP";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "FireML";
+    }
+
+    @Override
+    public @NotNull Plugin getPlugin() {
+        return EvenMoreFish.getInstance();
+    }
+
+}


### PR DESCRIPTION
Adds a requirement type for vault permission groups.

Tested using LuckPerms groups and all seems good.

Example Config:
```
    Atlantic Cod:
      requirements:
        group: fishgroup
```