### PR TITLE
Fix competition config conversion

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
@@ -5,6 +5,7 @@ import com.oheers.fish.config.ConfigBase;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 
@@ -29,10 +30,11 @@ public class CompetitionConversions {
             finalizeConversion(config);
             return;
         }
+        Section generalSection = config.getConfig().getSection("general");
         for (String competitionKey : competitionSection.getRoutesAsStrings(false)) {
             Section section = competitionSection.getSection(competitionKey);
             if (section != null) {
-                convertSectionToFile(section);
+                convertSectionToFile(section, generalSection);
             }
         }
         finalizeConversion(config);
@@ -54,7 +56,7 @@ public class CompetitionConversions {
         return new File(EvenMoreFish.getInstance().getDataFolder(), "competitions");
     }
 
-    private void convertSectionToFile(@NotNull Section section) {
+    private void convertSectionToFile(@NotNull Section section, @Nullable Section generalSection) {
         String id = section.getNameAsString();
         if (id == null) {
             return;
@@ -64,6 +66,16 @@ public class CompetitionConversions {
         YamlDocument config = configBase.getConfig();
         config.setAll(section.getRouteMappedValues(true));
         config.set("id", id);
+
+        // Account for the "general" section.
+        if (generalSection != null) {
+            for (String key : generalSection.getRoutesAsStrings(true)) {
+                if (!config.contains(key)) {
+                    config.set(key, generalSection.get(key));
+                }
+            }
+        }
+
         configBase.save();
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionConversions.java
@@ -30,11 +30,13 @@ public class CompetitionConversions {
             finalizeConversion(config);
             return;
         }
-        Section generalSection = config.getConfig().getSection("general");
+        Section rewards = config.getConfig().getSection("rewards");
+        Section leaderboard = config.getConfig().getSection("leaderboard");
+        Section general = config.getConfig().getSection("general");
         for (String competitionKey : competitionSection.getRoutesAsStrings(false)) {
             Section section = competitionSection.getSection(competitionKey);
             if (section != null) {
-                convertSectionToFile(section, generalSection);
+                convertSectionToFile(section, general, leaderboard, rewards);
             }
         }
         finalizeConversion(config);
@@ -56,7 +58,7 @@ public class CompetitionConversions {
         return new File(EvenMoreFish.getInstance().getDataFolder(), "competitions");
     }
 
-    private void convertSectionToFile(@NotNull Section section, @Nullable Section generalSection) {
+    private void convertSectionToFile(@NotNull Section section, @Nullable Section general, @Nullable Section leaderboard, @Nullable Section rewards) {
         String id = section.getNameAsString();
         if (id == null) {
             return;
@@ -67,16 +69,30 @@ public class CompetitionConversions {
         config.setAll(section.getRouteMappedValues(true));
         config.set("id", id);
 
+        applyGeneralSection(config, general, leaderboard, rewards);
+
+        configBase.save();
+    }
+
+    private void applyGeneralSection(@NotNull YamlDocument config, @Nullable Section general, @Nullable Section leaderboard, @Nullable Section rewards) {
         // Account for the "general" section.
-        if (generalSection != null) {
-            for (String key : generalSection.getRoutesAsStrings(true)) {
+        if (general != null) {
+            for (String key : general.getRoutesAsStrings(true)) {
                 if (!config.contains(key)) {
-                    config.set(key, generalSection.get(key));
+                    config.set(key, general.get(key));
                 }
             }
         }
 
-        configBase.save();
+        // Add "rewards" section if needed
+        if (rewards != null && !config.contains("rewards")) {
+            config.set("rewards", rewards);
+        }
+
+        // Add "leaderboard" section if needed
+        if (leaderboard != null && !config.contains("leaderboard")) {
+            config.set("leaderboard", leaderboard);
+        }
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionFile.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionFile.java
@@ -153,7 +153,7 @@ public class CompetitionFile extends ConfigBase {
      * @return The number of fish needed for SPECIFIC_* competition types.
      */
     public int getNumberNeeded() {
-        return Math.max(1, getConfig().getInt("number-needed"));
+        return Math.max(1, getConfig().getInt("number-needed", 1));
     }
 
     /**
@@ -174,7 +174,7 @@ public class CompetitionFile extends ConfigBase {
      * @return The colours to show for each winning position, if the {pos_colour} variable is used.
      */
     public @NotNull List<String> getPositionColours() {
-        return getConfig().getStringList("leaderboard.position-colours", List.of("&6", "&e", "&7", "&7", "&8"));
+        return getConfig().getStringList("leaderboard.position-colours", List.of("&6", "&e", "&7", "&7", "&#888888"));
     }
 
     public @NotNull List<Long> getAlertTimes() {
@@ -274,7 +274,7 @@ public class CompetitionFile extends ConfigBase {
      * @return The amount of players required for this competition to start.
      */
     public int getPlayersNeeded() {
-        return Math.max(1, getConfig().getInt("minimum-players"));
+        return Math.max(1, getConfig().getInt("minimum-players", 5));
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes an issue with competitions.yml conversion.
This should fix any config breaks from the old format.

---

### What has changed?
- CompetitionConversions now include the "general" section in their checks.
- CompetitionConversions now include the "rewards" and "leaderboard" sections in their checks.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.