### PR TITLE
Fix exceptions in BaitNBTManager

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -385,7 +385,12 @@ public class BaitNBTManager {
                 for (String bait : rodNBT.split(",")) {
                     baitCount++;
                     AbstractMessage message = EvenMoreFish.getAdapter().createMessage(BaitFile.getInstance().getBaitFormat());
-                    message.setAmount(bait.split(":")[1]);
+                    // TODO this is to prevent an ArrayIndexOutOfBoundsException, but it should be handled in a better way.
+                    try {
+                        message.setAmount(bait.split(":")[1]);
+                    } catch (ArrayIndexOutOfBoundsException exception) {
+                        message.setAmount("N/A");
+                    }
                     message.setBait(getBaitFormatted(bait.split(":")[0]));
                     lore.add(message.getLegacyMessage());
                 }
@@ -474,4 +479,5 @@ public class BaitNBTManager {
         }
         return FishUtils.translateColorCodes(bait.getDisplayName());
     }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -251,12 +251,7 @@ public class BaitNBTManager {
             return null;
         }
 
-        double totalWeight = 0;
-
-        // Weighted random logic (nabbed from stackoverflow)
-        for (Bait bait : baitList) {
-            totalWeight += (bait.getApplicationWeight());
-        }
+        double totalWeight = baitList.stream().mapToDouble(Bait::getApplicationWeight).sum();
 
         int idx = 0;
         for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {
@@ -275,7 +270,6 @@ public class BaitNBTManager {
      * @return A random bait weighted by its catch-weight.
      */
     public static @Nullable Bait randomBaitCatch() {
-        double totalWeight = 0;
 
         Map<String, Bait> baitMap = BaitManager.getInstance().getBaitMap();
         List<Bait> baitList = new ArrayList<>(baitMap.values());
@@ -285,10 +279,7 @@ public class BaitNBTManager {
             return null;
         }
 
-        // Weighted random logic (nabbed from stackoverflow)
-        for (Bait bait : baitList) {
-            totalWeight += (bait.getCatchWeight());
-        }
+        double totalWeight = baitList.stream().mapToDouble(Bait::getCatchWeight).sum();
 
         int idx = 0;
         for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -228,9 +228,8 @@ public class BaitNBTManager {
      * @param fishingRod The fishing rod.
      * @return A random bait applied to the fishing rod.
      */
-    // TODO look into why this throws IndexOutOfBoundsException
     public static @Nullable Bait randomBaitApplication(ItemStack fishingRod) {
-        if (fishingRod.getItemMeta() == null) {
+        if (fishingRod == null || fishingRod.getItemMeta() == null) {
             return null;
         }
 
@@ -274,7 +273,6 @@ public class BaitNBTManager {
      *
      * @return A random bait weighted by its catch-weight.
      */
-    // TODO look into why this throws IndexOutOfBoundsException
     public static @Nullable Bait randomBaitCatch() {
         double totalWeight = 0;
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -230,42 +230,42 @@ public class BaitNBTManager {
      */
     // TODO look into why this throws IndexOutOfBoundsException
     public static @Nullable Bait randomBaitApplication(ItemStack fishingRod) {
-        try {
-            if (fishingRod.getItemMeta() == null) {
-                return null;
-            }
-
-            String[] baitNameList = NbtUtils.getBaitArray(fishingRod);
-            List<Bait> baitList = new ArrayList<>();
-
-            for (String baitName : baitNameList) {
-
-                Bait bait = BaitManager.getInstance().getBait(baitName.split(":")[0]);
-                if (bait != null) {
-                    baitList.add(bait);
-                }
-
-            }
-
-            double totalWeight = 0;
-
-            // Weighted random logic (nabbed from stackoverflow)
-            for (Bait bait : baitList) {
-                totalWeight += (bait.getApplicationWeight());
-            }
-
-            int idx = 0;
-            for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {
-                r -= baitList.get(idx).getApplicationWeight();
-                if (r <= 0.0) {
-                    break;
-                }
-            }
-            return baitList.get(idx);
-        } catch (IndexOutOfBoundsException exception) {
-            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Could not find a valid bait!");
+        if (fishingRod.getItemMeta() == null) {
             return null;
         }
+
+        String[] baitNameList = NbtUtils.getBaitArray(fishingRod);
+        List<Bait> baitList = new ArrayList<>();
+
+        for (String baitName : baitNameList) {
+
+            Bait bait = BaitManager.getInstance().getBait(baitName.split(":")[0]);
+            if (bait != null) {
+                baitList.add(bait);
+            }
+
+        }
+
+        // Fix IndexOutOfBoundsException caused by the list being empty.
+        if (baitList.isEmpty()) {
+            return null;
+        }
+
+        double totalWeight = 0;
+
+        // Weighted random logic (nabbed from stackoverflow)
+        for (Bait bait : baitList) {
+            totalWeight += (bait.getApplicationWeight());
+        }
+
+        int idx = 0;
+        for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {
+            r -= baitList.get(idx).getApplicationWeight();
+            if (r <= 0.0) {
+                break;
+            }
+        }
+        return baitList.get(idx);
     }
 
     /**
@@ -276,29 +276,29 @@ public class BaitNBTManager {
      */
     // TODO look into why this throws IndexOutOfBoundsException
     public static @Nullable Bait randomBaitCatch() {
-        try {
-            double totalWeight = 0;
+        double totalWeight = 0;
 
-            List<Bait> baitList = new ArrayList<>(BaitManager.getInstance().getBaitMap().values());
+        List<Bait> baitList = new ArrayList<>(BaitManager.getInstance().getBaitMap().values());
 
-            // Weighted random logic (nabbed from stackoverflow)
-            for (Bait bait : baitList) {
-                totalWeight += (bait.getCatchWeight());
-            }
-
-            int idx = 0;
-            for (double r = Math.random() * totalWeight; idx < BaitManager.getInstance().getBaitMap().size() - 1; ++idx) {
-                r -= baitList.get(idx).getCatchWeight();
-                if (r <= 0.0) {
-                    break;
-                }
-            }
-
-            return baitList.get(idx);
-        } catch (IndexOutOfBoundsException exception) {
-            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Could not find a valid bait!");
+        // Fix IndexOutOfBoundsException caused by the list being empty.
+        if (baitList.isEmpty()) {
             return null;
         }
+
+        // Weighted random logic (nabbed from stackoverflow)
+        for (Bait bait : baitList) {
+            totalWeight += (bait.getCatchWeight());
+        }
+
+        int idx = 0;
+        for (double r = Math.random() * totalWeight; idx < BaitManager.getInstance().getBaitMap().size() - 1; ++idx) {
+            r -= baitList.get(idx).getCatchWeight();
+            if (r <= 0.0) {
+                break;
+            }
+        }
+
+        return baitList.get(idx);
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -276,7 +277,8 @@ public class BaitNBTManager {
     public static @Nullable Bait randomBaitCatch() {
         double totalWeight = 0;
 
-        List<Bait> baitList = new ArrayList<>(BaitManager.getInstance().getBaitMap().values());
+        Map<String, Bait> baitMap = BaitManager.getInstance().getBaitMap();
+        List<Bait> baitList = new ArrayList<>(baitMap.values());
 
         // Fix IndexOutOfBoundsException caused by the list being empty.
         if (baitList.isEmpty()) {
@@ -289,7 +291,7 @@ public class BaitNBTManager {
         }
 
         int idx = 0;
-        for (double r = Math.random() * totalWeight; idx < BaitManager.getInstance().getBaitMap().size() - 1; ++idx) {
+        for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {
             r -= baitList.get(idx).getCatchWeight();
             if (r <= 0.0) {
                 break;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -228,42 +228,42 @@ public class BaitNBTManager {
      * @param fishingRod The fishing rod.
      * @return A random bait applied to the fishing rod.
      */
-    public static Bait randomBaitApplication(ItemStack fishingRod) {
-        if (fishingRod.getItemMeta() == null) {
-            return null;
-        }
-
-        String[] baitNameList = NbtUtils.getBaitArray(fishingRod);
-        List<Bait> baitList = new ArrayList<>();
-
-        for (String baitName : baitNameList) {
-
-            Bait bait = BaitManager.getInstance().getBait(baitName.split(":")[0]);
-            if (bait != null) {
-                baitList.add(bait);
-            }
-
-        }
-
-        double totalWeight = 0;
-
-        // Weighted random logic (nabbed from stackoverflow)
-        for (Bait bait : baitList) {
-            totalWeight += (bait.getApplicationWeight());
-        }
-
-        int idx = 0;
-        for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {
-            r -= baitList.get(idx).getApplicationWeight();
-            if (r <= 0.0) {
-                break;
-            }
-        }
-
+    // TODO look into why this throws IndexOutOfBoundsException
+    public static @Nullable Bait randomBaitApplication(ItemStack fishingRod) {
         try {
+            if (fishingRod.getItemMeta() == null) {
+                return null;
+            }
+
+            String[] baitNameList = NbtUtils.getBaitArray(fishingRod);
+            List<Bait> baitList = new ArrayList<>();
+
+            for (String baitName : baitNameList) {
+
+                Bait bait = BaitManager.getInstance().getBait(baitName.split(":")[0]);
+                if (bait != null) {
+                    baitList.add(bait);
+                }
+
+            }
+
+            double totalWeight = 0;
+
+            // Weighted random logic (nabbed from stackoverflow)
+            for (Bait bait : baitList) {
+                totalWeight += (bait.getApplicationWeight());
+            }
+
+            int idx = 0;
+            for (double r = Math.random() * totalWeight; idx < baitList.size() - 1; ++idx) {
+                r -= baitList.get(idx).getApplicationWeight();
+                if (r <= 0.0) {
+                    break;
+                }
+            }
             return baitList.get(idx);
         } catch (IndexOutOfBoundsException exception) {
-            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Could not find a valid bait!", exception);
+            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Could not find a valid bait!");
             return null;
         }
     }
@@ -274,25 +274,31 @@ public class BaitNBTManager {
      *
      * @return A random bait weighted by its catch-weight.
      */
-    public static Bait randomBaitCatch() {
-        double totalWeight = 0;
+    // TODO look into why this throws IndexOutOfBoundsException
+    public static @Nullable Bait randomBaitCatch() {
+        try {
+            double totalWeight = 0;
 
-        List<Bait> baitList = new ArrayList<>(BaitManager.getInstance().getBaitMap().values());
+            List<Bait> baitList = new ArrayList<>(BaitManager.getInstance().getBaitMap().values());
 
-        // Weighted random logic (nabbed from stackoverflow)
-        for (Bait bait : baitList) {
-            totalWeight += (bait.getCatchWeight());
-        }
-
-        int idx = 0;
-        for (double r = Math.random() * totalWeight; idx < BaitManager.getInstance().getBaitMap().size() - 1; ++idx) {
-            r -= baitList.get(idx).getCatchWeight();
-            if (r <= 0.0) {
-                break;
+            // Weighted random logic (nabbed from stackoverflow)
+            for (Bait bait : baitList) {
+                totalWeight += (bait.getCatchWeight());
             }
-        }
 
-        return baitList.get(idx);
+            int idx = 0;
+            for (double r = Math.random() * totalWeight; idx < BaitManager.getInstance().getBaitMap().size() - 1; ++idx) {
+                r -= baitList.get(idx).getCatchWeight();
+                if (r <= 0.0) {
+                    break;
+                }
+            }
+
+            return baitList.get(idx);
+        } catch (IndexOutOfBoundsException exception) {
+            EvenMoreFish.getInstance().getLogger().log(Level.WARNING, "Could not find a valid bait!");
+            return null;
+        }
     }
 
     /**
@@ -303,6 +309,9 @@ public class BaitNBTManager {
      * @return If the fishing rod contains the bait or not.
      */
     public static boolean hasBaitApplied(ItemStack itemStack, String bait) {
+        if (itemStack == null) {
+            return false;
+        }
         ItemMeta meta = itemStack.getItemMeta();
         if (meta == null) {
             return false;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -150,13 +150,15 @@ public class FishingProcessor implements Listener {
         if (BaitFile.getInstance().getBaitCatchPercentage() > 0) {
             if (EvenMoreFish.getInstance().getRandom().nextDouble() * 100.0 < BaitFile.getInstance().getBaitCatchPercentage()) {
                 Bait caughtBait = BaitNBTManager.randomBaitCatch();
-                AbstractMessage message = ConfigMessage.BAIT_CAUGHT.getMessage();
-                message.setBaitTheme(caughtBait.getTheme());
-                message.setBait(caughtBait.getName());
-                message.setPlayer(player);
-                message.send(player);
+                if (caughtBait != null) {
+                    AbstractMessage message = ConfigMessage.BAIT_CAUGHT.getMessage();
+                    message.setBaitTheme(caughtBait.getTheme());
+                    message.setBait(caughtBait.getName());
+                    message.setPlayer(player);
+                    message.send(player);
 
-                return caughtBait.create(player);
+                    return caughtBait.create(player);
+                }
             }
         }
 
@@ -174,7 +176,7 @@ public class FishingProcessor implements Listener {
                         ItemMeta newMeta = BaitNBTManager.applyBaitedRodNBT(fishingRod, applyingBait, -1).getFishingRod().getItemMeta();
                         fishingRod.setItemMeta(newMeta);
                         EvenMoreFish.getInstance().incrementMetricBaitsUsed(1);
-                    } catch (MaxBaitsReachedException | MaxBaitReachedException exception) {
+                    } catch (MaxBaitsReachedException | MaxBaitReachedException | NullPointerException exception) {
                         EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, exception.getMessage(), exception);
                     }
                 } else {


### PR DESCRIPTION
## Description
Fixes some IndexOutOfBoundsExceptions in BaitNBTManager caused by the bait list being empty.

---

### What has changed?
- BaitNBTManager#randomBaitApplication now returns null if the baitList is empty.
- BaitNBTManager#randomBaitCatch now returns null if the baitList is empty.
- Adds a workaround to BaitNBTManager#newApplyLore. If the amount is missing, it will say N/A instead of throwing an exception.

---

### Related Issues
Closes #397 

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.