### PR TITLE
i18n: fix prefix formatting in zh_cn locale

### DIFF
--- a/even-more-fish-plugin/src/main/resources/locales/messages_zh_cn.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_zh_cn.yml
@@ -51,11 +51,11 @@ duration:
   minute: <white>{minute}m
   second: <white>{second}s
 # The prefix shown in commands. Keeping the space in is recommended.
-prefix-regular: '<bold><aqua>更多的鱼 <reset></aqua></bold><gray>>> '
+prefix-regular: '<bold><aqua>更多的鱼 <reset><gray>>> '
 # The prefix shown in admin commands.
-prefix-admin: '<bold><aqua>更多的鱼 <reset></aqua></bold><gray>>> '
+prefix-admin: '<bold><aqua>更多的鱼 <reset><gray>>> '
 # The prefix shown when errors occur e.g. no permission to run a command.
-prefix-error: '<bold><aqua>更多的鱼 <reset></aqua></bold><gray>>> '
+prefix-error: '<bold><aqua>更多的鱼 <reset><gray>>> '
 # This is the format of the lore given to fish when they're caught.
 # {custom-lore} is specified in the fish configs under the lore: section, if the fish has a lore, the lore's lines will
 # replace the {fish_lore}, however if it's empty the line will be removed. DO NOT ADD ANYTHING OTHER THAN THIS VARIABLE


### PR DESCRIPTION
## Description
Current prefix format in zh_cn locale added unnecessary closing color tags like `</aqua>` and `</bold>` after `<reset>`, which ended up rendering as an actual text, like:
<img width="621" height="29" alt="image" src="https://github.com/user-attachments/assets/4581cd68-88ee-45da-94e2-69fb999179d9" /><br>

---

### What has changed?
Remove the unnecessary closing color tags. **Result:**
<img width="382" height="28" alt="image" src="https://github.com/user-attachments/assets/bf31d69c-91d4-4c2f-8096-3b1d78586b9c" />

---

### Related Issues
`None`

---

### Checklist

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.