### PR TITLE
Default config updates

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
@@ -45,7 +45,7 @@ public class CompetitionConversions {
         file.delete();
 
         EvenMoreFish.getInstance().getLogger().severe("Your competition configs have been automatically converted to the new format.");
-        EvenMoreFish.getInstance().getLogger().severe("You may want to disable all competitions in the plugins/EvenMoreFish/competitions/defaults folder.");
+        EvenMoreFish.getInstance().getLogger().severe("You may want to disable all competitions in the plugins/EvenMoreFish/competitions/defaults folder, as they may conflict with your existing configs");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
@@ -43,6 +43,9 @@ public class CompetitionConversions {
         File file = competitionsConfig.getFile();
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "competitions.yml.old"));
         file.delete();
+
+        EvenMoreFish.getInstance().getLogger().severe("Your competition configs have been automatically converted to the new format.");
+        EvenMoreFish.getInstance().getLogger().severe("You may want to disable all competitions in the plugins/EvenMoreFish/competitions/defaults folder.");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/FishConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/FishConversions.java
@@ -41,6 +41,9 @@ public class FishConversions extends RarityConversions {
         File file = fishConfig.getFile();
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "fish.yml.old"));
         file.delete();
+
+        EvenMoreFish.getInstance().getLogger().severe("Your fish configs have been automatically converted to the new format.");
+        EvenMoreFish.getInstance().getLogger().severe("They are now located in the rarity files.");
     }
 
     private void convertSectionToFile(@NotNull Section section) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityConversions.java
@@ -42,7 +42,7 @@ public class RarityConversions {
         file.delete();
 
         EvenMoreFish.getInstance().getLogger().severe("Your rarity configs have been automatically converted to the new format.");
-        EvenMoreFish.getInstance().getLogger().severe("You may want to disable all rarities in the plugins/EvenMoreFish/rarities/defaults folder.");
+        EvenMoreFish.getInstance().getLogger().severe("You may want to disable all rarities in the plugins/EvenMoreFish/rarities/defaults folder, as they may conflict with your existing configs.");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/config/RarityConversions.java
@@ -40,6 +40,9 @@ public class RarityConversions {
         File file = raritiesConfig.getFile();
         file.renameTo(new File(EvenMoreFish.getInstance().getDataFolder(), "rarities.yml.old"));
         file.delete();
+
+        EvenMoreFish.getInstance().getLogger().severe("Your rarity configs have been automatically converted to the new format.");
+        EvenMoreFish.getInstance().getLogger().severe("You may want to disable all rarities in the plugins/EvenMoreFish/rarities/defaults folder.");
     }
 
     /**

--- a/even-more-fish-plugin/src/main/resources/competitions/defaults/main.yml
+++ b/even-more-fish-plugin/src/main/resources/competitions/defaults/main.yml
@@ -1,4 +1,4 @@
-id: defaultMainCompetition
+id: mainCompetition
 disabled: false
 type: LARGEST_FISH
 duration: 10

--- a/even-more-fish-plugin/src/main/resources/competitions/defaults/sunday1.yml
+++ b/even-more-fish-plugin/src/main/resources/competitions/defaults/sunday1.yml
@@ -1,4 +1,4 @@
-id: defaultSundayCompetition1
+id: sundayCompetition1
 disabled: false
 type: LARGEST_FISH
 duration: 30

--- a/even-more-fish-plugin/src/main/resources/competitions/defaults/sunday2.yml
+++ b/even-more-fish-plugin/src/main/resources/competitions/defaults/sunday2.yml
@@ -1,4 +1,4 @@
-id: defaultSundayCompetition2
+id: sundayCompetition2
 disabled: false
 type: MOST_FISH
 duration: 45

--- a/even-more-fish-plugin/src/main/resources/competitions/defaults/weekend.yml
+++ b/even-more-fish-plugin/src/main/resources/competitions/defaults/weekend.yml
@@ -1,4 +1,4 @@
-id: defaultWeekendCompetition
+id: weekendCompetition
 disabled: false
 type: SPECIFIC_FISH
 duration: 60

--- a/even-more-fish-plugin/src/main/resources/rarities/defaults/common.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/defaults/common.yml
@@ -1,4 +1,4 @@
-id: defaultCommon
+id: Common
 disabled: false
 weight: 100
 colour: '&7'

--- a/even-more-fish-plugin/src/main/resources/rarities/defaults/epic.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/defaults/epic.yml
@@ -1,4 +1,4 @@
-id: defaultEpic
+id: Epic
 disabled: false
 weight: 3
 colour: '&d'

--- a/even-more-fish-plugin/src/main/resources/rarities/defaults/junk.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/defaults/junk.yml
@@ -1,4 +1,4 @@
-id: defaultJunk
+id: Junk
 disabled: false
 weight: 5
 colour: '&#888888'

--- a/even-more-fish-plugin/src/main/resources/rarities/defaults/legendary.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/defaults/legendary.yml
@@ -1,4 +1,4 @@
-id: defaultLegendary
+id: Legendary
 disabled: false
 weight: 1
 colour: '&6'

--- a/even-more-fish-plugin/src/main/resources/rarities/defaults/rare.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/defaults/rare.yml
@@ -1,4 +1,4 @@
-id: defaultRare
+id: Rare
 disabled: false
 weight: 10
 colour: '&b'


### PR DESCRIPTION
## Description
Changes all default config ids back to potentially having conflicts.

This prevents issues with the other default configs, and the new logging should prevent issues. We may also want to mention this in the 2.0.0 release changelog.

---

### What has changed?
- Removed `default` prefix from all competition ids.
- Removed `default` prefix from all rarity ids.
- Added logging to the competition conversions: https://pastes.dev/JZ45kv125N
- Added logging to the rarity and fish conversions: https://pastes.dev/4T6A4QdI0v

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.