### PR TITLE
Message Fixes

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/adapter/AbstractMessage.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/adapter/AbstractMessage.java
@@ -23,7 +23,8 @@ public abstract class AbstractMessage {
     }
 
     protected AbstractMessage(@NotNull final List<String> messageList, @NotNull PlatformAdapter platformAdapter) {
-        this.message = String.join("\n", messageList.stream().map(this::formatColours).toList());
+        String reset = formatColours("&r");
+        this.message = String.join( reset + "\n", messageList.stream().map(this::formatColours).toList());
         this.platformAdapter = platformAdapter;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
@@ -291,7 +291,7 @@ public enum ConfigMessage {
     }
 
     public boolean isListForm() {
-        return this.normal == null;
+        return !Messages.getInstance().getConfig().getStringList(getId()).isEmpty();
     }
 
     public PrefixType getPrefixType() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/PrefixType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/PrefixType.java
@@ -33,7 +33,9 @@ public enum PrefixType {
         if (id == null) {
             return EvenMoreFish.getAdapter().createMessage("");
         } else {
-            return EvenMoreFish.getAdapter().createMessage(Messages.getInstance().getConfig().getString(id, normal));
+            AbstractMessage message = EvenMoreFish.getAdapter().createMessage(Messages.getInstance().getConfig().getString(id, normal));
+            message.appendString("&r");
+            return message;
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes a few issues I found with Messages

---

### What has changed?
- ConfigMessage#isListForm now checks the config file instead of its internal default, fixes multi-line messages not working.
- PrefixType#getPrefix now applies a reset character after itself, fixes an issue with multi-line messages.
- The AbstractMessage list constructor now applies a reset character at the end of every line, fixes style persistence issues in item lore.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.