### PR TITLE
Clean up null checks

### DIFF
--- a/docs/docs/developers/creating-item-addons.md
+++ b/docs/docs/developers/creating-item-addons.md
@@ -65,11 +65,10 @@ public class ItemsAdderItemAddon extends ItemAddon implements Listener {
 
     @EventHandler
     public void onItemsLoad(ItemsAdderLoadDataEvent event) {
-        getLogger().info("Detected that itemsadder has finished loading all items...");
+        getLogger().info("Detected that ItemsAdder has finished loading all items...");
         getLogger().info("Reloading EMF.");
-        this.itemsAdderLoaded = true;
 
-        ((EMFPlugin) Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("EvenMoreFish"))).reload();
+        EMFPlugin.getInstance().reload(null);
     }
 }
 ```

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -73,7 +73,10 @@ public abstract class EvenMoreFish extends EMFPlugin {
     private EMFAPI api;
 
     public static @NotNull EvenMoreFish getInstance() {
-        return Objects.requireNonNull(instance, "Plugin not initialized yet!");
+        if (instance == null) {
+            throw new IllegalStateException("Plugin not initialized yet!");
+        }
+        return instance;
     }
 
     public static TaskScheduler getScheduler() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionFile.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/configs/CompetitionFile.java
@@ -28,13 +28,18 @@ import java.util.logging.Logger;
 
 public class CompetitionFile extends ConfigBase {
 
-    private final Logger logger = getPlugin().getLogger();
+    private final @NotNull Logger logger = getPlugin().getLogger();
+    private final @NotNull String id;
+    private final @NotNull CompetitionType type;
+    private final int duration;
 
     // We should never use the configUpdater for this.
     public CompetitionFile(@NotNull File file) throws InvalidConfigurationException {
         super(file, EvenMoreFish.getInstance(), false);
         CompetitionFileUpdates.update(this);
-        performRequiredConfigChecks();
+        this.id = validateId();
+        this.type = validateType();
+        this.duration = validateDuration();
     }
 
     /**
@@ -43,33 +48,46 @@ public class CompetitionFile extends ConfigBase {
      */
     public CompetitionFile(@NotNull String id, @NotNull CompetitionType type, int duration) {
         super();
-        getConfig().set("id", id);
-        getConfig().set("type", type.toString());
-        getConfig().set("duration", duration);
+        this.id = id;
+        this.type = type;
+        this.duration = duration;
     }
 
-    // Current required config: id, type, times
-    private void performRequiredConfigChecks() throws InvalidConfigurationException {
-        if (getConfig().getString("id") == null) {
-            logger.warning("Competition invalid: 'id' missing in " + getFileName());
-            throw new InvalidConfigurationException("An ID has not been found in " + getFileName() + ". Please correct this.");
+    private String validateId() throws InvalidConfigurationException {
+        String id = getConfig().getString("id");
+        if (id == null) {
+            throw new InvalidConfigurationException("CompetitionFile " + getFileName() + " has no configured id.");
         }
-        String type = getConfig().getString("type");
-        if (type == null || CompetitionType.getType(type) == null) {
-            logger.warning("Competition invalid: 'type' missing in " + getFileName());
-            throw new InvalidConfigurationException("A type has not been found in " + getFileName() + ". Please correct this.");
+        return id;
+    }
+
+    private CompetitionType validateType() throws InvalidConfigurationException {
+        String typeStr = getConfig().getString("type");
+        if (typeStr == null) {
+            throw new InvalidConfigurationException("CompetitionFile " + getFileName() + " has no configured type.");
         }
-        if (getConfig().getInt("duration", -1) == -1) {
-            logger.warning("Competition invalid: 'duration' missing in " + getFileName());
-            throw new InvalidConfigurationException("A duration has not been found in " + getFileName() + ". Please correct this.");
+        CompetitionType type = CompetitionType.getType(typeStr);
+        if (type == null) {
+            throw new InvalidConfigurationException("CompetitionFile " + getFileName() + " has an invalid type: " + typeStr);
         }
+        return type;
+    }
+
+    private int validateDuration() throws InvalidConfigurationException {
+        Integer duration = getConfig().getInt("duration", null);
+        if (duration == null) {
+            throw new InvalidConfigurationException("CompetitionFile " + getFileName() + " has no configured duration.");
+        } else if (duration < 1) {
+            throw new InvalidConfigurationException("CompetitionFile " + getFileName() + " has an invalid duration. Must be 1 or more.");
+        }
+        return duration;
     }
 
     /**
      * @return The ID for this competition.
      */
     public @NotNull String getId() {
-        return Objects.requireNonNull(getConfig().getString("id"));
+        return this.id;
     }
 
     /**
@@ -83,7 +101,7 @@ public class CompetitionFile extends ConfigBase {
      * @return This competition's type.
      */
     public @NotNull CompetitionType getType() {
-        return Objects.requireNonNull(CompetitionType.getType(getConfig().getString("type")));
+        return this.type;
     }
 
     /**
@@ -116,7 +134,7 @@ public class CompetitionFile extends ConfigBase {
      * @return The duration of this competition (in minutes).
      */
     public int getDuration() {
-        return Math.max(1, getConfig().getInt("duration"));
+        return this.duration;
     }
 
     /**

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -28,6 +28,8 @@ public class Rarity extends ConfigBase implements IRarity {
 
     private static final Logger logger = EvenMoreFish.getInstance().getLogger();
 
+    private final @NotNull String id;
+
     private boolean fishWeighted;
     private boolean showInJournal = true;
     private final Requirement requirement;
@@ -40,25 +42,25 @@ public class Rarity extends ConfigBase implements IRarity {
     public Rarity(@NotNull File file) throws InvalidConfigurationException {
         super(file, EvenMoreFish.getInstance(), false);
         new RarityFileUpdates(this).update();
-        performRequiredConfigChecks();
+        this.id = validateId();
         this.requirement = loadRequirements();
         this.fishList = loadFish();
         this.showInJournal = getConfig().getBoolean("journal", true);
     }
 
-    // Current required config: id
-    private void performRequiredConfigChecks() throws InvalidConfigurationException {
-        if (getConfig().getString("id") == null) {
-            logger.warning("Rarity invalid: 'id' missing in " + getFileName());
-            throw new InvalidConfigurationException("An ID has not been found in " + getFileName() + ". Please correct this.");
+    private String validateId() throws InvalidConfigurationException {
+        String id = getConfig().getString("id");
+        if (id == null) {
+            throw new InvalidConfigurationException("Rarity " + getFileName() + " has no configured id.");
         }
+        return id;
     }
 
     // Config getters
 
     @Override
     public @NotNull String getId() {
-        return Objects.requireNonNull(getConfig().getString("id"));
+        return this.id;
     }
 
     @Override
@@ -103,8 +105,8 @@ public class Rarity extends ConfigBase implements IRarity {
     }
 
     public @NotNull EMFSingleMessage getDisplayName() {
-        String displayName = getConfig().getString("displayname");
-        return format(Objects.requireNonNullElseGet(displayName, this::getId));
+        String displayName = getConfig().getString("displayname", this.id);
+        return format(displayName);
     }
 
     public @NotNull EMFSingleMessage getLorePrep() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/rods/CustomRod.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/rods/CustomRod.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 
 public class CustomRod extends ConfigBase implements ICustomRod {
 
+    private final @NotNull String id;
     private final List<Rarity> allowedRarities;
     private final List<Fish> allowedFish;
     private final EMFRecipe<?> recipe;
@@ -34,7 +35,7 @@ public class CustomRod extends ConfigBase implements ICustomRod {
 
     public CustomRod(@NotNull File file) throws InvalidConfigurationException {
         super(file, EvenMoreFish.getInstance(), false);
-        performRequiredConfigChecks();
+        this.id = validateId();
         this.allowedRarities = loadAllowedRarities();
         this.allowedFish = loadAllowedFish();
         this.factory = ItemFactory.itemFactory(getConfig());
@@ -47,12 +48,12 @@ public class CustomRod extends ConfigBase implements ICustomRod {
         this.recipe = loadRecipe();
     }
 
-    // Current required config: id
-    private void performRequiredConfigChecks() throws InvalidConfigurationException {
-        if (getConfig().getString("id") == null) {
-            Logging.warn("Custom Rod invalid: 'id' missing in " + getFileName());
-            throw new InvalidConfigurationException("An ID has not been found in " + getFileName() + ". Please correct this.");
+    private String validateId() throws InvalidConfigurationException {
+        String id = getConfig().getString("id");
+        if (id == null) {
+            throw new InvalidConfigurationException("CustomRod " + getFileName() + " has no configured id.");
         }
+        return id;
     }
 
     // Loading things
@@ -114,7 +115,7 @@ public class CustomRod extends ConfigBase implements ICustomRod {
 
     @Override
     public @NotNull String getId() {
-        return Objects.requireNonNull(getConfig().getString("id"));
+        return this.id;
     }
 
     private @NotNull NamespacedKey getRecipeKey() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/ApplyBaitsGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/ApplyBaitsGui.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class ApplyBaitsGui extends ConfigGui {
 
@@ -35,7 +36,7 @@ public class ApplyBaitsGui extends ConfigGui {
             GuiConfig.getInstance().getConfig().getSection("apply-baits-menu"),
             player
         );
-        this.baitInventory = Objects.requireNonNullElseGet(baitInventory, () -> Bukkit.createInventory(player, 54));
+        this.baitInventory = Optional.ofNullable(baitInventory).orElse(Bukkit.createInventory(player, 54));
 
         setCloseAction(close -> {
             processBaits();

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/SellGui.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/gui/guis/SellGui.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
 
 // TODO look into dynamically updating the sell items when a fish is added/removed - AFTER we switch to TriumphGui
 public class SellGui extends ConfigGui {
@@ -24,7 +25,7 @@ public class SellGui extends ConfigGui {
     public SellGui(@NotNull Player player, @NotNull SellState sellState, @Nullable Inventory fishInventory) {
         super(sellState.getGuiConfig(), player);
 
-        this.fishInventory = Objects.requireNonNullElseGet(fishInventory, () -> Bukkit.createInventory(player, 54));
+        this.fishInventory = Optional.ofNullable(fishInventory).orElse(Bukkit.createInventory(player, 54));
 
         Economy economy = Economy.getInstance();
 

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public abstract class EMFMessage {
 
@@ -249,7 +250,7 @@ public abstract class EMFMessage {
             return;
         }
         this.relevantPlayer = player;
-        setVariable("{player}", Objects.requireNonNullElse(player.getName(), "N/A"));
+        setVariable("{player}", Optional.ofNullable(player.getName()).orElse("N/A"));
     }
 
     /**


### PR DESCRIPTION
## Description
Cleans up null checks in various places.

---

### What has changed?
- CompetitionFile now stores required keys on load.
- Rarity now stores required keys on load.
- CustomRod now stores required keys on load.
- SellGui and ApplyBaitsGui now use `Optional` instead of `Objects#requireNonNull`.
- EMFMessage now uses `Optional` instead of `Objects#requireNonNullElse` for player names.
- Updated "Creating Item Addons" wiki page.

---

### Related Issues
N/A

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.