### PR TITLE
Command Updates

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -15,7 +15,7 @@ import com.oheers.fish.api.reward.RewardManager;
 import com.oheers.fish.baits.BaitListener;
 import com.oheers.fish.baits.BaitManager;
 import com.oheers.fish.commands.AdminCommand;
-import com.oheers.fish.commands.EMFCommand;
+import com.oheers.fish.commands.MainCommand;
 import com.oheers.fish.competition.AutoRunner;
 import com.oheers.fish.competition.Competition;
 import com.oheers.fish.competition.CompetitionQueue;
@@ -499,7 +499,7 @@ public class EvenMoreFish extends EMFPlugin {
     }
 
     private void registerCommands() {
-        new EMFCommand().getCommand().register(this);
+        new MainCommand().getCommand().register(this);
 
         // Shortcut command for /emf admin
         if (MainConfig.getInstance().isAdminShortcutCommandEnabled()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -39,7 +39,8 @@ import java.util.*;
 
 public class AdminCommand {
 
-    private final Map<String, String> commandUsages = new HashMap<>();
+    private final HelpMessageBuilder helpMessageBuilder = HelpMessageBuilder.create();
+
     private final CommandAPICommand command;
 
     public AdminCommand(@NotNull String name) {
@@ -70,13 +71,13 @@ public class AdminCommand {
     }
 
     private void sendHelpMessage(@NotNull CommandSender sender) {
-        HelpMessageBuilder.create(commandUsages).sendMessage(sender);
+        helpMessageBuilder.sendMessage(sender);
     }
 
     private CommandAPICommand getFish() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin fish",
-                ConfigMessage.HELP_ADMIN_FISH.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_FISH::getMessage
         );
         return new CommandAPICommand("fish")
                 .withArguments(
@@ -168,9 +169,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getNbtRod() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin nbt-rod",
-                ConfigMessage.HELP_ADMIN_NBTROD.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_NBTROD::getMessage
         );
         return new CommandAPICommand("nbt-rod")
                 .withArguments(
@@ -201,9 +202,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getBait() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin bait",
-                ConfigMessage.HELP_ADMIN_BAIT.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_BAIT::getMessage
         );
         return new CommandAPICommand("bait")
                 .withArguments(
@@ -237,9 +238,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getClearBaits() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin clearbaits",
-                ConfigMessage.HELP_ADMIN_CLEARBAITS.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_CLEARBAITS::getMessage
         );
         return new CommandAPICommand("clearbaits")
                 .withArguments(
@@ -281,9 +282,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getReload() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin reload",
-                ConfigMessage.HELP_ADMIN_RELOAD.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_RELOAD::getMessage
         );
         return new CommandAPICommand("reload")
                 .executes(info -> {
@@ -292,9 +293,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getAddons() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin addons",
-                ConfigMessage.HELP_ADMIN_ADDONS.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_ADDONS::getMessage
         );
         return new CommandAPICommand("addons")
                 .withFullDescription(ConfigMessage.HELP_ADMIN_ADDONS.getMessage().getPlainTextMessage())
@@ -312,9 +313,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getVersion() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin version",
-                ConfigMessage.HELP_ADMIN_VERSION.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_VERSION::getMessage
         );
         return new CommandAPICommand("version")
                 .executes(info -> {
@@ -342,9 +343,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getRewardTypes() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin rewardtypes",
-                ConfigMessage.HELP_ADMIN_REWARDTYPES.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_REWARDTYPES::getMessage
         );
         return new CommandAPICommand("rewardtypes")
                 .executes(info -> {
@@ -367,9 +368,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getMigrate() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin migrate",
-                ConfigMessage.HELP_ADMIN_MIGRATE.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_MIGRATE::getMessage
         );
         return new CommandAPICommand("migrate")
                 .executes(info -> {
@@ -382,9 +383,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getRawItem() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin rawItem",
-                ConfigMessage.HELP_ADMIN_RAWITEM.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_RAWITEM::getMessage
         );
         return new CommandAPICommand("rawItem")
                 .executesPlayer(info -> {
@@ -407,9 +408,9 @@ public class AdminCommand {
     }
 
     private CommandAPICommand getHelp() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin help",
-                ConfigMessage.HELP_GENERAL_HELP.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_HELP::getMessage
         );
         return new CommandAPICommand("help")
                 .executes(info -> {
@@ -420,9 +421,9 @@ public class AdminCommand {
     // COMPETITION BRANCH
 
     private CommandAPICommand getCompetition() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "admin competition",
-                ConfigMessage.HELP_ADMIN_COMPETITION.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_ADMIN_COMPETITION::getMessage
         );
         return new CommandAPICommand("competition")
                 .withSubcommands(

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -86,7 +86,7 @@ public class AdminCommand {
                         ArgumentHelper.getPlayerArgument("target").setOptional(true)
                 )
                 .executes((sender, arguments) -> {
-                    final Fish fish = (Fish) arguments.get("fish");
+                    final Fish fish = arguments.getUnchecked("fish");
                     if (fish == null) {
                         return;
                     }
@@ -131,10 +131,10 @@ public class AdminCommand {
                         RarityArgument.create().setOptional(true)
                 )
                 .executes((sender, args) -> {
-                    String listTarget = (String) Objects.requireNonNull(args.get("listTarget"));
+                    String listTarget = Objects.requireNonNull(args.getUnchecked("listTarget"));
                     switch (listTarget) {
                         case "fish" -> {
-                            final Rarity rarity = (Rarity) args.get("rarity");
+                            final Rarity rarity = args.getUnchecked("rarity");
                             if (rarity == null) {
                                 // TODO add "invalid rarity" message.
                                 sender.sendMessage("Rarity is invalid.");
@@ -212,7 +212,7 @@ public class AdminCommand {
                         ArgumentHelper.getPlayerArgument("target").setOptional(true)
                 )
                 .executes((sender, args) -> {
-                    final Bait bait = (Bait) Objects.requireNonNull(args.get("bait"));
+                    final Bait bait = Objects.requireNonNull(args.getUnchecked("bait"));
                     final int quantity = (int) args.getOptional("quantity").orElse(1);
                     final Player target = (Player) args.getOptional("target").orElseGet(() -> {
                         if (sender instanceof Player p) {
@@ -442,8 +442,8 @@ public class AdminCommand {
                         new IntegerArgument("duration", 1).setOptional(true)
                 )
                 .executes((sender, arguments) -> {
-                    final String id = (String) Objects.requireNonNull(arguments.get("competitionId"));
-                    final Integer duration = (Integer) arguments.get("duration");
+                    final String id = Objects.requireNonNull(arguments.getUnchecked("competitionId"));
+                    final Integer duration = arguments.getUnchecked("duration");
                     if (Competition.isActive()) {
                         ConfigMessage.COMPETITION_ALREADY_RUNNING.getMessage().send(sender);
                         return;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/EMFCommand.java
@@ -133,7 +133,7 @@ public class EMFCommand {
                         ArgumentHelper.getPlayerArgument("target").setOptional(true)
                 )
                 .executes((sender, args) -> {
-                    Player player = (Player) args.get("target");
+                    Player player = args.getUnchecked("target");
                     if (player == null){
                         if (!(sender instanceof Player p)) {
                             ConfigMessage.ADMIN_CANT_BE_CONSOLE.getMessage().send(sender);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/HelpMessageBuilder.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/HelpMessageBuilder.java
@@ -6,21 +6,38 @@ import com.oheers.fish.config.messages.ConfigMessage;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class HelpMessageBuilder {
 
-    private final Map<String, String> usages;
+    private final HashMap<String, Supplier<AbstractMessage>> usages;
 
-    private HelpMessageBuilder(@NotNull Map<String, String> usages) {
+    private HelpMessageBuilder(@NotNull HashMap<String, Supplier<AbstractMessage>> usages) {
         this.usages = usages;
     }
 
     /**
      * Creates a HelpMessageBuilder instance
      */
-    public static HelpMessageBuilder create(@NotNull Map<String, String> usages) {
+    public static HelpMessageBuilder create() {
+        return new HelpMessageBuilder(new HashMap<>());
+    }
+
+    /**
+     * Creates a HelpMessageBuilder instance with the provided usages
+     */
+    public static HelpMessageBuilder create(@NotNull HashMap<String, Supplier<AbstractMessage>> usages) {
         return new HelpMessageBuilder(usages);
+    }
+
+    /**
+     * Adds a usage to this builder
+     */
+    public HelpMessageBuilder addUsage(@NotNull String name, @NotNull Supplier<AbstractMessage> helpMessage) {
+        this.usages.putIfAbsent(name, helpMessage);
+        return this;
     }
 
     /**
@@ -32,7 +49,7 @@ public class HelpMessageBuilder {
         usages.forEach((key, value) -> {
             AbstractMessage usage = ConfigMessage.HELP_FORMAT.getMessage();
             usage.setVariable("{command}", correctCommand(key));
-            usage.setVariable("{description}", value);
+            usage.setVariable("{description}", value.get().getLegacyMessage());
             message.appendString("\n");
             message.appendString(usage.getLegacyMessage());
         });

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -23,22 +23,26 @@ public class MainCommand {
     
     private final HelpMessageBuilder helpMessageBuilder = HelpMessageBuilder.create();
 
-    private final CommandAPICommand command = new CommandAPICommand(MainConfig.getInstance().getMainCommandName())
-            .withAliases(MainConfig.getInstance().getMainCommandAliases().toArray(String[]::new))
-            .withSubcommands(
-                    getNext(),
-                    getToggle(),
-                    getGui(),
-                    getHelp(),
-                    getTop(),
-                    getShop(),
-                    getSellAll(),
-                    getApplyBaits(),
-                    new AdminCommand("admin").getCommand()
-            )
-            .executes(info -> {
-                sendHelpMessage(info.sender());
-            });
+    private final CommandAPICommand command;
+
+    public MainCommand() {
+        this.command = new CommandAPICommand(MainConfig.getInstance().getMainCommandName())
+                .withAliases(MainConfig.getInstance().getMainCommandAliases().toArray(String[]::new))
+                .withSubcommands(
+                        getNext(),
+                        getToggle(),
+                        getGui(),
+                        getHelp(),
+                        getTop(),
+                        getShop(),
+                        getSellAll(),
+                        getApplyBaits(),
+                        new AdminCommand("admin").getCommand()
+                )
+                .executes(info -> {
+                    sendHelpMessage(info.sender());
+                });
+    }
 
     public CommandAPICommand getCommand() {
         return command;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-public class EMFCommand {
+public class MainCommand {
 
     private final Map<String, String> commandUsages = new HashMap<>();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/MainCommand.java
@@ -19,12 +19,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class MainCommand {
-
-    private final Map<String, String> commandUsages = new HashMap<>();
+    
+    private final HelpMessageBuilder helpMessageBuilder = HelpMessageBuilder.create();
 
     private final CommandAPICommand command = new CommandAPICommand(MainConfig.getInstance().getMainCommandName())
             .withAliases(MainConfig.getInstance().getMainCommandAliases().toArray(String[]::new))
@@ -48,9 +45,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getNext() {
-        commandUsages.putIfAbsent(
-                "next",
-                ConfigMessage.HELP_GENERAL_NEXT.getMessage().getLegacyMessage()
+        helpMessageBuilder.addUsage(
+                "next", 
+                ConfigMessage.HELP_GENERAL_NEXT::getMessage
         );
         return new CommandAPICommand("next")
                 .withPermission(UserPerms.NEXT)
@@ -62,9 +59,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getToggle() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "toggle",
-                ConfigMessage.HELP_GENERAL_TOGGLE.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_TOGGLE::getMessage
         );
         return new CommandAPICommand("toggle")
                 .withPermission(UserPerms.TOGGLE)
@@ -74,9 +71,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getGui() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "gui",
-                ConfigMessage.HELP_GENERAL_GUI.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_GUI::getMessage
         );
         return new CommandAPICommand("gui")
                 .withPermission(UserPerms.GUI)
@@ -86,9 +83,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getHelp() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "help",
-                ConfigMessage.HELP_GENERAL_HELP.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_HELP::getMessage
         );
         return new CommandAPICommand("help")
                 .withPermission(UserPerms.HELP)
@@ -98,9 +95,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getTop() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "top",
-                ConfigMessage.HELP_GENERAL_TOP.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_TOP::getMessage
         );
         return new CommandAPICommand("top")
                 .withPermission(UserPerms.TOP)
@@ -123,9 +120,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getShop() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "shop",
-                ConfigMessage.HELP_GENERAL_SHOP.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_SHOP::getMessage
         );
         return new CommandAPICommand("shop")
                 .withPermission(UserPerms.SHOP)
@@ -160,9 +157,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getSellAll() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "sellall",
-                ConfigMessage.HELP_GENERAL_SELLALL.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_SELLALL::getMessage
         );
         return new CommandAPICommand("sellall")
                 .withPermission(UserPerms.SELL_ALL)
@@ -175,9 +172,9 @@ public class MainCommand {
     }
 
     private CommandAPICommand getApplyBaits() {
-        commandUsages.putIfAbsent(
+        helpMessageBuilder.addUsage(
                 "applybaits",
-                ConfigMessage.HELP_GENERAL_APPLYBAITS.getMessage().getLegacyMessage()
+                ConfigMessage.HELP_GENERAL_APPLYBAITS::getMessage
         );
         return new CommandAPICommand("applybaits")
                 .withPermission(UserPerms.APPLYBAITS)
@@ -187,7 +184,7 @@ public class MainCommand {
     }
 
     private void sendHelpMessage(@NotNull CommandSender sender) {
-        HelpMessageBuilder.create(commandUsages).sendMessage(sender);
+        helpMessageBuilder.sendMessage(sender);
     }
 
     private boolean checkEconomy(@NotNull CommandSender sender) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/arguments/FishArgument.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/arguments/FishArgument.java
@@ -13,7 +13,7 @@ public class FishArgument {
 
     public static Argument<Fish> create() {
         return new CustomArgument<>(new StringArgument("fish"), info -> {
-            Rarity rarity = (Rarity) info.previousArgs().get("rarity");
+            Rarity rarity = info.previousArgs().getUnchecked("rarity");
             if (rarity == null) {
                 throw CustomArgument.CustomArgumentException.fromString("Could not find a previous RarityArgument!");
             }
@@ -29,7 +29,7 @@ public class FishArgument {
             return fish;
         }).replaceSuggestions(ArgumentHelper.getAsyncSuggestions(
                 info -> {
-                    Rarity rarity = (Rarity) info.previousArgs().get("rarity");
+                    Rarity rarity = info.previousArgs().getUnchecked("rarity");
                     if (rarity == null) {
                         return new String[0];
                     }


### PR DESCRIPTION
## Description
Small follow up to #539 

---

### What has changed?
- All casts have been replaced with CommandArguments#getUnchecked. This will do the same thing but it's a bit more clear.
- EMFCommand has been renamed to MainCommand.
- HelpMessageBuilder now wants an AbstractMessage Supplier instead of a String. This ensures the usage messages always match the config.
- Both commands now hold their own instance of HelpMessageBuilder instead of creating a new instance each time.
- MainCommand's command instance is now assigned in the constructor to match AdminCommand.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.