### PR TITLE
Handle UnsupportedOperationException in config update

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/config/ConfigBase.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/config/ConfigBase.java
@@ -163,7 +163,7 @@ public class ConfigBase {
         }
         try {
             getConfig().update();
-        } catch (IOException exception) {
+        } catch (IOException | UnsupportedOperationException exception) {
             plugin.getLogger().warning("Failed to update " + getFileName());
         }
     }


### PR DESCRIPTION
## Description
Handle UnsupportedOperationException in config update. We catch an additional exception, this is useful for "downgrading is not possible" errors. The current implementation does not record the file name.
Will be useful for debugging.

---

### What has changed?
Catching an additional exception. 

---

### Related Issues
N/A

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.