### PR TITLE
Competition Persistence

### DIFF
--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/fishing/items/RarityKey.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/fishing/items/RarityKey.java
@@ -1,7 +1,12 @@
 package com.oheers.fish.api.fishing.items;
 
+import com.oheers.fish.api.Logging;
+import net.kyori.adventure.key.Key;
 import org.bukkit.NamespacedKey;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
 
 /**
  * An immutable key that uniquely identifies a fish by its rarity and name.
@@ -18,6 +23,7 @@ public final class RarityKey {
 
     /**
      * Creates a RarityKey from an IFish instance.
+     *
      * @param fish The fish this key belongs to.
      */
     public static @NotNull RarityKey of(@NotNull IFish fish) {
@@ -26,24 +32,41 @@ public final class RarityKey {
 
     /**
      * Creates a RarityKey from a rarity name and a fish name.
+     *
      * @param rarityStr The name of the rarity.
-     * @param fishStr The name of the fish.
-     * @throws IllegalArgumentException If the rarity does not exist.
-     * @throws IllegalArgumentException If the fish does not exist in the given rarity.
+     * @param fishStr   The name of the fish.
+     * @return A valid RarityKey, or null if the rarity or fish do not exist.
      */
-    public static @NotNull RarityKey of(@NotNull String rarityStr, @NotNull String fishStr) throws IllegalArgumentException {
+    public static @Nullable RarityKey of(@NotNull String rarityStr, @NotNull String fishStr) {
         IRarity rarity = AbstractFishManager.getInstance().getRarity(rarityStr);
         if (rarity == null) {
-            throw new IllegalArgumentException("There is no rarity named " + rarityStr);
+            Logging.warn("There is no rarity named " + rarityStr, new IllegalArgumentException());
+            return null;
         }
         IFish fish = rarity.getFish(fishStr);
         if (fish == null) {
             fish = rarity.getFish(fishStr.replace("_", " "));
         }
         if (fish == null) {
-            throw new IllegalArgumentException("Rarity " + rarityStr + " has no fish named " + fishStr);
+            Logging.warn("Rarity " + rarityStr + " has no fish named " + fishStr, new IllegalArgumentException());
+            return null;
         }
         return new RarityKey(rarity, fish);
+    }
+
+    /**
+     * Creates a RarityKey from a key string. ("namespace:value")
+     *
+     * @param keyString The key string to use.
+     */
+    public static @Nullable RarityKey of(@NotNull String keyString) {
+        String[] split = keyString.split(":");
+        if (split.length < 2) {
+            return null;
+        }
+        String rarity = split[0];
+        String fish = split[1];
+        return of(rarity, fish);
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -160,6 +160,10 @@ public abstract class EvenMoreFish extends EMFPlugin {
 
         registerCommands();
 
+        // Attempt to resume a competition if the temporary file exists.
+        System.out.println("Attempting to resume competition.");
+        Competition.resumeFromFile();
+
         getLogger().info(() -> "EvenMoreFish by Oheers : Enabled");
     }
 
@@ -176,7 +180,7 @@ public abstract class EvenMoreFish extends EMFPlugin {
         // Ends the current competition in case the plugin is being disabled when the server will continue running
         Competition active = Competition.getCurrentlyActive();
         if (active != null) {
-            active.end(false);
+            active.end(false, true);
         }
         
         // Don't use the scheduler here because it will throw errors on disable

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -161,7 +161,6 @@ public abstract class EvenMoreFish extends EMFPlugin {
         registerCommands();
 
         // Attempt to resume a competition if the temporary file exists.
-        System.out.println("Attempting to resume competition.");
         Competition.resumeFromFile();
 
         getLogger().info(() -> "EvenMoreFish by Oheers : Enabled");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -29,6 +29,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -698,6 +699,7 @@ public class Competition {
         return configRarities;
     }
 
+    @ApiStatus.Experimental
     public void saveToFile() {
         EvenMoreFish plugin = EvenMoreFish.getInstance();
         ConfigBase base = new ConfigBase(dataFile, plugin, false);
@@ -715,13 +717,12 @@ public class Competition {
         base.save();
     }
 
+    @ApiStatus.Experimental
     public static void resumeFromFile() {
         EvenMoreFish plugin = EvenMoreFish.getInstance();
         if (!dataFile.exists()) {
-            System.out.println("File did not exist.");
             return;
         }
-        System.out.println("File did exist. Attempting to rebuild competition.");
         ConfigBase base = new ConfigBase(dataFile, plugin, false);
 
         YamlDocument config = base.getConfig();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -4,9 +4,12 @@ import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.api.EMFCompetitionEndEvent;
 import com.oheers.fish.api.EMFCompetitionStartEvent;
 import com.oheers.fish.api.Logging;
+import com.oheers.fish.api.config.ConfigBase;
+import com.oheers.fish.api.fishing.items.RarityKey;
 import com.oheers.fish.api.reward.Reward;
 import com.oheers.fish.competition.configs.CompetitionFile;
 import com.oheers.fish.competition.leaderboard.Leaderboard;
+import com.oheers.fish.config.MainConfig;
 import com.oheers.fish.config.MessageConfig;
 import com.oheers.fish.database.DatabaseUtil;
 import com.oheers.fish.database.model.CompetitionReport;
@@ -18,6 +21,8 @@ import com.oheers.fish.messages.ConfigMessage;
 import com.oheers.fish.messages.EMFListMessage;
 import com.oheers.fish.messages.EMFSingleMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.block.implementation.Section;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
@@ -27,6 +32,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -37,10 +43,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Competition {
+
+    private static final File dataFile = new File(EvenMoreFish.getInstance().getDataFolder(), "competition-data.yml.tmp");
 
     private static Competition active;
     private boolean originallyRandom;
@@ -208,6 +217,10 @@ public class Competition {
     }
 
     public void end(boolean startFail) {
+        end(startFail, false);
+    }
+
+    public void end(boolean startFail, boolean pluginDisable) {
         if (ended()) {
             return;
         }
@@ -224,6 +237,11 @@ public class Competition {
             return;
         }
 
+        if (pluginDisable && MainConfig.getInstance().shouldCompetitionResume()) {
+            saveToFile();
+            return;
+        }
+
         try {
             fireEndEvent();
             notifyPlayers();
@@ -233,9 +251,9 @@ public class Competition {
             leaderboard.clear();
         } catch (Exception exception) {
             EvenMoreFish.getInstance().getLogger().log(
-                    Level.SEVERE,
-                    "An exception was thrown while the competition was being ended!",
-                    exception
+                Level.SEVERE,
+                "An exception was thrown while the competition was being ended!",
+                exception
             );
         } finally {
             active = null;
@@ -678,6 +696,75 @@ public class Competition {
             return null;
         }
         return configRarities;
+    }
+
+    public void saveToFile() {
+        EvenMoreFish plugin = EvenMoreFish.getInstance();
+        ConfigBase base = new ConfigBase(dataFile, plugin, false);
+
+        YamlDocument config = base.getConfig();
+        config.set("comp-id", getCompetitionFile().getId());
+        config.set("total-duration", maxDuration);
+        config.set("time-left", timeLeft);
+        for (CompetitionEntry entry : leaderboard.getEntries()) {
+            UUID uuid = entry.getPlayer();
+            config.set("leaderboard." + uuid + ".fish", entry.getFish().getRarityKey().toString());
+            config.set("leaderboard." + uuid + ".value", entry.getValue());
+            config.set("leaderboard." + uuid + ".time", entry.getTime());
+        }
+        base.save();
+    }
+
+    public static void resumeFromFile() {
+        EvenMoreFish plugin = EvenMoreFish.getInstance();
+        if (!dataFile.exists()) {
+            System.out.println("File did not exist.");
+            return;
+        }
+        System.out.println("File did exist. Attempting to rebuild competition.");
+        ConfigBase base = new ConfigBase(dataFile, plugin, false);
+
+        YamlDocument config = base.getConfig();
+        String id = config.getString("comp-id");
+        long totalDuration = config.getLong("total-duration");
+        long timeLeft = config.getLong("time-left");
+
+        CompetitionFile file = plugin.getCompetitionQueue().getFileFromId(id);
+        if (file == null) {
+            Logging.warn("Failed to resume competition. It is no longer configured?");
+            //dataFile.delete();
+            return;
+        }
+
+        Competition competition = new Competition(file);
+        competition.timeLeft = timeLeft;
+        competition.maxDuration = totalDuration;
+        competition.adminStarted = true;
+
+        competition.begin();
+
+        Section leaderboardSection = config.createSection("leaderboard");
+        leaderboardSection.getRoutesAsStrings(false).forEach(key -> {
+            Section entrySection = leaderboardSection.createSection(key);
+            UUID player;
+            try {
+                player = UUID.fromString(key);
+            } catch (IllegalArgumentException exception) {
+                //dataFile.delete();
+                return;
+            }
+            String fishStr = entrySection.getString("fish");
+            RarityKey rarityKey = RarityKey.of(fishStr);
+            if (rarityKey == null) {
+                Logging.warn("Failed to restore leaderboard entry. Fish " + fishStr + " is no longer configured?");
+                return;
+            }
+            CompetitionEntry entry = new CompetitionEntry(player, (Fish) rarityKey.getFish(), competition.competitionType);
+            entry.value = entrySection.getFloat("value");
+            entry.time = entrySection.getLong("time");
+            competition.leaderboard.addEntry(entry);
+        });
+        //dataFile.delete();
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -732,7 +732,7 @@ public class Competition {
         CompetitionFile file = plugin.getCompetitionQueue().getFileFromId(id);
         if (file == null) {
             Logging.warn("Failed to resume competition. It is no longer configured?");
-            //dataFile.delete();
+            dataFile.delete();
             return;
         }
 
@@ -750,7 +750,7 @@ public class Competition {
             try {
                 player = UUID.fromString(key);
             } catch (IllegalArgumentException exception) {
-                //dataFile.delete();
+                dataFile.delete();
                 return;
             }
             String fishStr = entrySection.getString("fish");
@@ -764,7 +764,7 @@ public class Competition {
             entry.time = entrySection.getLong("time");
             competition.leaderboard.addEntry(entry);
         });
-        //dataFile.delete();
+        dataFile.delete();
     }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionEntry.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionEntry.java
@@ -9,8 +9,8 @@ public class CompetitionEntry {
 
     private final UUID player;
     private final Fish fish;
-    private long time;
-    private float value;
+    protected long time;
+    protected float value;
     private final CompetitionType type;
 
     public CompetitionEntry(UUID player, Fish fish, CompetitionType type) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/CompetitionQueue.java
@@ -128,5 +128,17 @@ public class CompetitionQueue extends AbstractFileBasedManager<CompetitionFile> 
         return !competitions.isEmpty();
     }
 
+    public @Nullable CompetitionFile getFileFromId(@Nullable String id) {
+        if (id == null) {
+            return null;
+        }
+        for (CompetitionFile file : competitions.values()) {
+            if (file.getId().equalsIgnoreCase(id)) {
+                return file;
+            }
+        }
+        return null;
+    }
+
 }
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/config/MainConfig.java
@@ -401,6 +401,10 @@ public class MainConfig extends ConfigBase {
         return getConfig().getString("economy." + type.getIdentifier().toLowerCase() + ".display");
     }
 
+    public boolean shouldCompetitionResume() {
+        return getConfig().getBoolean("fishing.resume-competition-on-restart", false);
+    }
+
     @Override
     public UpdaterSettings getUpdaterSettings() {
         return UpdaterSettings.builder(super.getUpdaterSettings())

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -15,6 +15,10 @@ fishing:
   # This only happens if the player has space in their inventory.
   give-straight-to-inventory: false
 
+  # Makes competitions resume after a server restart.
+  # This does not work if the server crashes.
+  resume-competition-on-restart: false
+
   # Should fish be caught from fishing rods?
   catch-enabled: true
   # Should EMF fish only be given during a competition?

--- a/even-more-fish-plugin/src/main/resources/config.yml
+++ b/even-more-fish-plugin/src/main/resources/config.yml
@@ -17,6 +17,7 @@ fishing:
 
   # Makes competitions resume after a server restart.
   # This does not work if the server crashes.
+  # Experimental. May be changed or removed at any time.
   resume-competition-on-restart: false
 
   # Should fish be caught from fishing rods?


### PR DESCRIPTION
## Description
Allows competitions to persist over server restarts.

This feature is marked as experimental.

---

### What has changed?
- Added `fishing.resume-competition-on-restart` to config.yml.
- If the above option is enabled and the server is restarted, the active competition is saved to a temp file.
- After the plugin has loaded, if the temp file exists, the competition will continue where it left off.

---

### Related Issues
N/A

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.