### PR TITLE
fix: only run db tasks if database IS online

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/FishingProcessor.java
@@ -222,7 +222,7 @@ public class FishingProcessor implements Listener {
 
         competitionCheck(fish, player, location);
 
-        if (!MainConfig.getInstance().isDatabaseOnline()) {
+        if (MainConfig.getInstance().isDatabaseOnline()) {
             EvenMoreFish.getScheduler().runTaskAsynchronously(() -> {
                 if (EvenMoreFish.getInstance().getDatabaseV3().hasFishData(fish)) {
                     EvenMoreFish.getInstance().getDatabaseV3().incrementFish(fish);


### PR DESCRIPTION
## Description
Provide a brief description of the changes in this pull request.

Only run database tasks for the `FishingProcessor` if the database is online.
---

### What has changed?
Summarize the key changes in this pull request.

Removed the `!` not operator from line `FishingProcessor:225`

---

### Related Issues
Link related issues or describe which problem this PR fixes.

N/A, couldn't find.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR. <-- Can't add labels