### PR TITLE
Add a removal notice for SpigotAdapter

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -352,6 +352,8 @@ public class EvenMoreFish extends EMFPlugin {
         }));
 
         metrics.addCustomChart(new SimplePie("database", () -> MainConfig.getInstance().databaseEnabled() ? "true" : "false"));
+
+        metrics.addCustomChart(new SimplePie("paper-adapter", () -> (platformAdapter instanceof PaperAdapter) ? "true" : "false"));
     }
 
     private void loadCommandManager() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotAdapter.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotAdapter.java
@@ -18,7 +18,7 @@ public class SpigotAdapter extends PlatformAdapter {
         Logger logger = EMFPlugin.getInstance().getLogger();
         logger.info("Using API provided by Spigot.");
         logger.warning("Support for Spigot servers will be removed in the future in favour of Paper.");
-        logger.warning("Paper is a drop-in replacement, and you can download it here: https://papermc.io/downloads/paper");
+        logger.warning("You can download Paper here: https://papermc.io/downloads/paper");
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotAdapter.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/adapter/SpigotAdapter.java
@@ -5,6 +5,7 @@ import com.oheers.fish.api.plugin.EMFPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 public class SpigotAdapter extends PlatformAdapter {
 
@@ -14,7 +15,10 @@ public class SpigotAdapter extends PlatformAdapter {
 
     @Override
     public void logLoadedMessage() {
-        EMFPlugin.getInstance().getLogger().info("Using API provided by Spigot.");
+        Logger logger = EMFPlugin.getInstance().getLogger();
+        logger.info("Using API provided by Spigot.");
+        logger.warning("Support for Spigot servers will be removed in the future in favour of Paper.");
+        logger.warning("Paper is a drop-in replacement, and you can download it here: https://papermc.io/downloads/paper");
     }
 
     @Override


### PR DESCRIPTION
## Description
Warns Spigot servers about us eventually dropping Spigot support.

Before this is merged, a simple pie with the id `paper-adapter` needs to be added to EMF's bStats page.

---

### What has changed?
- SpigotAdapter now warns about the future removal.
- Added a bStats chart to see how many servers are using the PaperAdapter

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.