### PR TITLE
Update NBT-API to 2.14.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ plugin for your server.
 
 ---
 
-Supported Versions: 1.18.2, 1.19.4, 1.20.6, 1.21.1, 1.21.3 (Experimental, Dev Builds)
+Supported Versions: 1.18.2, 1.19.4, 1.20.6, 1.21.1, 1.21.4 (Experimental, Dev Builds)
 
 If you encounter any issues with the plugin, please do the following before reporting the problem:
 - Create a Spigot or Paper test server using one of the supported versions.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
             library("griefprevention", "com.github.TechFortress:GriefPrevention:16.17.1")
 
             library("itemsadder-api", "com.github.LoneDev6:API-ItemsAdder:3.6.1")
-            library("nbt-api", "de.tr7zw:item-nbt-api:2.13.3-SNAPSHOT")
+            library("nbt-api", "de.tr7zw:item-nbt-api:2.14.1")
             library("denizen-api", "com.denizenscript:denizen:1.3.1-SNAPSHOT")
             library("oraxen", "io.th0rgal:oraxen:1.173.0") // We must use 1.173.0 as later versions require Java 21
 


### PR DESCRIPTION
## Description
Adds support for Minecraft 1.21.4

---

### What has changed?
- Updated NBT-API from 2.13.3-SNAPSHOT to 2.14.1

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.