### PR TITLE
Use compileOnlyApi for BoostedYAML

### DIFF
--- a/even-more-fish-api/build.gradle.kts
+++ b/even-more-fish-api/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     }
     compileOnly(libs.annotations)
     compileOnly(libs.universalscheduler)
-    compileOnly(libs.boostedyaml)
+    compileOnlyApi(libs.boostedyaml)
 }
 
 

--- a/even-more-fish-plugin/build.gradle.kts
+++ b/even-more-fish-plugin/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
     library(libs.annotations)
     library(libs.guava)
 
-    compileOnly(libs.boostedyaml)
+    compileOnlyApi(libs.boostedyaml)
 
     jooqGenerator(project(":even-more-fish-database-extras"))
     jooqGenerator(libs.jooq.meta.extensions)


### PR DESCRIPTION
### What has changed?
- BoostedYAML now uses compileOnlyApi in all modules.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.