### PR TITLE
Allow rarity items to use ItemFactory

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/fishing/items/IRarity.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/fishing/items/IRarity.java
@@ -40,7 +40,18 @@ public interface IRarity {
 
     double getWorthMultiplier();
 
-    @NotNull ItemStack getMaterial();
+    /**
+     * @deprecated Use {@link #getJournalItem()} instead.
+     */
+    @Deprecated
+    default ItemStack getMaterial() {
+        return getJournalItem();
+    }
+
+    /**
+     * @return The item to use in the journal menu, before display and lore is changed.
+     */
+    @NotNull ItemStack getJournalItem();
 
     boolean getShowInJournal();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -9,6 +9,7 @@ import com.oheers.fish.api.config.ConfigUtils;
 import com.oheers.fish.exceptions.InvalidFishException;
 import com.oheers.fish.api.fishing.CatchType;
 import com.oheers.fish.fishing.items.config.RarityFileUpdates;
+import com.oheers.fish.items.ItemFactory;
 import com.oheers.fish.messages.EMFSingleMessage;
 import dev.dejvokep.boostedyaml.block.implementation.Section;
 import org.bukkit.Material;
@@ -185,9 +186,15 @@ public class Rarity extends ConfigBase implements IRarity {
     }
 
     @Override
-    public @NotNull ItemStack getMaterial() {
-        ItemStack item = FishUtils.getItem(getConfig().getString("material"));
-        return item == null ? new ItemStack(Material.COD) : item;
+    public @NotNull ItemStack getJournalItem() {
+        // Old format for compatibility
+        ItemStack oldItem = FishUtils.getItem(getConfig().getString("material"));
+        if (oldItem != null) {
+            return oldItem;
+        }
+        // New format that accepts ItemFactory configs
+        ItemFactory factory = ItemFactory.itemFactory(getConfig());
+        return factory.createItem();
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/FishJournalGui.java
@@ -206,7 +206,7 @@ public class FishJournalGui extends ConfigGui {
             return ItemFactory.itemFactory(section, "undiscovered-rarity").createItem(player.getUniqueId());
         }
 
-        final ItemStack rarityItem = rarity.getMaterial();
+        final ItemStack rarityItem = rarity.getJournalItem();
         final ItemStack configuredItem = ItemFactory.itemFactory(section, "rarity-item").createItem(player.getUniqueId());
 
         // Carry the configured item's lore and display name to the rarity item

--- a/even-more-fish-plugin/src/main/resources/rarities/_example.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/_example.yml
@@ -11,8 +11,10 @@ disabled: false
 # How should the rarity be formatted in messages?
 format: <light_purple>{name}
 
-# The material to represent this rarity in GUIs. Defaults to iron_bars if missing.
-material: magenta_concrete_powder
+# The item to represent this rarity inside the fish journal. Defaults to iron bars if missing.
+# See the wiki for all options: https://evenmorefish.github.io/EvenMoreFish/docs/configuration/items
+item:
+  material: iron_bars
 
 # How likely is the rarity to be chosen? Having a greater weight means the rarity is more likely to be chosen (the total weights don't have to add to 100)
 weight: 5

--- a/even-more-fish-plugin/src/main/resources/rarities/common.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/common.yml
@@ -1,7 +1,8 @@
 id: Common
 disabled: false
 weight: 100
-material: light_gray_concrete_powder
+item:
+  material: light_gray_concrete_powder
 format: <gray>{name}
 worth-multiplier: 0.1
 broadcast: false

--- a/even-more-fish-plugin/src/main/resources/rarities/epic.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/epic.yml
@@ -1,7 +1,8 @@
 id: Epic
 disabled: false
 weight: 3
-material: magenta_concrete_powder
+item:
+  material: magenta_concrete_powder
 format: <light_purple>{name}
 worth-multiplier: 0.15
 broadcast: true

--- a/even-more-fish-plugin/src/main/resources/rarities/junk.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/junk.yml
@@ -1,7 +1,8 @@
 id: Junk
 disabled: false
 weight: 5
-material: white_concrete_powder
+item:
+  material: white_concrete_powder
 format: <#888888>{name}
 worth-multiplier: 0.2
 broadcast: false

--- a/even-more-fish-plugin/src/main/resources/rarities/legendary.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/legendary.yml
@@ -1,7 +1,8 @@
 id: Legendary
 disabled: false
 weight: 1
-material: yellow_concrete_powder
+item:
+  material: yellow_concrete_powder
 format: <gold>{name}
 worth-multiplier: 0.2
 broadcast: true

--- a/even-more-fish-plugin/src/main/resources/rarities/rare.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/rare.yml
@@ -1,7 +1,8 @@
 id: Rare
 disabled: false
 weight: 10
-material: light_blue_concrete_powder
+item:
+  material: light_blue_concrete_powder
 format: <aqua>{name}
 worth-multiplier: 0.2
 broadcast: false


### PR DESCRIPTION
## Description
Old Format:
`material: light_gray_concrete_powder`

New Format (Supports all item configs):
```
item:
  material: light_gray_concrete_powder
```

---

### What has changed?
- Allow rarities to be configured using ItemFactory.
- Updated all default configs.
- Deprecated `IRarity#getMaterial` in favor of `IRarity#getJournalItem`.

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.