### PR TITLE
Reward cache

### DIFF
--- a/docs/docs/configuration/reward-types.md
+++ b/docs/docs/configuration/reward-types.md
@@ -36,3 +36,7 @@ _These will only load if the relevant external plugin is installed._
 | McMMO XP                     | McMMO                     | `MCMMO_XP:Woodcutting,15`               | Gives McMMO xp.        |
 | Permission                   | Vault + Permission Plugin | `PERMISSION:emf.example`                | Gives a permission.    |
 | Money                        | Vault + Economy Plugin    | `MONEY:1000`                            | Gives money.           |
+
+## Notes
+- If a player is offline when given a reward, it will be held until they rejoin.
+- Held rewards will only last until the next restart, then they will be forgotten about.

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/plugin/EMFPlugin.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/plugin/EMFPlugin.java
@@ -1,7 +1,9 @@
 package com.oheers.fish.api.plugin;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -69,5 +71,11 @@ public abstract class EMFPlugin extends JavaPlugin {
             getInstance().getLogger().log(level, "[" + caller + "] " + message, throwable);
         }
     }
+
+    /**
+     * Temporary and for internal use only. Will be removed once API methods for messages are added.
+     */
+    @ApiStatus.Internal
+    public abstract @NotNull Component getRewardCatchupMessage();
 
 }

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
@@ -96,6 +96,7 @@ public class Reward {
             return;
         }
         Logging.debug("Found cached rewards for " + uuid + ". Giving them all now.");
+        player.sendMessage(EMFPlugin.getInstance().getRewardCatchupMessage());
         List<RewardData> cached = rewardCache.remove(uuid);
         cached.forEach(data -> data.reward().rewardPlayer(player, data.hookLocation()));
     }

--- a/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
+++ b/even-more-fish-api/src/main/java/com/oheers/fish/api/reward/Reward.java
@@ -1,16 +1,27 @@
 package com.oheers.fish.api.reward;
 
+import com.oheers.fish.api.Logging;
 import com.oheers.fish.api.plugin.EMFPlugin;
 import com.oheers.fish.api.registry.EMFRegistry;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class Reward {
+
+    // A cache for rewards that could not be given because a player was offline.
+    private static final Map<UUID, List<RewardData>> rewardCache = new HashMap<>();
 
     private final @NotNull String key;
     private final @NotNull String value;
@@ -40,13 +51,53 @@ public class Reward {
     public @NotNull String getKey() { return this.key; }
 
     public @NotNull String getValue() { return this.value; }
-    
+
     public void rewardPlayer(@NotNull Player player, Location hookLocation) {
+        getRewardType().doReward(player, getKey(), getValue(), hookLocation);
+    }
+
+    public void rewardPlayer(@NotNull OfflinePlayer player, @Nullable Location hookLocation) {
         if (getRewardType() == null) {
             EMFPlugin.getInstance().getLogger().warning("No reward type found for key: " + getKey());
             return;
         }
-        getRewardType().doReward(player, getKey(), getValue(), hookLocation);
+        rewardPlayer(player, hookLocation, true);
+    }
+
+    public void rewardPlayer(@NotNull OfflinePlayer player, @Nullable Location hookLocation, boolean shouldAddToCache) {
+        if (getRewardType() == null) {
+            EMFPlugin.getInstance().getLogger().warning("No reward type found for key: " + getKey());
+            return;
+        }
+        Player online = player.getPlayer();
+        if (online != null) {
+            rewardPlayer(online, hookLocation);
+            return;
+        }
+        if (shouldAddToCache) {
+            Logging.debug("Player " + player.getUniqueId() + " was not online. Caching their rewards.");
+            addToCache(player.getUniqueId(), hookLocation);
+        }
+    }
+
+    private void addToCache(@NotNull UUID uuid, @Nullable Location hookLocation) {
+        List<RewardData> cached = rewardCache.computeIfAbsent(uuid, u -> new ArrayList<>());
+        cached.add(new RewardData(this, hookLocation));
+    }
+
+    public static void checkCache(@NotNull UUID uuid) {
+        if (!rewardCache.containsKey(uuid)) {
+            Logging.debug("Player has no cached rewards.");
+            return;
+        }
+        Player player = Bukkit.getPlayer(uuid);
+        if (player == null) {
+            Logging.debug("Player was not online. Cannot give rewards.");
+            return;
+        }
+        Logging.debug("Found cached rewards for " + uuid + ". Giving them all now.");
+        List<RewardData> cached = rewardCache.remove(uuid);
+        cached.forEach(data -> data.reward().rewardPlayer(player, data.hookLocation()));
     }
 
     public void setFishVelocity(@Nullable Vector fishVelocity) {
@@ -56,5 +107,7 @@ public class Reward {
     public @Nullable Vector getFishVelocity() {
         return this.fishVelocity;
     }
+
+    record RewardData(@NotNull Reward reward, @Nullable Location hookLocation) {}
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/EvenMoreFish.java
@@ -29,6 +29,7 @@ import com.oheers.fish.update.UpdateChecker;
 import de.themoep.inventorygui.InventoryGui;
 import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -310,5 +311,10 @@ public abstract class EvenMoreFish extends EMFPlugin {
 
     @ApiStatus.Internal
     public abstract @NotNull ItemStack getSkullFromBase64(@NotNull String base64);
+
+    @Override
+    public @NotNull Component getRewardCatchupMessage() {
+        return ConfigMessage.REWARD_CATCHUP.getMessage().getComponentMessage();
+    }
 
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/competition/Competition.java
@@ -486,13 +486,7 @@ public class Competition {
         }
 
         for (CompetitionEntry entry : entries) {
-            Player player = Bukkit.getPlayer(entry.getPlayer());
-
-            // If the player is null, increment the place and continue
-            if (player == null) {
-                rewardPlace++;
-                continue;
-            }
+            OfflinePlayer player = Bukkit.getOfflinePlayer(entry.getPlayer());
 
             // Does the player's place have reward?
             if (rewards.containsKey(rewardPlace)) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/events/JoinChecker.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/events/JoinChecker.java
@@ -1,25 +1,34 @@
-package com.oheers.fish.competition;
+package com.oheers.fish.events;
 
 import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.api.reward.Reward;
+import com.oheers.fish.competition.Competition;
 import com.oheers.fish.database.DatabaseUtil;
 import com.oheers.fish.messages.ConfigMessage;
 import com.oheers.fish.messages.abstracted.EMFMessage;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class JoinChecker implements Listener {
 
     // Gives the player the active fishing bar if there's a fishing event cracking off
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
+        checkCompetitionJoin(event.getPlayer());
+        checkRewardsJoin(event.getPlayer());
+    }
+
+    private void checkCompetitionJoin(@NotNull Player player) {
         Competition activeComp = Competition.getCurrentlyActive();
         if (activeComp == null) {
             return;
         }
 
-        activeComp.getStatusBar().addPlayer(event.getPlayer());
+        activeComp.getStatusBar().addPlayer(player);
         if (activeComp.getStartMessage() == null) {
             return;
         }
@@ -28,15 +37,23 @@ public class JoinChecker implements Listener {
             activeComp, ConfigMessage.COMPETITION_JOIN
         );
 
-        EvenMoreFish.getScheduler().runTaskLater(() -> message.send(event.getPlayer()), 20L * 3);
+        EvenMoreFish.getScheduler().runTaskLater(() -> message.send(player), 60L);
+    }
+
+    public void checkRewardsJoin(@NotNull Player player) {
+        EvenMoreFish.getScheduler().runTaskLater(() -> Reward.checkCache(player.getUniqueId()), 60L);
     }
 
     // Removes the player from the bar list if they leave the server
     @EventHandler
     public void onLeave(PlayerQuitEvent event) {
+        checkCompetitionLeave(event.getPlayer());
+    }
+
+    private void checkCompetitionLeave(@NotNull Player player) {
         final Competition activeComp = Competition.getCurrentlyActive();
         if (activeComp != null) {
-            activeComp.getStatusBar().removePlayer(event.getPlayer());
+            activeComp.getStatusBar().removePlayer(player);
         }
 
         if (!DatabaseUtil.isDatabaseOnline()) {
@@ -46,4 +63,5 @@ public class JoinChecker implements Listener {
         EvenMoreFish.getInstance().getPluginDataManager().getUserReportDataManager().flush();
         EvenMoreFish.getInstance().getPluginDataManager().getUserFishStatsDataManager().flush();
     }
+
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/messages/ConfigMessage.java
@@ -190,6 +190,7 @@ public enum ConfigMessage {
     WORTH_GUI_SELL_LORE(PrefixType.NONE, "sell-gui-lore"),
     RARITY_INVALID(PrefixType.ERROR, "rarity-invalid"),
     JOURNAL_DISABLED(PrefixType.ERROR, "journal-disabled"),
+    REWARD_CATCHUP(PrefixType.DEFAULT, "reward.catch-up"),
     BAIT_ROD_LORE(PrefixType.NONE, "bait.rod-lore"),
     BAIT_BAIT_LORE(PrefixType.NONE, "bait.bait-lore"),
     BAIT_BAITS(PrefixType.NONE, "bait.baits"),

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/plugin/EventManager.java
@@ -4,7 +4,7 @@ package com.oheers.fish.plugin;
 import com.oheers.fish.EvenMoreFish;
 import com.oheers.fish.SkullSaver;
 import com.oheers.fish.baits.BaitApplicationListener;
-import com.oheers.fish.competition.JoinChecker;
+import com.oheers.fish.events.JoinChecker;
 import com.oheers.fish.database.DatabaseUtil;
 import com.oheers.fish.events.FishInteractEvent;
 import com.oheers.fish.fishing.EMFFishListener;

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -281,6 +281,10 @@ rarity-invalid: <white>That is not a valid rarity!
 # When the player can't access the Fishing Journal
 journal-disabled: <white>The Fishing Journal is not accessible. Please enable the plugin's database.
 
+# Reward messages
+reward:
+  catch-up: <white>You received some rewards while offline. You will now be given them.
+
 # Bait messages
 bait:
   # How the lore should look ({baits} is a multi-line variable)
@@ -318,4 +322,4 @@ bait:
 
 # ATTENTION ATTENTION ATTENTION
 # DO NOT EDIT THIS VALUE OR THINGS WILL BREAK!!!
-version: 11
+version: 12

--- a/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
+++ b/even-more-fish-plugin/src/main/resources/locales/messages_en.yml
@@ -283,7 +283,7 @@ journal-disabled: <white>The Fishing Journal is not accessible. Please enable th
 
 # Reward messages
 reward:
-  catch-up: <white>You received some rewards while offline. You will now be given them.
+  catch-up: <white>You received rewards while you were offline. Delivering them now."
 
 # Bait messages
 bait:

--- a/even-more-fish-plugin/src/test/java/com/oheers/fish/database/DatabaseTest.java
+++ b/even-more-fish-plugin/src/test/java/com/oheers/fish/database/DatabaseTest.java
@@ -11,13 +11,13 @@ import org.jdbi.v3.core.HandleConsumer;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Update;
 import org.bukkit.inventory.ItemStack;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Answers;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.io.File;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -200,12 +200,12 @@ class DatabaseTest {
         }
 
         @Override
-        public ItemStack getSkullFromUUID(UUID uuid) {
+        public @NonNull ItemStack getSkullFromUUID(@NonNull UUID uuid) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public ItemStack getSkullFromBase64(String base64) {
+        public @NonNull ItemStack getSkullFromBase64(@NonNull String base64) {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
## Description
Caches rewards for offline players to be awarded upon rejoin.

---

### What has changed?
- Rewards are now cached if a player is offline and awarded if/when they rejoin.
- JoinChecker has been moved to the events package.
- Added `EMFPlugin#getRewardCatchupMessage`. (Temporary internal method until the message API is written.)
- Added a notes section to the reward types docs explaining these changes.

---

### Related Issues
N/A

---

### Checklist

- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the documentation as needed.