### PR TITLE
Add next/previous page buttons to the Journal menu

### DIFF
--- a/even-more-fish-plugin/src/main/resources/guis.yml
+++ b/even-more-fish-plugin/src/main/resources/guis.yml
@@ -297,7 +297,7 @@ journal-menu:
     - '2rrrrrrr2'
     - '3rrrrrrr3'
     - '2rrrrrrr2'
-    - ' 323x323 '
+    - 'p323x323n'
   filler: gray_stained_glass_pane
   # The character to use for rarity items
   rarity-character: r
@@ -343,7 +343,7 @@ journal-rarity:
     - ' fffffff '
     - ' fffffff '
     - ' fffffff '
-    - '    x    '
+    - 'p   x   n'
   filler: gray_stained_glass_pane
   # The character to use for fish items
   fish-character: f


### PR DESCRIPTION
### What has changed?
- The default journal menu configs now have next/previous page buttons

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.