### PR TITLE
Update config-version to be higher than EMF 1.6.11.17

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/MessageConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/MessageConfig.java
@@ -35,7 +35,7 @@ public class MessageConfig extends ConfigBase {
         UpdaterSettings.Builder builder = UpdaterSettings.builder(super.getUpdaterSettings());
 
         // Bossbar config relocations - config version 2
-        builder.addCustomLogic("2", yamlDocument -> {
+        builder.addCustomLogic("18", yamlDocument -> {
             String hourColor = yamlDocument.getString("bossbar.hour-color", "&f");
             String hour = yamlDocument.getString("bossbar.hour", "h");
             yamlDocument.set("bossbar.hour", hourColor + "{hour}" + hour);
@@ -53,7 +53,7 @@ public class MessageConfig extends ConfigBase {
         });
 
         // Prefix config relocations - config version 3
-        builder.addCustomLogic("3", yamlDocument -> {
+        builder.addCustomLogic("19", yamlDocument -> {
             String prefix = yamlDocument.getString("prefix");
 
             String oldRegular = yamlDocument.getString("prefix-regular");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/MessageConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/messages/MessageConfig.java
@@ -36,36 +36,44 @@ public class MessageConfig extends ConfigBase {
 
         // Bossbar config relocations - config version 2
         builder.addCustomLogic("18", yamlDocument -> {
-            String hourColor = yamlDocument.getString("bossbar.hour-color", "&f");
-            String hour = yamlDocument.getString("bossbar.hour", "h");
-            yamlDocument.set("bossbar.hour", hourColor + "{hour}" + hour);
-            yamlDocument.remove("bossbar.hour-color");
+            if (yamlDocument.contains("bossbar.hour-color")) {
+                String hourColor = yamlDocument.getString("bossbar.hour-color", "&f");
+                String hour = yamlDocument.getString("bossbar.hour", "h");
+                yamlDocument.set("bossbar.hour", hourColor + "{hour}" + hour);
+                yamlDocument.remove("bossbar.hour-color");
+            }
 
-            String minuteColor = yamlDocument.getString("bossbar.minute-color", "&f");
-            String minute = yamlDocument.getString("bossbar.minute", "m");
-            yamlDocument.set("bossbar.minute", minuteColor + "{minute}" + minute);
-            yamlDocument.remove("bossbar.minute-color");
+            if (yamlDocument.contains("bossbar.minute-color")) {
+                String minuteColor = yamlDocument.getString("bossbar.minute-color", "&f");
+                String minute = yamlDocument.getString("bossbar.minute", "m");
+                yamlDocument.set("bossbar.minute", minuteColor + "{minute}" + minute);
+                yamlDocument.remove("bossbar.minute-color");
+            }
 
-            String secondColor = yamlDocument.getString("bossbar.second-color", "&f");
-            String second = yamlDocument.getString("bossbar.second", "s");
-            yamlDocument.set("bossbar.second", secondColor + "{second}" + second);
-            yamlDocument.remove("bossbar.second-color");
+            if (yamlDocument.contains("bossbar.second-color")) {
+                String secondColor = yamlDocument.getString("bossbar.second-color", "&f");
+                String second = yamlDocument.getString("bossbar.second", "s");
+                yamlDocument.set("bossbar.second", secondColor + "{second}" + second);
+                yamlDocument.remove("bossbar.second-color");
+            }
         });
 
         // Prefix config relocations - config version 3
         builder.addCustomLogic("19", yamlDocument -> {
-            String prefix = yamlDocument.getString("prefix");
+            if (yamlDocument.contains("prefix")) {
+                String prefix = yamlDocument.getString("prefix");
 
-            String oldRegular = yamlDocument.getString("prefix-regular");
-            yamlDocument.set("prefix-regular", oldRegular + prefix);
+                String oldRegular = yamlDocument.getString("prefix-regular");
+                yamlDocument.set("prefix-regular", oldRegular + prefix);
 
-            String oldAdmin = yamlDocument.getString("prefix-admin");
-            yamlDocument.set("prefix-admin", oldAdmin + prefix);
+                String oldAdmin = yamlDocument.getString("prefix-admin");
+                yamlDocument.set("prefix-admin", oldAdmin + prefix);
 
-            String oldError = yamlDocument.getString("prefix-error");
-            yamlDocument.set("prefix-error", oldError + prefix);
+                String oldError = yamlDocument.getString("prefix-error");
+                yamlDocument.set("prefix-error", oldError + prefix);
 
-            yamlDocument.remove("prefix");
+                yamlDocument.remove("prefix");
+            }
         });
 
         return builder.build();

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -189,4 +189,4 @@ biome-sets:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 6
+config-version: 20

--- a/even-more-fish-plugin/src/main/resources/locales/messages_cs.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_cs.yml
@@ -192,4 +192,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_da.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_da.yml
@@ -198,4 +198,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_de.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_de.yml
@@ -192,4 +192,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -255,4 +255,4 @@ rarity-invalid: "&rThat is not a valid rarity!"
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 10
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_es.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_es.yml
@@ -244,4 +244,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_fr.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_fr.yml
@@ -192,4 +192,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_ja.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_ja.yml
@@ -199,4 +199,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_ko.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_ko.yml
@@ -133,4 +133,4 @@ bait-use: "{bait_theme}&l{bait} &r미끼 중 하나를 사용했습니다."
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_nl.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_nl.yml
@@ -202,4 +202,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_pl.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_pl.yml
@@ -199,4 +199,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_pt-br.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_pt-br.yml
@@ -237,4 +237,4 @@ admin:
 
 # ATENÇÃO ATENÇÃO ATENÇÃO
 # NÃO EDITE ESTE VALOR OU AS COISAS QUEBRARÃO!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_ru.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_ru.yml
@@ -139,4 +139,4 @@ toggle-on: "Теперь вы будете ловить кастомную ры�
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_tr.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_tr.yml
@@ -121,4 +121,4 @@ emf-competition-fish-format: "{length}cm &l{rarity} {fish}"
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_vn.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_vn.yml
@@ -172,4 +172,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_zh_cn.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_zh_cn.yml
@@ -207,4 +207,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26

--- a/even-more-fish-plugin/src/main/resources/locales/messages_zh_tw.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_zh_tw.yml
@@ -189,4 +189,4 @@ admin:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-config-version: 8
+config-version: 26


### PR DESCRIPTION
## Description
Fixes a downgrade error by making config-versions higher than they were in 1.6.11.17.

---

### What has changed?
config.yml's config-version is now 20. It was 14 in 1.6.11.17 + 6 in 2.0.0-SNAPSHOT.
messages.yml's config-version is now 26. It was 16 in 1.6.11.17 + 10 in 2.0.0-SNAPSHOT.
Updated MessageConfig's custom version logic to use the new version numbers.

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
- [x] I have added any labels that fit this PR.