### PR TITLE
fix(lang): not properly handling empty messages

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -44,6 +44,10 @@ public abstract class EMFMessage {
     public abstract void setUnderlying(@NotNull ComponentMessage message);
 
     public final void send(@NotNull Audience target) {
+        if (getUnderlying().isEmpty()) {
+            return;
+        }
+
         if (target instanceof Player player) {
             OfflinePlayer relevant = relevantPlayer == null ? player : relevantPlayer;
             getUnderlying().replace("{player}", relevant.getName())
@@ -62,6 +66,10 @@ public abstract class EMFMessage {
     }
 
     public final void sendActionBar(@NotNull Audience target) {
+        if (getUnderlying().isEmpty()) {
+            return;
+        }
+
         if (target instanceof Player player) {
             OfflinePlayer relevant = relevantPlayer == null ? player : relevantPlayer;
             getUnderlying().messageType(MessageType.ACTION_BAR)

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -23,7 +23,7 @@ contest-end: <white>The fishing contest has ended.
 # The message to be sent when a player joins whilst a competition is going on
 contest-join: <white>A fishing contest for {type} is occurring.
 
-# Shown to players when a new player takes #1 spot, remove this value or set it to "" to disable this message
+# Shown to players when a new player takes #1 spot, remove this value or set it to "-s" to disable this message
 new-first: '<white>{player} is now #1'
 # Should this message appear in chat (false) or above the exp bar (true)
 action-bar-message: true


### PR DESCRIPTION
## Description
Provide a brief description of the changes in this pull request.

EMF wasn't properly recognizing empty component messages and was just sending empty components out to players.

### What has changed?
Summarize the key changes in this pull request.

EMF now ignores empty components and doesn't send anything

### Related Issues
Link related issues or describe which problem this PR fixes.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.