### PR TITLE
Correctly format %emf_competition_type_format%

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/placeholders/PlaceholderReceiver.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/placeholders/PlaceholderReceiver.java
@@ -169,7 +169,12 @@ public class PlaceholderReceiver extends PlaceholderExpansion {
         }
 
         ConfigMessage message = COMPETITION_TYPE_MESSAGES.get(activeComp.getCompetitionType());
-        return message != null ? message.getMessage().getLegacyMessage() : "";
+        if (message == null) {
+            return "";
+        }
+
+        EMFMessage typeFormat = activeComp.getCompetitionType().getStrategy().getTypeFormat(activeComp, message);
+        return typeFormat.getLegacyMessage();
     }
 
     private String handleCompetitionType(Player player, String identifier) {


### PR DESCRIPTION
### What has changed?
- %emf_competition_type_format% now correctly formats the message using the competition strategy.

---

### Related Issues
N/A

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.