### PR TITLE
Added limit to jooq plugin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,10 @@
       "groupName": "jOOQ",
       "allowedVersions": "~3.19.0"
     },
-
+    {
+      "matchPackagePrefixes": ["nu.studer.jooq:"],
+      "allowedVersions": "~9.0"
+    },
     {
       "matchUpdateTypes": ["patch", "minor"],
       "matchCurrentVersion": "!/^0/",


### PR DESCRIPTION
## Description
The jooq plugin should not be updated beyond 9.X. At least until we support JDK21

---

### What has changed?
Added rule matching the jooq plugin

---

### Related Issues


---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.