### PR TITLE
Yet another competition cleanup

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -82,7 +82,6 @@ public class EvenMoreFish extends EMFPlugin {
     private boolean checkingIntEvent;
     // Do some fish in some rarities have the comp-check-exempt: true.
     private boolean raritiesCompCheckExempt = false;
-    private Competition active;
     private CompetitionQueue competitionQueue;
     private Logger logger;
     private PluginManager pluginManager;
@@ -235,7 +234,8 @@ public class EvenMoreFish extends EMFPlugin {
         saveUserData(false);
 
         // Ends the current competition in case the plugin is being disabled when the server will continue running
-        if (Competition.isActive()) {
+        Competition active = Competition.getCurrentlyActive();
+        if (active != null) {
             active.end(false);
         }
 
@@ -609,14 +609,6 @@ public class EvenMoreFish extends EMFPlugin {
 
     public void setRaritiesCompCheckExempt(boolean bool) {
         this.raritiesCompCheckExempt = bool;
-    }
-
-    public Competition getActiveCompetition() {
-        return active;
-    }
-
-    public void setActiveCompetition(Competition competition) {
-        this.active = competition;
     }
 
     public CompetitionQueue getCompetitionQueue() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -3,6 +3,7 @@ package com.oheers.fish;
 import br.net.fabiozumbi12.RedProtect.Bukkit.RedProtect;
 import br.net.fabiozumbi12.RedProtect.Bukkit.Region;
 import com.oheers.fish.api.adapter.AbstractMessage;
+import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.configs.CompetitionFile;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.ConfigMessage;
@@ -334,12 +335,13 @@ public class FishUtils {
     public static void broadcastFishMessage(AbstractMessage message, Player referencePlayer, boolean actionBar) {
 
         String formatted = message.getLegacyMessage();
+        Competition activeComp = Competition.getCurrentlyActive();
 
-        if (formatted.isEmpty()) {
+        if (formatted.isEmpty() || activeComp == null) {
             return;
         }
 
-        CompetitionFile activeCompetitionFile = EvenMoreFish.getInstance().getActiveCompetition().getCompetitionFile();
+        CompetitionFile activeCompetitionFile = activeComp.getCompetitionFile();
 
         int rangeSquared = activeCompetitionFile.getBroadcastRange(); // 10 blocks squared
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/PlaceholderReceiver.java
@@ -107,19 +107,21 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
             return "";
         }
 
+        Competition activeComp = Competition.getCurrentlyActive();
+
         if (identifier.equalsIgnoreCase("competition_type")) {
-            if (!Competition.isActive()) {
+            if (activeComp == null) {
                 return ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING.getMessage().getLegacyMessage();
             }
-            return EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType().name();
+            return activeComp.getCompetitionType().name();
         }
 
         if (identifier.equalsIgnoreCase("competition_type_format")) {
-            if (!Competition.isActive()) {
+            if (activeComp == null) {
                 return ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING.getMessage().getLegacyMessage();
             }
 
-            CompetitionType competitionType = EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType();
+            CompetitionType competitionType = activeComp.getCompetitionType();
             return switch (competitionType) {
                 case LARGEST_FISH -> ConfigMessage.COMPETITION_TYPE_LARGEST.getMessage().getLegacyMessage();
                 case LARGEST_TOTAL -> ConfigMessage.COMPETITION_TYPE_LARGEST_TOTAL.getMessage().getLegacyMessage();
@@ -134,20 +136,20 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
 
         // %emf_competition_place_player_1% would return the player in first place of any possible competition.
         if (identifier.startsWith("competition_place_player_")) {
-            if (!Competition.isActive()) {
+            if (activeComp == null) {
                 return ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING.getMessage().getLegacyMessage();
             }
             
             // checking the leaderboard actually contains the value of place
             int place = Integer.parseInt(identifier.substring(25));
-            if (!leaderboardContainsPlace(place)) {
+            if (!leaderboardContainsPlace(activeComp, place)) {
                 return ConfigMessage.PLACEHOLDER_NO_PLAYER_IN_PLACE.getMessage().getLegacyMessage();
             }
             
             // getting "place" place in the competition
             UUID uuid;
             try {
-                uuid = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getEntry(place).getPlayer();
+                uuid = activeComp.getLeaderboard().getEntry(place).getPlayer();
             } catch (NullPointerException exception) {
                 uuid = null;
             }
@@ -158,24 +160,24 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
         }
 
         if (identifier.startsWith("competition_place_size_")) {
-            if (!Competition.isActive()) {
+            if (activeComp == null) {
                 return ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING_SIZE.getMessage().getLegacyMessage();
             }
-            if (!(EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType() == CompetitionType.LARGEST_FISH ||
-                EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType() == CompetitionType.LARGEST_TOTAL)) {
+            if (!(activeComp.getCompetitionType() == CompetitionType.LARGEST_FISH ||
+                activeComp.getCompetitionType() == CompetitionType.LARGEST_TOTAL)) {
                 return ConfigMessage.PLACEHOLDER_SIZE_DURING_MOST_FISH.getMessage().getLegacyMessage();
             }
             
             // checking the leaderboard actually contains the value of place
             int place = Integer.parseInt(identifier.substring(23));
-            if (!leaderboardContainsPlace(place)) {
+            if (!leaderboardContainsPlace(activeComp, place)) {
                 return ConfigMessage.PLACEHOLDER_NO_SIZE_IN_PLACE.getMessage().getLegacyMessage();
             }
             
             // getting "place" place in the competition
             float value;
             try {
-                value = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getEntry(place).getValue();
+                value = activeComp.getLeaderboard().getEntry(place).getValue();
             } catch (NullPointerException exception) {
                 value = -1;
             }
@@ -188,21 +190,23 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
         }
 
         if (identifier.startsWith("competition_place_fish_")) {
-            if (!Competition.isActive()) {
+            if (activeComp == null) {
                 return ConfigMessage.PLACEHOLDER_NO_COMPETITION_RUNNING_FISH.getMessage().getLegacyMessage();
             }
 
             int place = Integer.parseInt(identifier.substring(23));
-            if (EvenMoreFish.getInstance().getActiveCompetition().getCompetitionType() == CompetitionType.LARGEST_FISH) {
+
+
+            if (activeComp.getCompetitionType() == CompetitionType.LARGEST_FISH) {
                 // checking the leaderboard actually contains the value of place
-                if (!leaderboardContainsPlace(place)) {
+                if (!leaderboardContainsPlace(activeComp, place)) {
                     return ConfigMessage.PLACEHOLDER_NO_FISH_IN_PLACE.getMessage().getLegacyMessage();
                 }
                 
                 // getting "place" place in the competition
                 Fish fish;
                 try {
-                    fish = EvenMoreFish.getInstance().getActiveCompetition().getLeaderboard().getEntry(place).getFish();
+                    fish = activeComp.getLeaderboard().getEntry(place).getFish();
                 } catch (NullPointerException exception) {
                     fish = null;
                 }
@@ -224,7 +228,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
                 // checking the leaderboard actually contains the value of place
                 float value;
                 try {
-                    value = Competition.leaderboard.getEntry(place).getValue();
+                    value = Competition.getCurrentlyActive().getLeaderboard().getEntry(place).getValue();
                 } catch (NullPointerException exception) {
                     value = -1;
                 }
@@ -290,7 +294,7 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
         return null;
     }
     
-    private boolean leaderboardContainsPlace(int place) {
-        return EvenMoreFish.getInstance().getActiveCompetition().getLeaderboardSize() >= place;
+    private boolean leaderboardContainsPlace(@NotNull Competition competition, int place) {
+        return competition.getLeaderboardSize() >= place;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -143,8 +143,7 @@ public class AdminCommand extends BaseCommand {
             }
             CompetitionFile file = EvenMoreFish.getInstance().getCompetitionQueue().getFileMap().get(competitionId);
             if (file == null) {
-                // TODO needs a proper message.
-                sender.sendMessage("That is not a valid competition id.");
+                ConfigMessage.INVALID_COMPETITION_ID.getMessage().send(sender);
                 return;
             }
             Competition competition = new Competition(file);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -149,7 +149,6 @@ public class AdminCommand extends BaseCommand {
             }
             Competition competition = new Competition(file);
             competition.setAdminStarted(true);
-            EvenMoreFish.getInstance().setActiveCompetition(competition);
             competition.begin();
         }
 
@@ -165,15 +164,15 @@ public class AdminCommand extends BaseCommand {
             CompetitionFile file = new CompetitionFile("adminTest", type, duration);
             Competition competition = new Competition(file);
             competition.setAdminStarted(true);
-            EvenMoreFish.getInstance().setActiveCompetition(competition);
             competition.begin();
         }
 
         @Subcommand("end")
         @Description("%desc_competition_end")
         public void onEnd(final CommandSender sender) {
-            if (Competition.isActive()) {
-                EvenMoreFish.getInstance().getActiveCompetition().end(false);
+            Competition active = Competition.getCurrentlyActive();
+            if (active != null) {
+                active.end(false);
                 return;
             }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -136,7 +136,7 @@ public class AdminCommand extends BaseCommand {
         @Subcommand("start")
         @CommandCompletion("@competitionId")
         @Description("%desc_competition_start")
-        public void onStart(final CommandSender sender, final String competitionId) {
+        public void onStart(final CommandSender sender, final String competitionId, @Optional @Conditions("limits:min=1") Integer duration) {
             if (Competition.isActive()) {
                 ConfigMessage.COMPETITION_ALREADY_RUNNING.getMessage().send(sender);
                 return;
@@ -149,6 +149,9 @@ public class AdminCommand extends BaseCommand {
             }
             Competition competition = new Competition(file);
             competition.setAdminStarted(true);
+            if (duration != null) {
+                competition.setMaxDuration(duration);
+            }
             competition.begin();
         }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -65,18 +65,20 @@ public class EMFCommand extends BaseCommand {
     @CommandPermission(UserPerms.TOP)
     @Description("%desc_general_top")
     public void onTop(final CommandSender sender) {
-        if (!Competition.isActive()) {
+        Competition active = Competition.getCurrentlyActive();
+
+        if (active == null) {
             ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(sender);
             return;
         }
 
         if (sender instanceof Player player) {
-            EvenMoreFish.getInstance().getActiveCompetition().sendPlayerLeaderboard(player);
+            active.sendPlayerLeaderboard(player);
             return;
         }
 
         if (sender instanceof ConsoleCommandSender consoleCommandSender) {
-            EvenMoreFish.getInstance().getActiveCompetition().sendConsoleLeaderboard(consoleCommandSender);
+            active.sendConsoleLeaderboard(consoleCommandSender);
         }
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/AutoRunner.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/AutoRunner.java
@@ -22,8 +22,7 @@ public class AutoRunner {
                 CompetitionQueue queue = EvenMoreFish.getInstance().getCompetitionQueue();
                 if (queue.competitions.containsKey(weekMinute)) {
                     if (!Competition.isActive()) {
-                        EvenMoreFish.getInstance().setActiveCompetition(queue.competitions.get(weekMinute));
-                        EvenMoreFish.getInstance().getActiveCompetition().begin();
+                        queue.competitions.get(weekMinute).begin();
                     }
                 }
             }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -69,6 +69,10 @@ public class Competition {
         this.competitionType = type;
     }
 
+    public void setMaxDuration(int duration) {
+        this.maxDuration = duration  * 60L;
+    }
+
     public static boolean isActive() {
         return getCurrentlyActive() != null;
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -43,8 +43,8 @@ public class Competition {
     private long timeLeft;
     private Bar statusBar;
     private long epochStartTime;
-    private List<Long> alertTimes;
-    private Map<Integer, List<Reward>> rewards;
+    private final List<Long> alertTimes;
+    private final Map<Integer, List<Reward>> rewards;
     private int playersNeeded;
     private Sound startSound;
     private MyScheduledTask timingSystem;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -287,6 +287,9 @@ public class Competition {
     }
 
     public void sendPlayerLeaderboard(Player player) {
+        if (player == null) {
+            return;
+        }
         if (!isActive()) {
             ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(player);
             return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -30,7 +30,7 @@ import java.util.logging.Level;
 public class Competition {
 
     private static Competition active;
-    private static boolean originallyRandom;
+    private boolean originallyRandom;
     private Leaderboard leaderboard;
     private CompetitionType competitionType;
     private Fish selectedFish;
@@ -77,8 +77,12 @@ public class Competition {
         return getCurrentlyActive() != null;
     }
 
-    public static void setOriginallyRandom(boolean originallyRandom) {
-        Competition.originallyRandom = originallyRandom;
+    public void setOriginallyRandom(boolean originallyRandom) {
+        this.originallyRandom = originallyRandom;
+    }
+
+    public boolean isOriginallyRandom() {
+        return this.originallyRandom;
     }
 
     public static @Nullable Competition getCurrentlyActive() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -310,7 +310,7 @@ public class Competition {
         message.send(player);
     }
 
-    public List<CompetitionEntry> getSortedEntries(List<CompetitionEntry> entries) {
+    public @NotNull List<CompetitionEntry> getSortedEntries(List<CompetitionEntry> entries) {
         if (competitionType == CompetitionType.SHORTEST_FISH) {
             entries.sort(Comparator.comparingDouble(entry -> entry.getFish().getLength()));
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -204,7 +204,7 @@ public class Competition {
      * @param configMessage The configmessage to use. Must have the {type} variable in it.
      * @return A message object that's pre-set to be compatible for the time remaining.
      */
-    private AbstractMessage getTypeFormat(ConfigMessage configMessage) {
+    private @NotNull AbstractMessage getTypeFormat(ConfigMessage configMessage) {
         return competitionType.getStrategy().getTypeFormat(this, configMessage);
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -429,11 +429,11 @@ public class Competition {
         }
     }
 
-    public Bar getStatusBar() {
+    public @NotNull Bar getStatusBar() {
         return this.statusBar;
     }
 
-    public CompetitionType getCompetitionType() {
+    public @NotNull CompetitionType getCompetitionType() {
         return competitionType;
     }
 
@@ -445,7 +445,7 @@ public class Competition {
         return leaderboard.getSize();
     }
 
-    public Leaderboard getLeaderboard() {
+    public @NotNull Leaderboard getLeaderboard() {
         return leaderboard;
     }
 
@@ -453,19 +453,19 @@ public class Competition {
         return startMessage;
     }
 
-    public String getCompetitionName() {
+    public @NotNull String getCompetitionName() {
         return competitionName;
     }
 
-    public CompetitionFile getCompetitionFile() {
+    public @NotNull CompetitionFile getCompetitionFile() {
         return this.competitionFile;
     }
 
-    public void setCompetitionName(String competitionName) {
+    public void setCompetitionName(@NotNull String competitionName) {
         this.competitionName = competitionName;
     }
 
-    public static AbstractMessage getNextCompetitionMessage() {
+    public static @NotNull AbstractMessage getNextCompetitionMessage() {
         if (Competition.isActive()) {
             return ConfigMessage.PLACEHOLDER_TIME_REMAINING_DURING_COMP.getMessage();
         }
@@ -499,19 +499,19 @@ public class Competition {
         this.competitionType = competitionType;
     }
 
-    public Fish getSelectedFish() {
+    public @Nullable Fish getSelectedFish() {
         return selectedFish;
     }
 
-    public void setSelectedFish(Fish selectedFish) {
+    public void setSelectedFish(@Nullable Fish selectedFish) {
         this.selectedFish = selectedFish;
     }
 
-    public Rarity getSelectedRarity() {
+    public @Nullable Rarity getSelectedRarity() {
         return selectedRarity;
     }
 
-    public void setSelectedRarity(Rarity selectedRarity) {
+    public void setSelectedRarity(@Nullable Rarity selectedRarity) {
         this.selectedRarity = selectedRarity;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -442,7 +442,7 @@ public class Competition {
         return leaderboard;
     }
 
-    public AbstractMessage getStartMessage() {
+    public @Nullable AbstractMessage getStartMessage() {
         return startMessage;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -317,7 +317,11 @@ public class Competition {
         return entries;
     }
 
-    private String buildLeaderboardMessage(List<CompetitionEntry> entries, List<String> competitionColours, boolean isConsole, UUID playerUuid) {
+    private @NotNull String buildLeaderboardMessage(List<CompetitionEntry> entries, List<String> competitionColours, boolean isConsole, UUID playerUuid) {
+        if (entries == null) {
+            entries = List.of();
+        }
+
         StringBuilder builder = new StringBuilder();
         int pos = 0;
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionStrategy.java
@@ -84,7 +84,7 @@ public interface CompetitionStrategy {
      * @param configMessage The configmessage to use. Must have the {type} variable in it.
      * @return A message object that's pre-set to be compatible for the time remaining.
      */
-    default AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
+    default @NotNull AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
         AbstractMessage message = configMessage.getMessage();
         message.setTimeFormatted(FishUtils.timeFormat(competition.getTimeLeft()));
         message.setTimeRaw(FishUtils.timeRaw(competition.getTimeLeft()));

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
@@ -67,13 +67,14 @@ public class JoinChecker implements Listener {
     // Gives the player the active fishing bar if there's a fishing event cracking off
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        if (Competition.isActive()) {
-            EvenMoreFish.getInstance().getActiveCompetition().getStatusBar().addPlayer(event.getPlayer());
-            AbstractMessage startMessage = EvenMoreFish.getInstance().getActiveCompetition().getStartMessage();
+        Competition activeComp = Competition.getCurrentlyActive();
+        if (activeComp != null) {
+            activeComp.getStatusBar().addPlayer(event.getPlayer());
+            AbstractMessage startMessage = activeComp.getStartMessage();
             if (startMessage != null) {
                 startMessage.setMessage(ConfigMessage.COMPETITION_JOIN.getMessage());
             }
-            EvenMoreFish.getScheduler().runTaskLater(() -> EvenMoreFish.getInstance().getActiveCompetition().getStartMessage().send(event.getPlayer()), 20 * 3);
+            EvenMoreFish.getScheduler().runTaskLater(() -> activeComp.getStartMessage().send(event.getPlayer()), 20 * 3);
         }
 
         EvenMoreFish.getScheduler().runTaskAsynchronously(() -> databaseRegistration(event.getPlayer().getUniqueId(), event.getPlayer().getName()));
@@ -83,8 +84,9 @@ public class JoinChecker implements Listener {
     @EventHandler
     public void onLeave(PlayerQuitEvent event) {
 
-        if (Competition.isActive()) {
-            EvenMoreFish.getInstance().getActiveCompetition().getStatusBar().removePlayer(event.getPlayer());
+        Competition activeComp = Competition.getCurrentlyActive();
+        if (activeComp != null) {
+            activeComp.getStatusBar().removePlayer(event.getPlayer());
         }
 
         if (!MainConfig.getInstance().isDatabaseOnline()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/JoinChecker.java
@@ -73,8 +73,8 @@ public class JoinChecker implements Listener {
             AbstractMessage startMessage = activeComp.getStartMessage();
             if (startMessage != null) {
                 startMessage.setMessage(ConfigMessage.COMPETITION_JOIN.getMessage());
+                EvenMoreFish.getScheduler().runTaskLater(() -> startMessage.send(event.getPlayer()), 20 * 3);
             }
-            EvenMoreFish.getScheduler().runTaskLater(() -> activeComp.getStartMessage().send(event.getPlayer()), 20 * 3);
         }
 
         EvenMoreFish.getScheduler().runTaskAsynchronously(() -> databaseRegistration(event.getPlayer().getUniqueId(), event.getPlayer().getName()));

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/RandomStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/RandomStrategy.java
@@ -19,7 +19,7 @@ public class RandomStrategy implements CompetitionStrategy {
     public boolean begin(Competition competition) {
         competition.setCompetitionType(getRandomType());
         this.randomType = competition.getCompetitionType();
-        Competition.setOriginallyRandom(true);
+        competition.setOriginallyRandom(true);
         return true;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/RandomStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/RandomStrategy.java
@@ -44,7 +44,7 @@ public class RandomStrategy implements CompetitionStrategy {
     }
 
     @Override
-    public AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
+    public @NotNull AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
         return randomType.getStrategy().getTypeFormat(competition, configMessage);
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
@@ -50,7 +50,7 @@ public class SpecificFishStrategy implements CompetitionStrategy {
     }
 
     @Override
-    public AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
+    public @NotNull AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
         AbstractMessage message = CompetitionStrategy.super.getTypeFormat(competition, configMessage);
         message.setAmount(Integer.toString(competition.getNumberNeeded()));
         message.setRarityColour(competition.getSelectedFish().getRarity().getColour());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificFishStrategy.java
@@ -28,9 +28,12 @@ public class SpecificFishStrategy implements CompetitionStrategy {
 
     @Override
     public void applyToLeaderboard(Fish fish, Player fisher, Leaderboard leaderboard, Competition competition) {
-        if (!fish.getName().equalsIgnoreCase(competition.getSelectedFish().getName()) ||
-                fish.getRarity() != competition.getSelectedFish().getRarity()) {
-            return;
+        Fish selected = competition.getSelectedFish();
+        if (selected != null) {
+            if (!fish.getName().equalsIgnoreCase(selected.getName()) ||
+                    fish.getRarity() != selected.getRarity()) {
+                return;
+            }
         }
 
         CompetitionEntry entry = leaderboard.getEntry(fisher.getUniqueId());
@@ -51,11 +54,14 @@ public class SpecificFishStrategy implements CompetitionStrategy {
 
     @Override
     public @NotNull AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
+        Fish selectedFish = competition.getSelectedFish();
         AbstractMessage message = CompetitionStrategy.super.getTypeFormat(competition, configMessage);
         message.setAmount(Integer.toString(competition.getNumberNeeded()));
-        message.setRarityColour(competition.getSelectedFish().getRarity().getColour());
-        message.setRarity(competition.getSelectedFish().getRarity().getDisplayName());
-        message.setFishCaught(competition.getSelectedFish().getDisplayName());
+        if (selectedFish != null) {
+            message.setRarityColour(selectedFish.getRarity().getColour());
+            message.setRarity(selectedFish.getRarity().getDisplayName());
+            message.setFishCaught(selectedFish.getDisplayName());
+        }
         return message;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
@@ -53,7 +53,7 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
     }
 
     @Override
-    public AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
+    public @NotNull AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
         final AbstractMessage message = CompetitionStrategy.super.getTypeFormat(competition, configMessage);
         message.setAmount(Integer.toString(competition.getNumberNeeded()));
         if (competition.getSelectedRarity() == null) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/strategies/SpecificRarityStrategy.java
@@ -26,8 +26,8 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
 
     @Override
     public void applyToLeaderboard(Fish fish, Player fisher, Leaderboard leaderboard, Competition competition) {
-        if (competition.getSelectedRarity() != null &&
-                !fish.getRarity().getValue().equals(competition.getSelectedRarity().getValue())) {
+        Rarity compRarity = competition.getSelectedRarity();
+        if (compRarity != null && !fish.getRarity().getValue().equals(compRarity.getValue())) {
             return; // Fish doesn't match the required rarity
         }
 
@@ -56,12 +56,13 @@ public class SpecificRarityStrategy implements CompetitionStrategy {
     public @NotNull AbstractMessage getTypeFormat(@NotNull Competition competition, ConfigMessage configMessage) {
         final AbstractMessage message = CompetitionStrategy.super.getTypeFormat(competition, configMessage);
         message.setAmount(Integer.toString(competition.getNumberNeeded()));
-        if (competition.getSelectedRarity() == null) {
+        Rarity selectedRarity = competition.getSelectedRarity();
+        if (selectedRarity == null) {
             EvenMoreFish.getInstance().getLogger().warning("Null rarity found. Please check your config files.");
             return message;
         }
-        message.setRarityColour(competition.getSelectedRarity().getColour());
-        message.setRarity(competition.getSelectedRarity().getDisplayName());
+        message.setRarityColour(selectedRarity.getColour());
+        message.setRarity(selectedRarity.getDisplayName());
 
         return message;
     }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
@@ -126,6 +126,7 @@ public enum ConfigMessage {
     HELP_COMPETITION_START("[noPrefix]Starts a competition of a specified duration", PrefixType.ADMIN, false, true, "help-competition.start"),
     HELP_COMPETITION_END("[noPrefix]Ends the current competition (if there is one)", PrefixType.ADMIN, false, true, "help-competition.end"),
     INVALID_COMPETITION_TYPE("&rThat isn't a type of competition type, available types: MOST_FISH, LARGEST_FISH, SPECIFIC_FISH", PrefixType.ADMIN, false, false, "admin.competition-type-invalid"),
+    INVALID_COMPETITION_ID("&rThat isn't a valid competition id.", PrefixType.ADMIN, false, false, "admin.competition-id-invalid"),
 
     LEADERBOARD_LARGEST_FISH(
             "&r#{position} | {pos_colour}{player} &r({rarity_colour}&l{rarity} {rarity_colour}{fish}&r, {length}cm&r)",

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/events/AuraSkillsFishingEvent.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/events/AuraSkillsFishingEvent.java
@@ -1,5 +1,6 @@
 package com.oheers.fish.events;
-import com.oheers.fish.EvenMoreFish;
+
+import com.oheers.fish.competition.Competition;
 import com.oheers.fish.config.MainConfig;
 import dev.aurelium.auraskills.api.event.loot.LootDropEvent;
 import org.bukkit.event.EventHandler;
@@ -12,7 +13,7 @@ public class AuraSkillsFishingEvent implements Listener {
         if (event.getCause() == LootDropEvent.Cause.FISHING_LUCK || event.getCause() == LootDropEvent.Cause.TREASURE_HUNTER || event.getCause() == LootDropEvent.Cause.FISHING_OTHER_LOOT || event.getCause() == LootDropEvent.Cause.EPIC_CATCH) {
             if (MainConfig.getInstance().disableAureliumSkills()) {
                 if (MainConfig.getInstance().isCompetitionUnique()) {
-                    if (EvenMoreFish.getInstance().getActiveCompetition() != null) {
+                    if (Competition.isActive()) {
                         event.setCancelled(true);
                     }
                 } else {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/events/AureliumSkillsFishingEvent.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/events/AureliumSkillsFishingEvent.java
@@ -3,6 +3,7 @@ package com.oheers.fish.events;
 import com.archyx.aureliumskills.api.event.LootDropCause;
 import com.archyx.aureliumskills.api.event.PlayerLootDropEvent;
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.competition.Competition;
 import com.oheers.fish.config.MainConfig;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -14,7 +15,7 @@ public class AureliumSkillsFishingEvent implements Listener {
         if (event.getCause() == LootDropCause.LUCKY_CATCH || event.getCause() == LootDropCause.TREASURE_HUNTER || event.getCause() == LootDropCause.EPIC_CATCH || event.getCause() == LootDropCause.FISHING_OTHER_LOOT) {
             if (MainConfig.getInstance().disableAureliumSkills()) {
                 if (MainConfig.getInstance().isCompetitionUnique()) {
-                    if (EvenMoreFish.getInstance().getActiveCompetition() != null) {
+                    if (Competition.isActive()) {
                         event.setCancelled(true);
                     }
                 } else {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/events/McMMOTreasureEvent.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/events/McMMOTreasureEvent.java
@@ -24,7 +24,7 @@ public class McMMOTreasureEvent implements Listener {
     public void mcmmoTreasure(McMMOReplaceVanillaTreasureEvent event) {
         if (MainConfig.getInstance().disableMcMMOTreasure()) {
             if (MainConfig.getInstance().isCompetitionUnique()) {
-                if (EvenMoreFish.getInstance().getActiveCompetition() != null) {
+                if (Competition.isActive()) {
                     event.setReplacementItemStack(event.getOriginalItem().getItemStack());
                 }
             } else {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -264,17 +264,18 @@ public class FishingProcessor implements Listener {
     }
 
     private void competitionCheck(Fish fish, Player fisherman, Location location) {
-        if (Competition.isActive()) {
-            List<World> competitionWorlds = EvenMoreFish.getInstance().getActiveCompetition().getCompetitionFile().getRequiredWorlds();
-            if (!competitionWorlds.isEmpty()) {
-                if (location.getWorld() != null) {
-                    if (!competitionWorlds.contains(location.getWorld())) {
-                        return;
-                    }
+        Competition active = Competition.getCurrentlyActive();
+        if (active == null) {
+            return;
+        }
+        List<World> competitionWorlds = active.getCompetitionFile().getRequiredWorlds();
+        if (!competitionWorlds.isEmpty()) {
+            if (location.getWorld() != null) {
+                if (!competitionWorlds.contains(location.getWorld())) {
+                    return;
                 }
             }
-
-            EvenMoreFish.getInstance().getActiveCompetition().applyToLeaderboard(fish, fisherman);
         }
+        active.applyToLeaderboard(fish, fisherman);
     }
 }

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -232,8 +232,10 @@ admin:
 
   # Sent when a competition is already running when using /emf admin competition start
   competition-already-running: "&rThere's already a competition running."
-  # When an invalid competition type is tried to be started
+  # When an invalid competition type is provided
   competition-type-invalid: "&rThat isn't a type of competition type, available types: MOST_FISH, LARGEST_FISH, SPECIFIC_FISH"
+  # When an invalid competition id is provided
+  competition-id-invalid: "&rThat isn't a valid competition id."
 
   # When the command /emf admin nbt-rod is run.
   nbt-rod-given: "&rYou have given {player} a NBT rod, make sure \"require-nbt-rod\" is set to &atrue &rfor this to be different from any other fishing rod."
@@ -249,4 +251,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 7
+config-version: 8


### PR DESCRIPTION
## Description
Cleans up the Competition class

---

### What has changed?
- `/emf admin competition start <competition-id>` now allows you to specify a duration.
- The `active` variable is now a Competition instance, code has been updated to match this.
- Removed EvenMoreFish#getActiveCompetition.
- The `originallyRandom` variable is no longer static.
- Set some variables to final.
- Added Nullable and NotNull annotations to all getters, and updated their usages to reflect this.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.