### PR TITLE
Make recipes persist after server reload

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
@@ -11,6 +11,7 @@ import com.oheers.fish.events.FishInteractEvent;
 import com.oheers.fish.fishing.EMFFishListener;
 import com.oheers.fish.fishing.FishingProcessor;
 import com.oheers.fish.fishing.HuntingProcessor;
+import com.oheers.fish.recipe.RecipeListener;
 import com.oheers.fish.update.UpdateNotify;
 import com.oheers.fish.utils.ItemProtectionListener;
 import org.bukkit.plugin.PluginManager;
@@ -41,6 +42,7 @@ public class EventManager {
         pm.registerEvents(new BaitApplicationListener(), plugin);
         pm.registerEvents(new ItemProtectionListener(), plugin);
         pm.registerEvents(new FishInteractEvent(), plugin);
+        pm.registerEvents(new RecipeListener(), plugin);
     }
 
     public void registerOptionalListeners() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/recipe/RecipeListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/recipe/RecipeListener.java
@@ -1,0 +1,19 @@
+package com.oheers.fish.recipe;
+
+import com.oheers.fish.api.Logging;
+import com.oheers.fish.fishing.rods.RodManager;
+import io.papermc.paper.event.server.ServerResourcesReloadedEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class RecipeListener implements Listener {
+
+    @EventHandler
+    public void onReload(ServerResourcesReloadedEvent event) {
+        Logging.info("Detected server reload. Reloading all custom recipes.");
+
+        // Custom rods are currently the only items with custom recipes.
+        RodManager.getInstance().reload();
+    }
+
+}


### PR DESCRIPTION
### What has changed?
- Added RecipeListener to reload RodManager when a `/minecraft:reload` is done.

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.