### PR TITLE
Allow duration to be specified in the admin competition start command.

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -136,7 +136,7 @@ public class AdminCommand extends BaseCommand {
         @Subcommand("start")
         @CommandCompletion("@competitionId")
         @Description("%desc_competition_start")
-        public void onStart(final CommandSender sender, final String competitionId) {
+        public void onStart(final CommandSender sender, final String competitionId, @Optional @Conditions("limits:min=1") Integer duration) {
             if (Competition.isActive()) {
                 ConfigMessage.COMPETITION_ALREADY_RUNNING.getMessage().send(sender);
                 return;
@@ -149,6 +149,9 @@ public class AdminCommand extends BaseCommand {
             }
             Competition competition = new Competition(file);
             competition.setAdminStarted(true);
+            if (duration != null) {
+                competition.setMaxDuration(duration);
+            }
             EvenMoreFish.getInstance().setActiveCompetition(competition);
             competition.begin();
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -68,6 +68,10 @@ public class Competition {
         this.competitionType = type;
     }
 
+    public void setMaxDuration(int duration) {
+        this.maxDuration = duration  * 60L;
+    }
+
     public static boolean isActive() {
         return active;
     }


### PR DESCRIPTION
## Description
Title

---

### What has changed?
- `/emf admin competition start <competition-id>` now allows you to specify a duration.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.