### PR TITLE
Fix CodeMC maven publication

### DIFF
--- a/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.oheers.evenmorefish.java-conventions.gradle.kts
@@ -10,19 +10,6 @@ repositories {
     maven("https://jitpack.io")
 }
 
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            groupId = groupId
-            artifactId = artifactId
-            version = version
-
-            from(components["java"])
-        }
-    }
-}
-
 tasks {
     if (project.name.contains("addons")) {
         val addonName = defaultAddonName(project.name)


### PR DESCRIPTION
## Description
Should fix publishing artifacts to CodeMC's repo

---

### What has changed?
- Removed the publishing block from `com.oheers.evenmorefish.java-conventions.gradle.kts` 

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.