### PR TITLE
Fixes maven publication

### DIFF
--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 version = 2.0
+group = "com.oheers.evenmorefish"
 
 dependencies {
     compileOnly(libs.spigot.api)
@@ -16,5 +17,18 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))
         vendor.set(JvmVendorSpec.ADOPTIUM)
+    }
+}
+
+publishing {
+    repositories {}
+    publications {
+        create<MavenPublication>("api") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+
+            from(components["java"])
+        }
     }
 }

--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -21,8 +21,22 @@ java {
 }
 
 publishing {
-    repositories {
-        // We can add CodeMC here when we're ready
+    repositories { // Copied directly from CodeMC's docs
+        val mavenUrl: String? by project
+        val mavenSnapshotUrl: String? by project
+
+        (if(version.toString().endsWith("SNAPSHOT")) mavenSnapshotUrl else mavenUrl)?.let { url ->
+            maven(url) {
+                val mavenUsername: String? by project
+                val mavenPassword: String? by project
+                if(mavenUsername != null && mavenPassword != null) {
+                    credentials {
+                        username = mavenUsername
+                        password = mavenPassword
+                    }
+                }
+            }
+        }
     }
     publications {
         create<MavenPublication>("api") {

--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -21,7 +21,9 @@ java {
 }
 
 publishing {
-    repositories {}
+    repositories {
+        // We can add CodeMC here when we're ready
+    }
     publications {
         create<MavenPublication>("api") {
             groupId = project.group.toString()

--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     id("com.oheers.evenmorefish.java-conventions")
 }
 
-version = 2.0
 group = "com.oheers.evenmorefish"
+version = "2.0.0-SNAPSHOT"
 
 dependencies {
     compileOnly(libs.spigot.api)

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -255,7 +255,9 @@ tasks {
 }
 
 publishing {
-    repositories {}
+    repositories {
+        // We can add CodeMC here when we're ready
+    }
     publications {
         create<MavenPublication>("plugin") {
             groupId = project.group.toString()

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.oheers.evenmorefish"
-version = "2.0.0"
+version = "2.0.0-SNAPSHOT"
 
 description = "A fishing extension bringing an exciting new experience to fishing."
 

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -254,6 +254,19 @@ tasks {
     }
 }
 
+publishing {
+    repositories {}
+    publications {
+        create<MavenPublication>("plugin") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+
+            from(components["shadow"])
+        }
+    }
+}
+
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(17))

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -255,8 +255,22 @@ tasks {
 }
 
 publishing {
-    repositories {
-        // We can add CodeMC here when we're ready
+    repositories { // Copied directly from CodeMC's docs
+        val mavenUrl: String? by project
+        val mavenSnapshotUrl: String? by project
+
+        (if(version.toString().endsWith("SNAPSHOT")) mavenSnapshotUrl else mavenUrl)?.let { url ->
+            maven(url) {
+                val mavenUsername: String? by project
+                val mavenPassword: String? by project
+                if(mavenUsername != null && mavenPassword != null) {
+                    credentials {
+                        username = mavenUsername
+                        password = mavenPassword
+                    }
+                }
+            }
+        }
     }
     publications {
         create<MavenPublication>("plugin") {

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -278,6 +278,7 @@ publishing {
             artifactId = project.name
             version = project.version.toString()
 
+            // Publish the fat jar so all relocated dependencies are available
             from(components["shadow"])
         }
     }


### PR DESCRIPTION
## Description
Makes `./gradlew publishToMavenLocal` work and prepares for publishing to CodeMC's maven repo

---

### What has changed?
- The API and Plugin modules now properly support `publishToMavenLocal`
- Added the CodeMC repo as a publish target
- Set the version to 2.0.0-SNAPSHOT so maven doesn't complain (this is especially important for when we start using CodeMC's maven repo)

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.
- [X] I have added any labels that fit this PR.