### PR TITLE
Leaderboard fix

### DIFF
--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -135,6 +135,7 @@ bukkit {
         "Denizen",
         "EcoItems",
         "Oraxen",
+        "Nexo",
         "HeadDatabase",
         "GriefPrevention"
     )

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -257,14 +257,6 @@ public class Competition {
         }
     }
 
-    private void setPositionColour(int place, AbstractMessage message) {
-        switch (place) {
-            case 0 -> message.setPositionColour("&c» &r");
-            case 1 -> message.setPositionColour("&c_ &r");
-            case 2 -> message.setPositionColour("&c&ko &r");
-        }
-    }
-
     public void sendConsoleLeaderboard(CommandSender console) {
         if (!isActive()) {
             ConfigMessage.NO_COMPETITION_RUNNING.getMessage().send(console);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -70,7 +70,7 @@ public class Competition {
     }
 
     public void setMaxDuration(int duration) {
-        this.maxDuration = duration  * 60L;
+        this.maxDuration = duration * 60L;
     }
 
     public static boolean isActive() {
@@ -327,16 +327,15 @@ public class Competition {
 
         for (CompetitionEntry entry : entries) {
             pos++;
+            // If we're out of colours, break the loop
+            if (pos > competitionColours.size()) {
+                break;
+            }
             AbstractMessage message = ConfigMessage.LEADERBOARD_LARGEST_FISH.getMessage();
             message.setPlayer(Bukkit.getOfflinePlayer(entry.getPlayer()));
             message.setPosition(Integer.toString(pos));
 
-            if (pos > competitionColours.size()) {
-                int s = EvenMoreFish.getInstance().getRandom().nextInt(3);
-                setPositionColour(s, message);
-            } else {
-                message.setPositionColour(competitionColours.get(pos - 1));
-            }
+            message.setPositionColour(competitionColours.get(pos - 1));
 
             if (isConsole) {
                 message = competitionType.getStrategy().getSingleConsoleLeaderboardMessage(message, entry);


### PR DESCRIPTION
## Description
Fixes the competition leaderboard showing too many entries.

---

### What has changed?
- Competition#buildLeaderboardMessage now breaks the entry loop if it runs out of available colours.
- Re-added shouldBroadcastOnlyRods check, this must have been missed in the competition config reworks.
- Added Nexo to the plugin's soft-depend list

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.