### PR TITLE
Fish Cleanup

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/FishUtils.java
@@ -81,28 +81,22 @@ public class FishUtils {
         }
 
         // setting the correct length so it's an exact replica.
-        Fish loadedFish = rarity.getFish(nameString);
-        Fish finalFish;
-        try {
-            // Ignore NPE warning here, it is caught in the catch block.
-            finalFish = loadedFish.clone();
-        } catch (NullPointerException | CloneNotSupportedException exception) {
-            EvenMoreFish.getInstance().getLogger().severe("Could not create fish from an ItemStack with rarity " + rarityString + " and name " + nameString + ". You may have" +
-                    "deleted the fish since this fish was caught.");
+        Fish fish = rarity.getFish(nameString);
+        if (fish == null) {
             return null;
         }
         if (randomIndex != null) {
-            finalFish.getFactory().setType(randomIndex);
+            fish.getFactory().setType(randomIndex);
         }
-        finalFish.setLength(lengthFloat);
+        fish.setLength(lengthFloat);
         if (playerString != null) {
             try {
-                finalFish.setFisherman(UUID.fromString(playerString));
+                fish.setFisherman(UUID.fromString(playerString));
             } catch (IllegalArgumentException exception) {
-                finalFish.setFisherman(null);
+                fish.setFisherman(null);
             }
         }
-        return finalFish;
+        return fish;
     }
 
     public static @Nullable Fish getFish(Skull skull, Player fisher) throws InvalidFishException {
@@ -125,28 +119,25 @@ public class FishUtils {
         }
 
         // setting the correct length and randomIndex, so it's an exact replica.
-        Fish loadedFish = rarity.getFish(nameString);
-        Fish finalFish;
-        try {
-            finalFish = loadedFish.clone();
-        } catch (NullPointerException | CloneNotSupportedException exception) {
+        Fish fish = rarity.getFish(nameString);
+        if (fish == null) {
             return null;
         }
-        finalFish.setLength(lengthFloat);
+        fish.setLength(lengthFloat);
         if (randomIndex != null) {
-            finalFish.getFactory().setType(randomIndex);
+            fish.getFactory().setType(randomIndex);
         }
         if (playerString != null) {
             try {
-                finalFish.setFisherman(UUID.fromString(playerString));
+                fish.setFisherman(UUID.fromString(playerString));
             } catch (IllegalArgumentException exception) {
-                finalFish.setFisherman(null);
+                fish.setFisherman(null);
             }
         } else {
-            finalFish.setFisherman(fisher.getUniqueId());
+            fish.setFisherman(fisher.getUniqueId());
         }
 
-        return finalFish;
+        return fish;
     }
 
     public static void giveItems(List<ItemStack> items, Player player) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -197,15 +197,16 @@ public class FishingProcessor implements Listener {
         }
 
         fish.init();
+
+        EMFFishEvent cEvent = new EMFFishEvent(fish, player);
+        Bukkit.getPluginManager().callEvent(cEvent);
+        if (cEvent.isCancelled()) return null;
+
         fish.checkFishEvent();
 
         if (fish.hasFishRewards()) {
             fish.getFishRewards().forEach(fishReward -> fishReward.rewardPlayer(player, location));
         }
-
-        EMFFishEvent cEvent = new EMFFishEvent(fish, player);
-        Bukkit.getPluginManager().callEvent(cEvent);
-        if (cEvent.isCancelled()) return null;
 
         if (!fish.isSilent()) {
             String length = decimalFormat.format(fish.getLength());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -62,7 +62,7 @@ public class Fish implements Cloneable {
 
     private int day = -1;
     private final double setWorth;
-    
+
     private Fish(@NotNull Rarity rarity, @NotNull Section section) {
         this.section = section;
         this.rarity = rarity;
@@ -430,10 +430,8 @@ public class Fish implements Cloneable {
     }
 
     @Override
-    public Fish clone() throws CloneNotSupportedException {
-        Fish clone = (Fish) super.clone();
-        clone.factory = new ItemFactory(null, section);
-        return clone;
+    public Fish clone() {
+        return create(rarity, section);
     }
 
     public boolean hasFishermanDisabled() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -62,15 +62,8 @@ public class Fish implements Cloneable {
 
     private int day = -1;
     private final double setWorth;
-
-    /**
-     * Constructs a Fish from its config section.
-     * @param section The section for this fish.
-     */
-    public Fish(@NotNull Rarity rarity, @Nullable Section section) throws InvalidFishException {
-        if (section == null) {
-            throw new InvalidFishException("Fish could not be fetched from the config.");
-        }
+    
+    private Fish(@NotNull Rarity rarity, @NotNull Section section) {
         this.section = section;
         this.rarity = rarity;
         // This should never be null, but we have this check just to be safe.
@@ -104,6 +97,26 @@ public class Fish implements Cloneable {
 
         checkSellEvent();
         handleRequirements();
+    }
+
+    /**
+     * Creates a Fish from its config section.
+     * @param section The section for this fish.
+     */
+    public static Fish create(@NotNull Rarity rarity, @NotNull Section section) {
+        return new Fish(rarity, section);
+    }
+
+    /**
+     * Creates a Fish from its config section.
+     * @param section The section for this fish.
+     * @throws InvalidFishException When section is null.
+     */
+    public static Fish createOrThrow(@NotNull Rarity rarity, @Nullable Section section) throws InvalidFishException {
+        if (section == null) {
+            throw new InvalidFishException("Fish could not be fetched from the config.");
+        }
+        return new Fish(rarity, section);
     }
 
     private void handleRequirements() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -33,35 +33,35 @@ import java.util.stream.Collectors;
 public class Fish implements Cloneable {
 
     private final @NotNull Section section;
-    String name;
-    Rarity rarity;
-    ItemFactory factory;
-    UUID fisherman;
-    Float length;
+    private final String name;
+    private final Rarity rarity;
+    private ItemFactory factory;
+    private UUID fisherman;
+    private Float length;
 
-    String displayName;
+    private String displayName;
 
-    List<Reward> actionRewards;
-    List<Reward> fishRewards;
-    List<Reward> sellRewards;
-    String eventType;
+    private List<Reward> actionRewards;
+    private List<Reward> fishRewards;
+    private List<Reward> sellRewards;
+    private String eventType;
 
-    Requirement requirement = new Requirement();
+    private Requirement requirement = new Requirement();
 
-    boolean wasBaited;
-    boolean silent;
+    private boolean wasBaited;
+    private boolean silent;
 
-    double weight;
+    private double weight;
 
-    double minSize;
-    double maxSize;
+    private double minSize;
+    private double maxSize;
 
-    boolean isCompExemptFish;
+    private boolean isCompExemptFish;
 
-    boolean disableFisherman;
+    private final boolean disableFisherman;
 
     private int day = -1;
-    private double setWorth;
+    private final double setWorth;
 
     /**
      * Constructs a Fish from its config section.

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -125,13 +125,21 @@ public class Rarity extends ConfigBase {
         return fishList;
     }
 
-    public @Nullable Fish getFish(@NotNull String name) {
+    public @Nullable Fish getEditableFish(@NotNull String name) {
         for (Fish fish : fishList) {
             if (fish.getName().equalsIgnoreCase(name)) {
                 return fish;
             }
         }
         return null;
+    }
+
+    public @Nullable Fish getFish(@NotNull String name) {
+        Fish fish = getEditableFish(name);
+        if (fish == null) {
+            return null;
+        }
+        return fish.clone();
     }
 
     public double getWorthMultiplier() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -162,7 +162,7 @@ public class Rarity extends ConfigBase {
                 fishSection = rootFishSection.createSection(fishStr);
             }
             try {
-                fishList.add(new Fish(this, fishSection));
+                fishList.add(Fish.createOrThrow(this, fishSection));
             } catch (InvalidFishException exception) {
                 EvenMoreFish.getInstance().getLogger().log(Level.WARNING, exception.getMessage(), exception);
             }


### PR DESCRIPTION
## Description
Cleans up Fish-related code

---

### What has changed?
- A Fish instance is now created with a static factory.
- Fish#clone no longer throws CloneNotSupportedException.
- EMFFishEvent is now fired and checked before issuing fish rewards.
- Cleans up FishingProcessor#getFish by moving bait code to the Bait class itself.
- Rarity#getFish now always returns a clone instead of the original instance. This should fix any sync issues.
- Added Rarity#getEditableFish which returns the original instance.
- FishUtils has been updated to match these changes.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.