### PR TITLE
Actually return the proper no-size placeholder, not no-player

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
@@ -166,7 +166,7 @@ public enum ConfigMessage {
     PLACEHOLDER_FISH_MOST_FORMAT("{amount} fish", PrefixType.NONE, true, false, "emf-most-fish-format"),
     PLACEHOLDER_NO_COMPETITION_RUNNING("No competition running right now.", PrefixType.NONE, true, false, "no-competition-running"),
     PLACEHOLDER_NO_COMPETITION_RUNNING_FISH("No competition running right now.", PrefixType.NONE, true, false, "no-competition-running-fish"),
-    PLACEHOLDER_NO_COMPETITION_RUNNING_SIZE("No competition running right now.", PrefixType.NONE, true, false, "no-competition-running"),
+    PLACEHOLDER_NO_COMPETITION_RUNNING_SIZE("No competition running right now.", PrefixType.NONE, true, false, "no-competition-running-size"),
 
     PLACEHOLDER_NO_PLAYER_IN_PLACE("Start fishing to take this place", PrefixType.NONE, true, false, "no-player-in-place"),
     PLACEHOLDER_NO_FISH_IN_PLACE("Start fishing to take this place", PrefixType.NONE, true, false, "no-fish-in-place"),


### PR DESCRIPTION
## Description
Provide a brief description of the changes in this pull request.

Just a single line. ConfigMessage enum had PLACEHOLDER_NO_COMPETITION_RUNNING_SIZE but it's key was the same key with PLACEHOLDER_NO_COMPETITION_RUNNING. Correct key already existed in the config (at least on the 1.7.3, idk about the 2.0.0)

### What has changed?
Summarize the key changes in this pull request.

Placeholder fix.

### Related Issues
Link related issues or describe which problem this PR fixes.

---

### Checklist

- [ +] I have added tests that prove my fix is effective or that my feature works.
- [ -] I have updated the documentation as needed. (I don't think it is needed, let me know)
- [ -] I have added any labels that fit this PR.