### PR TITLE
Potentially fix mariadb issues

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -144,7 +144,7 @@ public class Database implements DatabaseAPI {
 
     @NotNull
     public DSLContext getContext(Connection connection) {
-        return DSL.using(connection, DatabaseUtil.getSQLDialect(this.connectionFactory.getType()), this.settings);
+        return DSL.using(connection, this.connectionFactory.getSQLDialect(connection), this.settings);
     }
 
     @Override

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/execute/ExecuteBase.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/execute/ExecuteBase.java
@@ -1,6 +1,5 @@
 package com.oheers.fish.database.execute;
 
-import com.oheers.fish.database.DatabaseUtil;
 import com.oheers.fish.database.connection.ConnectionFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
@@ -21,9 +20,9 @@ public abstract class ExecuteBase {
 
     protected @NotNull DSLContext getContext(Connection connection) {
         if (settings == null) {
-            return DSL.using(connection, DatabaseUtil.getSQLDialect(connectionFactory.getType()));
+            return DSL.using(connection, connectionFactory.getSQLDialect(connection));
         }
-        return DSL.using(connection, DatabaseUtil.getSQLDialect(connectionFactory.getType()), settings);
+        return DSL.using(connection, connectionFactory.getSQLDialect(connection), settings);
     }
 
     protected Connection getConnection() throws SQLException {


### PR DESCRIPTION
## Description
Fixes jOOQ SQL rendering for MySQL-compatible databases by selecting the SQL dialect from the actual JDBC server metadata at runtime (MariaDB vs MySQL), instead of relying only on configured database type.

---

### What has changed?
- Added runtime SQL dialect detection in `ConnectionFactory` using `DatabaseMetaData` (`productName`, `productVersion`, `url`).
- Added fallback mapping to configured type for non-MySQL databases (`H2`, `SQLite`, etc.) when detection is unavailable.
- Updated DSL context creation paths to use detected dialect:
  - `ExecuteBase#getContext(...)`
  - `Database#getContext(...)`
- Cached the resolved dialect in the connection factory to avoid repeated metadata parsing.

---

### Related Issues
Fixes MariaDB incompatibility where jOOQ rendered MySQL-style `ON DUPLICATE KEY UPDATE` SQL that MariaDB rejected in this environment.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.
