### PR TITLE
Fixes a database update failure (`TooManyRowsException`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ build
 !gradle/*
 
 /.vscode
+
+.PR-REQUEST.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+If asked by the user to create a PR of the changes. 
+Use the template from .github/PULL_REQUEST_TEMPLATE.md for your repsonse, you can create the new file at root with the name ".PR-REQUEST.md"

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -189,10 +189,12 @@ public class Database implements DatabaseAPI {
         return new ExecuteQuery<Integer>(connectionFactory, settings) {
             @Override
             protected Integer onRunQuery(DSLContext dslContext) {
-                Integer id = dslContext.select()
+                Integer id = dslContext.select(Tables.USERS.ID)
                         .from(Tables.USERS)
                         .where(Tables.USERS.UUID.eq(uuid.toString()))
-                        .fetchOne(Tables.USERS.ID);
+                        .orderBy(Tables.USERS.ID.asc())
+                        .limit(1)
+                        .fetchAny(Tables.USERS.ID);
 
                 if (id == null) {
                     return empty();
@@ -216,7 +218,9 @@ public class Database implements DatabaseAPI {
                 org.jooq.Record tableRecord = dslContext.select()
                         .from(Tables.USERS)
                         .where(Tables.USERS.UUID.eq(uuid.toString()))
-                        .fetchOne();
+                        .orderBy(Tables.USERS.ID.asc())
+                        .limit(1)
+                        .fetchAny();
                 if (tableRecord == null) {
                     return empty();
                 }
@@ -709,44 +713,56 @@ public class Database implements DatabaseAPI {
         return new ExecuteUpdate(connectionFactory, settings) {
             @Override
             protected int onRunUpdate(DSLContext dslContext) {
-                Integer id = dslContext.insertInto(Tables.USERS)
-                        .set(Tables.USERS.UUID, report.getUuid().toString())
-                        .set(Tables.USERS.COMPETITIONS_JOINED, report.getCompetitionsJoined())
-                        .set(Tables.USERS.COMPETITIONS_WON, report.getCompetitionsWon())
-                        .set(Tables.USERS.TOTAL_FISH_LENGTH, report.getTotalFishLength())
-                        .set(Tables.USERS.FIRST_FISH, report.getFirstFish().toString())
-                        .set(Tables.USERS.MONEY_EARNED, report.getMoneyEarned())
-                        .set(Tables.USERS.FISH_SOLD, report.getFishSold())
-                        .set(Tables.USERS.NUM_FISH_CAUGHT, report.getNumFishCaught())
-                        .set(Tables.USERS.LARGEST_FISH, report.getLargestFish().toString())
-                        .set(Tables.USERS.LARGEST_LENGTH, report.getLargestLength())
-                        .set(Tables.USERS.LAST_FISH, report.getLargestFish().toString())
-                        .set(Tables.USERS.SHORTEST_FISH, report.getShortestFish().toString())
-                        .set(Tables.USERS.SHORTEST_LENGTH, report.getShortestLength())
-                        .onDuplicateKeyUpdate()
-                        .set(Tables.USERS.COMPETITIONS_JOINED, report.getCompetitionsJoined())
-                        .set(Tables.USERS.COMPETITIONS_WON, report.getCompetitionsWon())
-                        .set(Tables.USERS.TOTAL_FISH_LENGTH, report.getTotalFishLength())
-                        .set(Tables.USERS.FIRST_FISH, report.getFirstFish().toString())
-                        .set(Tables.USERS.MONEY_EARNED, report.getMoneyEarned())
-                        .set(Tables.USERS.FISH_SOLD, report.getFishSold())
-                        .set(Tables.USERS.NUM_FISH_CAUGHT, report.getNumFishCaught())
-                        .set(Tables.USERS.LARGEST_FISH, report.getLargestFish().toString())
-                        .set(Tables.USERS.LARGEST_LENGTH, report.getLargestLength())
-                        .set(Tables.USERS.LAST_FISH, report.getLargestFish().toString())
-                        .set(Tables.USERS.SHORTEST_FISH, report.getShortestFish().toString())
-                        .set(Tables.USERS.SHORTEST_LENGTH, report.getShortestLength())
-                        .returning(Tables.USERS.ID)
-                        .fetchOne(Tables.USERS.ID);
+                final String userUuid = report.getUuid().toString();
+
+                Integer id = dslContext.select(Tables.USERS.ID)
+                        .from(Tables.USERS)
+                        .where(Tables.USERS.UUID.eq(userUuid))
+                        .orderBy(Tables.USERS.ID.asc())
+                        .limit(1)
+                        .fetchAny(Tables.USERS.ID);
 
                 if (id != null) {
+                    dslContext.update(Tables.USERS)
+                            .set(Tables.USERS.COMPETITIONS_JOINED, report.getCompetitionsJoined())
+                            .set(Tables.USERS.COMPETITIONS_WON, report.getCompetitionsWon())
+                            .set(Tables.USERS.TOTAL_FISH_LENGTH, report.getTotalFishLength())
+                            .set(Tables.USERS.FIRST_FISH, report.getFirstFish().toString())
+                            .set(Tables.USERS.MONEY_EARNED, report.getMoneyEarned())
+                            .set(Tables.USERS.FISH_SOLD, report.getFishSold())
+                            .set(Tables.USERS.NUM_FISH_CAUGHT, report.getNumFishCaught())
+                            .set(Tables.USERS.LARGEST_FISH, report.getLargestFish().toString())
+                            .set(Tables.USERS.LARGEST_LENGTH, report.getLargestLength())
+                            .set(Tables.USERS.LAST_FISH, report.getLargestFish().toString())
+                            .set(Tables.USERS.SHORTEST_FISH, report.getShortestFish().toString())
+                            .set(Tables.USERS.SHORTEST_LENGTH, report.getShortestLength())
+                            .where(Tables.USERS.ID.eq(id))
+                            .execute();
                     return id;
                 }
 
+                dslContext.insertInto(Tables.USERS)
+                        .set(Tables.USERS.UUID, userUuid)
+                        .set(Tables.USERS.COMPETITIONS_JOINED, report.getCompetitionsJoined())
+                        .set(Tables.USERS.COMPETITIONS_WON, report.getCompetitionsWon())
+                        .set(Tables.USERS.TOTAL_FISH_LENGTH, report.getTotalFishLength())
+                        .set(Tables.USERS.FIRST_FISH, report.getFirstFish().toString())
+                        .set(Tables.USERS.MONEY_EARNED, report.getMoneyEarned())
+                        .set(Tables.USERS.FISH_SOLD, report.getFishSold())
+                        .set(Tables.USERS.NUM_FISH_CAUGHT, report.getNumFishCaught())
+                        .set(Tables.USERS.LARGEST_FISH, report.getLargestFish().toString())
+                        .set(Tables.USERS.LARGEST_LENGTH, report.getLargestLength())
+                        .set(Tables.USERS.LAST_FISH, report.getLargestFish().toString())
+                        .set(Tables.USERS.SHORTEST_FISH, report.getShortestFish().toString())
+                        .set(Tables.USERS.SHORTEST_LENGTH, report.getShortestLength())
+                        .execute();
+
                 Integer fallbackId = dslContext.select(Tables.USERS.ID)
                         .from(Tables.USERS)
-                        .where(Tables.USERS.UUID.eq(report.getUuid().toString()))
-                        .fetchOne(Tables.USERS.ID);
+                        .where(Tables.USERS.UUID.eq(userUuid))
+                        .orderBy(Tables.USERS.ID.asc())
+                        .limit(1)
+                        .fetchAny(Tables.USERS.ID);
 
                 return fallbackId == null ? 0 : fallbackId;
             }


### PR DESCRIPTION
## Description
Fixes a database update failure (`TooManyRowsException`) when duplicate rows exist for the same user UUID in the `users` table.

---

### What has changed?
- Updated user lookups to avoid `fetchOne(...)` assumptions when duplicate UUID rows exist:
  - `getUserId(...)` now selects by UUID with `ORDER BY id ASC LIMIT 1`.
  - `getUserReport(...)` now selects by UUID with `ORDER BY id ASC LIMIT 1`.
- Reworked `upsertUserReport(...)` to use deterministic logic:
  - Select existing user row ID by UUID (`ORDER BY id ASC LIMIT 1`).
  - Update that row by ID if found.
  - Insert a new row only when no user exists.
  - Re-select canonical ID safely.
- This avoids runtime failures on legacy datasets that may contain duplicate UUID rows and also prevents creating more duplicates in that path.

---

### Related Issues
Fixes the runtime error:
`com.oheers.fish.libs.jooq.exception.TooManyRowsException: Cursor returned more than one result`
triggered from `Database.upsertUserReport(...)`.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.