### PR TITLE
Fix HeadDatabase Addon

### DIFF
--- a/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/DenizenItemAddon.java
+++ b/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/DenizenItemAddon.java
@@ -6,6 +6,7 @@ import com.oheers.fish.api.addons.ItemAddon;
 import org.bukkit.inventory.ItemStack;
 
 public class DenizenItemAddon extends ItemAddon {
+
     @Override
     public String getPrefix() {
         return "denizen";

--- a/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/EcoItemsItemAddon.java
+++ b/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/EcoItemsItemAddon.java
@@ -6,6 +6,7 @@ import com.willfp.ecoitems.items.EcoItems;
 import org.bukkit.inventory.ItemStack;
 
 public class EcoItemsItemAddon extends ItemAddon {
+
     @Override
     public String getPrefix() {
         return "ecoitems";

--- a/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/HeadDatabaseItemAddon.java
+++ b/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/HeadDatabaseItemAddon.java
@@ -3,15 +3,11 @@ package com.oheers.evenmorefish.addons;
 
 import com.oheers.fish.api.addons.ItemAddon;
 import com.oheers.fish.api.plugin.EMFPlugin;
-import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
 import me.arcaniax.hdb.api.DatabaseLoadEvent;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.Objects;
 
 public class HeadDatabaseItemAddon extends ItemAddon implements Listener {
 

--- a/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/HeadDatabaseItemAddon.java
+++ b/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/HeadDatabaseItemAddon.java
@@ -2,10 +2,21 @@ package com.oheers.evenmorefish.addons;
 
 
 import com.oheers.fish.api.addons.ItemAddon;
+import com.oheers.fish.api.plugin.EMFPlugin;
+import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
+import me.arcaniax.hdb.api.DatabaseLoadEvent;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
-public class HeadDatabaseItemAddon extends ItemAddon {
+import java.util.Objects;
+
+public class HeadDatabaseItemAddon extends ItemAddon implements Listener {
+
+    private HeadDatabaseAPI api = null;
+
     @Override
     public String getPrefix() {
         return "headdb";
@@ -23,12 +34,25 @@ public class HeadDatabaseItemAddon extends ItemAddon {
 
     @Override
     public ItemStack getItemStack(String id) {
-        final HeadDatabaseAPI api = new HeadDatabaseAPI();
-        if(!api.isHead(id)) {
-            getLogger().warning(() -> String.format("No such head with the id %s",id));
+        if (api == null) {
+            return null;
+        }
+
+        if (!api.isHead(id)) {
+            getLogger().warning(() -> String.format("No such head with the id %s", id));
             return null;
         }
 
         return api.getItemHead(id);
     }
+
+    @EventHandler
+    public void onItemsLoad(DatabaseLoadEvent event) {
+        getLogger().info("Detected that HeadDatabase has finished loading...");
+        getLogger().info("Reloading EMF.");
+        this.api = new HeadDatabaseAPI();
+
+        EMFPlugin.getInstance().reload(null);
+    }
+
 }

--- a/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/ItemsAdderItemAddon.java
+++ b/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/ItemsAdderItemAddon.java
@@ -5,14 +5,12 @@ import com.oheers.fish.api.addons.ItemAddon;
 import com.oheers.fish.api.plugin.EMFPlugin;
 import dev.lone.itemsadder.api.CustomStack;
 import dev.lone.itemsadder.api.Events.ItemsAdderLoadDataEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Objects;
-
 public class ItemsAdderItemAddon extends ItemAddon implements Listener {
+
     private boolean itemsAdderLoaded = false;
 
     @Override
@@ -49,16 +47,15 @@ public class ItemsAdderItemAddon extends ItemAddon implements Listener {
             return null;
         }
         return CustomStack.getInstance(namespaceId).getItemStack();
-
     }
 
     @EventHandler
     public void onItemsLoad(ItemsAdderLoadDataEvent event) {
-        getLogger().info("Detected that itemsadder has finished loading all items...");
+        getLogger().info("Detected that ItemsAdder has finished loading all items...");
         getLogger().info("Reloading EMF.");
         this.itemsAdderLoaded = true;
 
-        ((EMFPlugin) Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("EvenMoreFish"))).reload(null);
+        EMFPlugin.getInstance().reload(null);
     }
 
     /**
@@ -73,4 +70,5 @@ public class ItemsAdderItemAddon extends ItemAddon implements Listener {
     public boolean verifyItemsFormat(final String[] splitMaterialValue) {
         return splitMaterialValue.length == 2;
     }
+
 }

--- a/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/OraxenItemAddon.java
+++ b/even-more-fish-addons-j17/src/main/java/com/oheers/evenmorefish/addons/OraxenItemAddon.java
@@ -6,14 +6,12 @@ import com.oheers.fish.api.plugin.EMFPlugin;
 import io.th0rgal.oraxen.api.OraxenItems;
 import io.th0rgal.oraxen.api.events.OraxenItemsLoadedEvent;
 import io.th0rgal.oraxen.items.ItemBuilder;
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Objects;
-
 public class OraxenItemAddon extends ItemAddon implements Listener {
+
     private boolean oraxenLoaded = false;
     
     @Override
@@ -52,7 +50,7 @@ public class OraxenItemAddon extends ItemAddon implements Listener {
         getLogger().info("Reloading EMF.");
         this.oraxenLoaded = true;
 
-        ((EMFPlugin) Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("EvenMoreFish"))).reload(null);
+        EMFPlugin.getInstance().reload(null);
     }
 
 }

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     implementation(libs.inventorygui)
     implementation(libs.vanishchecker)
     implementation(libs.boostedyaml)
+    implementation(libs.maven.artifact)
 
     library(libs.friendlyid)
     library(libs.flyway.core)

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -52,6 +52,7 @@ import de.themoep.inventorygui.InventoryGui;
 import de.tr7zw.changeme.nbtapi.NBT;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
 import net.milkbowl.vault.permission.Permission;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.SingleLineChart;
@@ -552,15 +553,9 @@ public class EvenMoreFish extends EMFPlugin {
 
     // Checks for updates, surprisingly
     private boolean checkUpdate() {
-        // Removes the dots from the version numbers and turns them into ints.
-        // If spigotVersion's int is bigger than serverVersion's int, there is an update available.
-        try {
-            int spigotVersion = Integer.parseInt(new UpdateChecker(this, 91310).getVersion().replace(".", ""));
-            int serverVersion = Integer.parseInt(getDescription().getVersion().replace(".", ""));
-            return spigotVersion > serverVersion;
-        } catch (NumberFormatException exception) {
-            return false;
-        }
+        ComparableVersion spigotVersion = new ComparableVersion(new UpdateChecker(this, 91310).getVersion());
+        ComparableVersion serverVersion = new ComparableVersion(getDescription().getVersion());
+        return spigotVersion.compareTo(serverVersion) > 0;
     }
 
     private void checkPapi() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -552,20 +552,15 @@ public class EvenMoreFish extends EMFPlugin {
 
     // Checks for updates, surprisingly
     private boolean checkUpdate() {
-
-        String[] spigotVersion = new UpdateChecker(this, 91310).getVersion().split("\\.");
-        String[] serverVersion = getDescription().getVersion().split("\\.");
-
-        for (int i = 0; i < serverVersion.length; i++) {
-            if (i < spigotVersion.length) {
-                if (Integer.parseInt(spigotVersion[i]) > Integer.parseInt(serverVersion[i])) {
-                    return true;
-                }
-            } else {
-                return false;
-            }
+        // Removes the dots from the version numbers and turns them into ints.
+        // If spigotVersion's int is bigger than serverVersion's int, there is an update available.
+        try {
+            int spigotVersion = Integer.parseInt(new UpdateChecker(this, 91310).getVersion().replace(".", ""));
+            int serverVersion = Integer.parseInt(getDescription().getVersion().replace(".", ""));
+            return spigotVersion > serverVersion;
+        } catch (NumberFormatException exception) {
+            return false;
         }
-        return false;
     }
 
     private void checkPapi() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/baits/BaitNBTManager.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 public class BaitNBTManager {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ dependencyResolutionManagement {
             library("commons-codec", "commons-codec:commons-codec:1.17.0")
             library("caffeine", "com.github.ben-manes.caffeine:caffeine:3.1.8")
             library("annotations", "org.jetbrains:annotations:24.1.0")
+            library("maven-artifact", "org.apache.maven:maven-artifact:3.9.9")
 
             version("flyway", "10.17.0")
             library("flyway-core", "org.flywaydb","flyway-core").versionRef("flyway")


### PR DESCRIPTION
## Description
Fixes HeadDatabase heads not working without a plugin reload.

---

### What has changed?
- HeadDatabaseItemAddon now listens to DatabaseLoadEvent and reloads the plugin.
- Small cleanup to the other addons
- Fixes update checking

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.