### PR TITLE
Respect leaderboard-count config

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -27,7 +27,7 @@ import com.oheers.fish.config.GUIConfig;
 import com.oheers.fish.config.GUIFillerConfig;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.ConfigMessage;
-import com.oheers.fish.config.messages.Messages;
+import com.oheers.fish.config.messages.MessageConfig;
 import com.oheers.fish.database.DataManager;
 import com.oheers.fish.database.Database;
 import com.oheers.fish.economy.GriefPreventionEconomyType;
@@ -161,7 +161,7 @@ public class EvenMoreFish extends EMFPlugin {
         usingPlayerPoints = Bukkit.getPluginManager().isPluginEnabled("PlayerPoints");
 
         new MainConfig();
-        new Messages();
+        new MessageConfig();
 
         saveAdditionalDefaultAddons();
         this.addonManager = new AddonManager(this);
@@ -442,7 +442,7 @@ public class EvenMoreFish extends EMFPlugin {
         saveDefaultConfig();
 
         MainConfig.getInstance().reload();
-        Messages.getInstance().reload();
+        MessageConfig.getInstance().reload();
         GUIConfig.getInstance().reload();
         GUIFillerConfig.getInstance().reload();
         BaitFile.getInstance().reload();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/commands/AdminCommand.java
@@ -16,7 +16,7 @@ import com.oheers.fish.competition.configs.CompetitionFile;
 import com.oheers.fish.config.ConfigBase;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.ConfigMessage;
-import com.oheers.fish.config.messages.Messages;
+import com.oheers.fish.config.messages.MessageConfig;
 import com.oheers.fish.fishing.items.Fish;
 import com.oheers.fish.fishing.items.FishManager;
 import com.oheers.fish.fishing.items.Rarity;
@@ -341,7 +341,7 @@ public class AdminCommand {
                     {prefix} Database Engine: {engine}\s
                     {prefix} Database Type: {type}\s
                     """
-                        .replace("{prefix}", Messages.getInstance().getSTDPrefix())
+                        .replace("{prefix}", MessageConfig.getInstance().getSTDPrefix())
                         .replace("{version}", EvenMoreFish.getInstance().getDescription().getVersion())
                         .replace("{branch}", getFeatureBranchName())
                         .replace("{build-date}", getFeatureBranchBuildOrDate())

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -314,13 +314,15 @@ public class Competition {
             entries = List.of();
         }
 
+        int maxCount = Messages.getInstance().getLeaderboardCount();
+
         StringBuilder builder = new StringBuilder();
         int pos = 0;
 
         for (CompetitionEntry entry : entries) {
             pos++;
-            // If we're out of colours, break the loop
-            if (pos > competitionColours.size()) {
+            // If we're out of colours or the max count is reached, break the loop
+            if (pos > competitionColours.size() || pos > maxCount) {
                 break;
             }
             AbstractMessage message = ConfigMessage.LEADERBOARD_LARGEST_FISH.getMessage();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -11,7 +11,7 @@ import com.oheers.fish.competition.configs.CompetitionFile;
 import com.oheers.fish.competition.leaderboard.Leaderboard;
 import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.messages.ConfigMessage;
-import com.oheers.fish.config.messages.Messages;
+import com.oheers.fish.config.messages.MessageConfig;
 import com.oheers.fish.database.DataManager;
 import com.oheers.fish.database.model.UserReport;
 import com.oheers.fish.fishing.items.Fish;
@@ -236,8 +236,8 @@ public class Competition {
      * @return A boolean, true = do it in actionbar.
      */
     public boolean isDoingFirstPlaceActionBar() {
-        boolean doActionBarMessage = Messages.getInstance().getConfig().getBoolean("action-bar-message");
-        boolean isSupportedActionBarType = Messages.getInstance().getConfig().getStringList("action-bar-types").isEmpty() || Messages.getInstance()
+        boolean doActionBarMessage = MessageConfig.getInstance().getConfig().getBoolean("action-bar-message");
+        boolean isSupportedActionBarType = MessageConfig.getInstance().getConfig().getStringList("action-bar-types").isEmpty() || MessageConfig.getInstance()
                 .getConfig()
                 .getStringList("action-bar-types")
                 .contains(getCompetitionType().toString());
@@ -314,7 +314,7 @@ public class Competition {
             entries = List.of();
         }
 
-        int maxCount = Messages.getInstance().getLeaderboardCount();
+        int maxCount = MessageConfig.getInstance().getLeaderboardCount();
 
         StringBuilder builder = new StringBuilder();
         int pos = 0;

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/ConfigMessage.java
@@ -293,7 +293,7 @@ public enum ConfigMessage {
     }
 
     public boolean isListForm() {
-        return !Messages.getInstance().getConfig().getStringList(getId()).isEmpty();
+        return !MessageConfig.getInstance().getConfig().getStringList(getId()).isEmpty();
     }
 
     public PrefixType getPrefixType() {
@@ -337,7 +337,7 @@ public enum ConfigMessage {
      * @return The string from config that matches the value of id.
      */
     private String getString(String normal, String id) {
-        Messages messageConfig = Messages.getInstance();
+        MessageConfig messageConfig = MessageConfig.getInstance();
         String string = messageConfig.getConfig().getString(id, null);
         if (string == null) {
             EvenMoreFish.getInstance().getLogger().warning("No valid value in messages.yml for: " + id + ". Attempting to insert the default value.");
@@ -357,7 +357,7 @@ public enum ConfigMessage {
      * @return The string list from config that matches the value of id.
      */
     private List<String> getStringList(List<String> normal, String id) {
-        Messages messageConfig = Messages.getInstance();
+        MessageConfig messageConfig = MessageConfig.getInstance();
         List<String> list = messageConfig.getConfig().getStringList(id);
         if (list.isEmpty()) {
             EvenMoreFish.getInstance().getLogger().warning("No valid value in messages.yml for: " + id + ". Attempting to insert the default value.");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/MessageConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/MessageConfig.java
@@ -6,16 +6,16 @@ import com.oheers.fish.config.ConfigBase;
 import com.oheers.fish.config.MainConfig;
 import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
 
-public class Messages extends ConfigBase {
+public class MessageConfig extends ConfigBase {
 
-    private static Messages instance = null;
+    private static MessageConfig instance = null;
 
-    public Messages() {
+    public MessageConfig() {
         super("messages.yml", "locales/" + "messages_" + MainConfig.getInstance().getLocale() + ".yml", EvenMoreFish.getInstance(), true);
         instance = this;
     }
 
-    public static Messages getInstance() {
+    public static MessageConfig getInstance() {
         return instance;
     }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Messages.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/Messages.java
@@ -26,6 +26,10 @@ public class Messages extends ConfigBase {
         return message.getLegacyMessage();
     }
 
+    public int getLeaderboardCount() {
+        return getConfig().getInt("leaderboard-count", 5);
+    }
+
     @Override
     public UpdaterSettings getUpdaterSettings() {
         UpdaterSettings.Builder builder = UpdaterSettings.builder(super.getUpdaterSettings());

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/PrefixType.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/PrefixType.java
@@ -33,7 +33,7 @@ public enum PrefixType {
         if (id == null) {
             return EvenMoreFish.getAdapter().createMessage("");
         } else {
-            AbstractMessage message = EvenMoreFish.getAdapter().createMessage(Messages.getInstance().getConfig().getString(id, normal));
+            AbstractMessage message = EvenMoreFish.getAdapter().createMessage(MessageConfig.getInstance().getConfig().getString(id, normal));
             message.appendString("&r");
             return message;
         }


### PR DESCRIPTION
### What has changed?
- The competition leaderboard now respects the `leaderboard-count` config in the messages file.
- Renamed Messages class to MessageConfig to match the other config classes

---

### Related Issues
Closes #557 

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.