### PR TITLE
Rarity lore override

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -309,7 +309,6 @@ public class Fish implements IFish, Sortable {
 
         if (!disableFisherman && fishermanPlayer != null) {
             EMFMessage message = ConfigMessage.FISHERMAN_LORE.getMessage();
-            message.setRelevantPlayer(fishermanPlayer);
             newLoreLine.setVariableWithListInsertion("{fisherman_lore}", message.toListMessage());
         } else {
             newLoreLine.setVariableWithListInsertion("{fisherman_lore}", EMFListMessage.empty());
@@ -317,18 +316,15 @@ public class Fish implements IFish, Sortable {
 
         if (length > 0) {
             newLoreLine.setVariableWithListInsertion("{length_lore}", ConfigMessage.LENGTH_LORE.getMessage().toListMessage());
-            newLoreLine.setLength(Float.toString(length));
         } else {
             newLoreLine.setVariableWithListInsertion("{length_lore}", EMFListMessage.empty());
         }
 
+        newLoreLine.setRelevantPlayer(fishermanPlayer);
+        newLoreLine.setLength(length);
         newLoreLine.setRarity(this.rarity.getLorePrep());
 
-        if (disableFisherman || fishermanPlayer == null) {
-            return newLoreLine.getComponentListMessage();
-        } else {
-            return newLoreLine.getComponentListMessage(fishermanPlayer);
-        }
+        return newLoreLine.getComponentListMessage();
     }
 
     private void checkEatEvent() {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -283,6 +283,10 @@ public class Fish implements IFish, Sortable {
         checkEffects();
     }
 
+    private List<String> getLoreOverride() {
+        return section.getStringList("lore-override", rarity.getLoreOverride());
+    }
+
     /**
      * From the new method of fetching the lore, where the admin specifies exactly how they want the lore to be set up,
      * letting them modify the order, add a twist to how they want extra details and so on.
@@ -293,7 +297,7 @@ public class Fish implements IFish, Sortable {
      * @return A lore to be used by fetching data from the old messages.yml set-up.
      */
     private List<Component> getFishLore() {
-        List<String> loreOverride = section.getStringList("lore-override");
+        List<String> loreOverride = getLoreOverride();
         EMFListMessage newLoreLine;
         if (!loreOverride.isEmpty()) {
             newLoreLine = EMFListMessage.fromStringList(loreOverride);

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Fish.java
@@ -313,7 +313,7 @@ public class Fish implements IFish, Sortable {
 
         if (!disableFisherman && fishermanPlayer != null) {
             EMFMessage message = ConfigMessage.FISHERMAN_LORE.getMessage();
-            newLoreLine.setVariableWithListInsertion("{fisherman_lore}", message.toListMessage());
+            newLoreLine.setVariableWithListInsertion("{fisherman_lore}", message.toListMessage().getUnderlying());
         } else {
             newLoreLine.setVariableWithListInsertion("{fisherman_lore}", EMFListMessage.empty());
         }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/items/Rarity.java
@@ -123,6 +123,10 @@ public class Rarity extends ConfigBase implements IRarity, Sortable {
         return format(finalName);
     }
 
+    protected List<String> getLoreOverride() {
+        return getConfig().getStringList("lore-override");
+    }
+
     @Override
     public @Nullable String getPermission() {
         return getConfig().getString("permission");

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/abstracted/EMFMessage.java
@@ -128,7 +128,10 @@ public abstract class EMFMessage {
      * Sets the relevant player for this message. If the relevant player exists, per-player placeholders will NOT be parsed.
      * @param relevantPlayer The relevant player for this message
      */
-    public final void setRelevantPlayer(@NotNull OfflinePlayer relevantPlayer) {
+    public final void setRelevantPlayer(@Nullable OfflinePlayer relevantPlayer) {
+        if (relevantPlayer == null) {
+            return;
+        }
         this.relevantPlayer = relevantPlayer;
     }
 

--- a/even-more-fish-plugin/src/main/resources/rarities/_example.yml
+++ b/even-more-fish-plugin/src/main/resources/rarities/_example.yml
@@ -58,6 +58,16 @@ requirements:
 # This can be overridden by each fish.
 disable-fisherman: false
 
+# You can override the lore configured in messages.yml's fish-lore for each fish.
+# All variables from the fish-lore message are supported.
+# This can be overridden by each fish.
+lore-override:
+  - '{fisherman_lore}'
+  - '{length_lore}'
+  - ''
+  - '{fish_lore}'
+  - '<b>{rarity}'
+
 # Change the sizing ranges of the fish that belong to this rarity.
 # This can be overridden by each fish.
 size:
@@ -130,7 +140,7 @@ fish:
     # How likely is this fish to be chosen? Having a greater weight means the rarity is more likely to be chosen (the total weights don't have to add to 100)
     weight: 10
 
-    # You can set custom requirement for this fish to appear, all possible requirement are on the wiki: https://evenmorefish.github.io/EvenMoreFish/docs/features/requirements
+    # You can set custom requirement for this fish to appear, all possible requirements are on the wiki: https://evenmorefish.github.io/EvenMoreFish/docs/features/requirements
     requirements:
       biome:
         - COLD_OCEAN
@@ -143,6 +153,7 @@ fish:
 
     # You can override the lore configured in messages.yml's fish-lore for each fish.
     # All variables from the fish-lore message are supported.
+    # This overrides the rarity's setting.
     lore-override:
       - '{fisherman_lore}'
       - '{length_lore}'


### PR DESCRIPTION
## Description
Allows `lore-override` to be used on rarities.

---

### What has changed?
- Added `lore-override` on the rarity-level.
- Ensured variables are always parsed correctly when overriding lore.
- Updated the example file.

---

### Related Issues
N/A

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.