### PR TITLE
Docs/homepage

### DIFF
--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -9,74 +9,97 @@ type FeatureItem = {
   description: ReactNode;
 };
 
-const FeatureList: FeatureItem[] = [
-    {
-        title: 'Custom Fish & Items',
-        Svg: require('@site/static/img/home/fish.svg').default, 
-        description: (
-            <>
-                Create unique fish with custom items, lore, lengths, and effects. Supports custom heads and model data.
-            </>
-        ),
-    },
-    {
-        title: 'Dynamic Competitions',
-        Svg: require('@site/static/img/home/leaderboard-star.svg').default,
-        description: (
-            <>
-                6 competition types with configurable rewards, bossbars, and leaderboards.
-            </>
-        ),
-    },
-    {
-        title: 'Advanced Customization',
-        Svg: require('@site/static/img/home/settings.svg').default,
-        description: (
-            <>
-                Biome-specific fish, region restrictions, commands on catch, and more.
-            </>
-        ),
-    },
-    {
-        title: 'Fish Shop & Economy',
-        Svg: require('@site/static/img/home/coins-swap.svg').default,
-        description: (
-            <>
-                Players can sell their catches with secure transactions and configurable prices.
-            </>
-        ),
-    },
-    {
-        title: 'Bait System',
-        Svg: require('@site/static/img/home/bait.svg').default,
-        description: (
-            <>
-                Special baits that affect catch rates for specific fish or rarities.
-            </>
-        ),
-    },
-    {
-        title: 'PlaceholderAPI Integration',
-        Svg: require('@site/static/img/home/placeholder.svg').default,
-        description: (
-            <>
-                Display competition standings and timers anywhere with comprehensive placeholders.
-            </>
-        ),
-    },
+const primaryFeatures: FeatureItem[] = [
+  {
+    title: 'Custom Fish & Rewards',
+    Svg: require('@site/static/img/home/fish.svg').default,
+    description: (
+      <>
+        Create collectible fish with custom items, rarities, lore, lengths,
+        and rewards that fit your server theme.
+      </>
+    ),
+  },
+  {
+    title: 'Competitions & Leaderboards',
+    Svg: require('@site/static/img/home/leaderboard-star.svg').default,
+    description: (
+      <>
+        Run timed fishing events with bossbars, schedules, rewards, and live
+        standings that keep players competing.
+      </>
+    ),
+  },
+  {
+    title: 'Economy, Baits & Progression',
+    Svg: require('@site/static/img/home/coins-swap.svg').default,
+    description: (
+      <>
+        Turn fishing into progression with shop values, targeted baits, and
+        reward loops that give catches real value.
+      </>
+    ),
+  },
 ];
 
-function Feature({title, Svg, description}: FeatureItem) {
+const secondaryFeatures: FeatureItem[] = [
+  {
+    title: 'Biome & Region Rules',
+    Svg: require('@site/static/img/home/settings.svg').default,
+    description: (
+      <>
+        Restrict catches by biome, region, rarity, commands, and other
+        server-specific rules.
+      </>
+    ),
+  },
+  {
+    title: 'PlaceholderAPI',
+    Svg: require('@site/static/img/home/placeholder.svg').default,
+    description: (
+      <>
+        Expose standings, timers, and plugin data anywhere on your server with
+        PlaceholderAPI support.
+      </>
+    ),
+  },
+  {
+    title: 'Deep Configuration',
+    Svg: require('@site/static/img/home/bait.svg').default,
+    description: (
+      <>
+        Control rewards, fish behavior, progression, balancing, and admin
+        workflows from config files.
+      </>
+    ),
+  },
+];
+
+function PrimaryFeature({title, Svg, description}: FeatureItem) {
   return (
-    <div className={clsx('col col--4', styles.featureItem)}>
-      <div className="text--center">
-        <Svg className={styles.featureSvg} role="img" />
+    <article className={styles.primaryCard}>
+      <div className={styles.primaryIcon}>
+        <Svg className={styles.primarySvg} role="img" />
       </div>
-      <div className="text--center padding-horiz--md">
+      <div className={styles.primaryContent}>
         <Heading as="h3">{title}</Heading>
         <p>{description}</p>
       </div>
-    </div>
+    </article>
+  );
+}
+
+function SecondaryFeature({title, Svg, description}: FeatureItem) {
+  return (
+    <article className={styles.secondaryCard}>
+      <div className={styles.secondaryIcon}>
+        <Svg className={styles.secondarySvg} role="img" />
+      </div>
+      <div className={styles.secondaryContent}>
+        <Heading as="h3">{title}</Heading>
+        <p>{description}</p>
+      </div>
+    </article>
   );
 }
 
@@ -84,9 +107,23 @@ export default function HomepageFeatures(): ReactNode {
   return (
     <section className={styles.features}>
       <div className="container">
-        <div className={clsx("row", styles.homepageRow)}>
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
+        <div className={styles.sectionHeading}>
+          <Heading as="h2">Core features</Heading>
+          <p>
+            Custom catches, competitions, economy tools, and progression systems
+            built for server owners.
+          </p>
+        </div>
+
+        <div className={styles.primaryGrid}>
+          {primaryFeatures.map((feature) => (
+            <PrimaryFeature key={feature.title} {...feature} />
+          ))}
+        </div>
+
+        <div className={styles.secondaryGrid}>
+          {secondaryFeatures.map((feature) => (
+            <SecondaryFeature key={feature.title} {...feature} />
           ))}
         </div>
       </div>

--- a/docs/src/components/HomepageFeatures/styles.module.css
+++ b/docs/src/components/HomepageFeatures/styles.module.css
@@ -1,25 +1,127 @@
 .features {
   display: flex;
   align-items: center;
-  padding: 2rem 0;
+  padding: 1rem 0 4rem;
   width: 100%;
 }
 
-.featureSvg {
-  height: 150px;
-  width: 150px;
+.sectionHeading {
+  max-width: 44rem;
+  margin: 0 auto 2.5rem;
+  text-align: center;
+  color: var(--emf-section-title);
 }
 
-/*
-.featureItem {
-  border: 1px solid rgba(255, 255, 255, 0.1);
+.sectionHeading h2 {
+  margin-bottom: 0.75rem;
+}
+
+.sectionHeading p {
+  margin: 0;
+  color: var(--emf-section-subtitle);
+}
+
+.primaryGrid,
+.secondaryGrid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.primaryGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 1.25rem;
+}
+
+.secondaryGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.primaryCard,
+.secondaryCard {
+  border: 1px solid var(--emf-border);
   border-radius: 1.5rem;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--emf-surface-strong) 96%, transparent) 0%,
+      color-mix(in srgb, var(--emf-surface) 92%, transparent) 100%
+    );
+  box-shadow: var(--emf-shadow-md);
+  color: var(--emf-section-title);
 }
 
-.homepageRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: center;
+.primaryCard {
+  padding: 1.75rem;
 }
-*/
+
+.secondaryCard {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: start;
+  padding: 1.25rem;
+}
+
+.primaryIcon,
+.secondaryIcon {
+  color: color-mix(in srgb, var(--emf-section-title) 88%, var(--ifm-color-primary) 12%);
+}
+
+.primaryIcon {
+  margin-bottom: 1.25rem;
+}
+
+.primarySvg {
+  width: 62px;
+  height: 62px;
+}
+
+.secondarySvg {
+  width: 32px;
+  height: 32px;
+}
+
+.primaryContent h3,
+.secondaryContent h3 {
+  margin-bottom: 0.75rem;
+}
+
+.primaryContent h3 {
+  font-size: 1.3rem;
+  line-height: 1.2;
+}
+
+.secondaryContent h3 {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.primaryContent p,
+.secondaryContent p {
+  margin: 0;
+  color: var(--emf-text-muted-strong);
+}
+
+.primaryContent p {
+  line-height: 1.7;
+}
+
+.secondaryContent p {
+  line-height: 1.6;
+}
+
+@media screen and (max-width: 996px) {
+  .primaryGrid,
+  .secondaryGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .primaryCard {
+    padding: 1.5rem;
+  }
+
+  .primarySvg {
+    width: 54px;
+    height: 54px;
+  }
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -6,44 +6,66 @@
 
 /* You can override the default Infima variables here. */
 :root {
-    --ifm-color-primary: #EC8F4Cff;
-    --ifm-color-primary-dark: #e08442;
-    --ifm-color-primary-darker: #d47a38;
-    --ifm-color-primary-darkest: #c86f2e;
-    --ifm-color-primary-light: #FDC16Aff;
-    --ifm-color-primary-lighter: #FEC26Bff;
-    --ifm-color-primary-lightest: #fef0d7;
+    --emf-orange: #EC8F4C;
+    --ifm-color-primary: #d8732b;
+    --ifm-color-primary-dark: #c96825;
+    --ifm-color-primary-darker: #bc6223;
+    --ifm-color-primary-darkest: #9b4f1d;
+    --ifm-color-primary-light: #e88943;
+    --ifm-color-primary-lighter: #ee9d5e;
+    --ifm-color-primary-lightest: #f9e3d2;
     --ifm-code-font-size: 95%;
     --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 
+    --emf-brand-modrinth: #1bd96a;
+    --emf-brand-modrinth-strong: #16bf5d;
+    --emf-brand-discord: #5865f2;
+    --emf-brand-discord-strong: #4752c4;
+
     --emf-background-color: #ffffff;
-    --emf-background-color-secondary: #a4adbd;
-    --emf-background-color-alt: #6d758b;
+    --emf-background-color-secondary: #f5f5f5;
+    --emf-background-color-alt: #e9e9e9;
     --emf-background-color-gradient: linear-gradient(
             180deg,
             var(--emf-background-color) 0%,
-            color-mix(in srgb, var(--emf-background-color) 75%, var(--emf-background-color-alt) 25%) 25%,
-            color-mix(in srgb, var(--emf-background-color) 50%, var(--emf-background-color-alt) 50%) 50%,
-            color-mix(in srgb, var(--emf-background-color) 25%, var(--emf-background-color-alt) 75%) 75%,
-            color-mix(in srgb, var(--emf-background-color) 15%, var(--emf-background-color-alt) 90%) 90%,
-            color-mix(in srgb, var(--emf-background-color) 0%, var(--emf-background-color-alt) 100%) 100%,
+            color-mix(in srgb, var(--emf-background-color) 72%, var(--emf-background-color-secondary) 28%) 30%,
+            color-mix(in srgb, var(--emf-background-color-secondary) 55%, var(--emf-background-color-alt) 45%) 68%,
             var(--emf-background-color-alt) 100%
     );
+
+    --emf-home-start: #ffffff;
+    --emf-home-end: #f5f5f5;
+    --emf-surface: rgba(255, 255, 255, 0.86);
+    --emf-surface-strong: rgba(255, 255, 255, 0.96);
+    --emf-border: rgba(0, 0, 0, 0.12);
+    --emf-border-strong: rgba(0, 0, 0, 0.18);
+    --emf-shadow-md: 0 16px 34px rgba(0, 0, 0, 0.08);
+    --emf-shadow-lg: 0 22px 48px rgba(0, 0, 0, 0.12);
+    --emf-text-muted: #4f4f4f;
+    --emf-text-muted-strong: #444444;
+    --emf-text-soft: #737373;
+    --emf-section-title: #1f1f1f;
+    --emf-section-subtitle: #5f5f5f;
 
     --badge-background-color: #fef0d7;
     --badge-color: #131313;
 }
 
 [data-theme='dark'] {
-    /* Dark mode - adjusted for better contrast and readability */
-    --ifm-color-primary: #FDC16Aff;
-    --ifm-color-primary-dark: #EC8F4Cff;
-    --ifm-color-primary-darker: #d47a38;
-    --ifm-color-primary-darkest: #b86524;
-    --ifm-color-primary-light: #FEC26Bff;
-    --ifm-color-primary-lighter: #fed89d;
-    --ifm-color-primary-lightest: #fff4e5;
+    --emf-orange: #EC8F4C;
+    --ifm-color-primary: #f3a35c;
+    --ifm-color-primary-dark: #ef9441;
+    --ifm-color-primary-darker: #ec8a33;
+    --ifm-color-primary-darkest: #dd7313;
+    --ifm-color-primary-light: #f7b277;
+    --ifm-color-primary-lighter: #f9bc89;
+    --ifm-color-primary-lightest: #fce1c5;
     --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+    --emf-brand-modrinth: #1bd96a;
+    --emf-brand-modrinth-strong: #38ec82;
+    --emf-brand-discord: #5865f2;
+    --emf-brand-discord-strong: #7280ff;
 
     --emf-background-color: #2e384d;
     --emf-background-color-secondary: #283143;
@@ -51,13 +73,24 @@
     --emf-background-color-gradient: linear-gradient(
             180deg,
             var(--emf-background-color) 0%,
-            color-mix(in srgb, var(--emf-background-color) 75%, var(--emf-background-color-alt) 25%) 25%,
-            color-mix(in srgb, var(--emf-background-color) 50%, var(--emf-background-color-alt) 50%) 50%,
-            color-mix(in srgb, var(--emf-background-color) 25%, var(--emf-background-color-alt) 75%) 75%,
-            color-mix(in srgb, var(--emf-background-color) 15%, var(--emf-background-color-alt) 90%) 90%,
-            color-mix(in srgb, var(--emf-background-color) 0%, var(--emf-background-color-alt) 100%) 100%,
+            color-mix(in srgb, var(--emf-background-color) 74%, var(--emf-background-color-secondary) 26%) 28%,
+            color-mix(in srgb, var(--emf-background-color-secondary) 48%, var(--emf-background-color-alt) 52%) 70%,
             var(--emf-background-color-alt) 100%
     );
+
+    --emf-home-start: #151923;
+    --emf-home-end: #1c2230;
+    --emf-surface: rgba(21, 25, 35, 0.78);
+    --emf-surface-strong: rgba(30, 36, 50, 0.94);
+    --emf-border: rgba(255, 255, 255, 0.12);
+    --emf-border-strong: rgba(255, 255, 255, 0.18);
+    --emf-shadow-md: 0 18px 40px rgba(0, 0, 0, 0.24);
+    --emf-shadow-lg: 0 26px 56px rgba(0, 0, 0, 0.32);
+    --emf-text-muted: #c8ced8;
+    --emf-text-muted-strong: #d8dde5;
+    --emf-text-soft: #9aa3b3;
+    --emf-section-title: #f5f7fa;
+    --emf-section-subtitle: #c8ced8;
 
     --badge-background-color: #131313;
     --badge-color: #fef0d7;

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -4,38 +4,285 @@
  */
 :global(.navbar) {
     opacity: 0.95;
+    backdrop-filter: blur(14px);
 }
 
 .heroBanner {
-    padding: 4rem 0;
-    text-align: center;
+    padding: 5rem 0 4rem;
     position: relative;
     overflow: hidden;
+    background:
+        radial-gradient(circle at top left, color-mix(in srgb, var(--emf-orange) 22%, transparent), transparent 34%),
+        radial-gradient(circle at top right, color-mix(in srgb, var(--emf-brand-discord) 14%, transparent), transparent 28%),
+        var(--emf-background-color-gradient);
+}
 
-    background: var(--emf-background-color);
-    background: var(--emf-background-color-gradient);
+.heroContainer {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+}
 
+.heroCopy {
+    color: var(--ifm-font-color-base);
+    max-width: 72rem;
+}
+
+.heroTitle {
+    font-size: clamp(3rem, 7vw, 5rem);
+    line-height: 0.92;
+    margin-bottom: 1rem;
+    letter-spacing: -0.04em;
+}
+
+.heroSubtitle {
+    font-size: 1.25rem;
+    line-height: 1.5;
+    max-width: 48rem;
+    margin-bottom: 1rem;
+    color: var(--ifm-color-emphasis-900);
+}
+
+.heroDescription {
+    font-size: 1rem;
+    line-height: 1.75;
+    max-width: 48rem;
+    margin-bottom: 1.75rem;
+    color: var(--emf-text-muted);
+}
+
+.heroActions,
+.sectionActions {
     display: flex;
-    justify-content: center; /* horizontal */
-    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.marketPanel {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    border: 1px solid var(--emf-border-strong);
+    background:
+        linear-gradient(135deg, color-mix(in srgb, var(--emf-surface-strong) 92%, transparent), color-mix(in srgb, var(--emf-surface) 92%, transparent)),
+        radial-gradient(circle at right top, color-mix(in srgb, var(--ifm-color-primary) 16%, transparent), transparent 35%);
+    box-shadow: var(--emf-shadow-lg);
+}
+
+.marketSummary {
+    margin-bottom: 1.25rem;
+}
+
+.marketSummary strong {
+    display: block;
+    font-size: clamp(2rem, 6vw, 3rem);
+    line-height: 1;
+    margin-bottom: 0.5rem;
+    color: var(--emf-section-title);
+}
+
+.marketSummary p {
+    margin: 0;
+    color: var(--emf-text-muted);
+}
+
+.modrinthButton,
+.discordButton,
+.docsButton {
+    border: 0;
+    box-shadow: none;
+}
+
+.modrinthButton {
+    background: var(--emf-brand-modrinth);
+    color: #06210f;
+}
+
+.modrinthButton:hover,
+.modrinthButton:focus {
+    background: var(--emf-brand-modrinth-strong);
+    color: #04160a;
+}
+
+.discordButton {
+    background: var(--emf-brand-discord);
+    color: #fff;
+}
+
+.discordButton:hover,
+.discordButton:focus {
+    background: var(--emf-brand-discord-strong);
+    color: #fff;
+}
+
+.docsButton {
+    background: color-mix(in srgb, var(--emf-surface-strong) 88%, transparent);
+    color: var(--ifm-font-color-base);
+    border: 1px solid var(--emf-border-strong);
+}
+
+.docsButton:hover,
+.docsButton:focus {
+    background: color-mix(in srgb, var(--emf-surface-strong) 96%, transparent);
+    color: var(--ifm-font-color-base);
 }
 
 .emfHome {
-    background: var(--emf-background-color-alt);
+    background:
+        linear-gradient(
+            180deg,
+            var(--emf-home-start) 0%,
+            var(--emf-home-end) 100%
+        );
 }
 
-.heroBanner img {
-    border-radius: 10px;
+.section {
+    padding: 4rem 0;
+}
+
+.sectionHeading {
+    max-width: 46rem;
+    margin: 0 auto 2rem;
+    text-align: center;
+    color: var(--emf-section-title);
+}
+
+.sectionHeading h2 {
+    margin-bottom: 0.75rem;
+}
+
+.sectionHeading p {
+    margin: 0;
+    color: var(--emf-section-subtitle);
+}
+
+.infoGrid,
+.linkGrid,
+.stepsGrid {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.infoGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.linkGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.stepsGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.infoCard,
+.linkCard,
+.stepCard,
+.ctaPanel {
+    border-radius: 1.5rem;
+    border: 1px solid var(--emf-border);
+    background: color-mix(in srgb, var(--emf-surface) 90%, transparent);
+    box-shadow: var(--emf-shadow-md);
+    backdrop-filter: blur(10px);
+}
+
+.infoCard,
+.stepCard {
+    padding: 1.5rem;
+}
+
+.infoCard p,
+.stepCard p,
+.linkCard p,
+.ctaPanel p {
+    margin: 0;
+    color: var(--emf-text-muted-strong);
+}
+
+.linkCard {
+    display: block;
+    padding: 1.5rem;
+    color: var(--emf-section-title);
+    text-decoration: none;
+    transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.linkCard:hover {
+    color: var(--emf-section-title);
+    text-decoration: none;
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--ifm-color-primary) 35%, var(--emf-border));
+    background: color-mix(in srgb, var(--emf-surface-strong) 88%, transparent);
+}
+
+.linkCard h3 {
+    margin-bottom: 0.75rem;
+}
+
+.stepNumber {
+    display: inline-flex;
+    margin-bottom: 1rem;
+    font-size: 2rem;
+    font-weight: 800;
+    line-height: 1;
+    color: var(--ifm-color-primary);
+}
+
+.finalSection {
+    padding-top: 0;
+    padding-bottom: 5rem;
+}
+
+.ctaPanel {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 2rem;
+    padding: 2rem;
+    color: var(--emf-section-title);
+    background:
+        linear-gradient(135deg, color-mix(in srgb, var(--emf-surface) 92%, transparent), color-mix(in srgb, var(--emf-surface-strong) 92%, transparent)),
+        radial-gradient(circle at right, color-mix(in srgb, var(--ifm-color-primary) 12%, transparent), transparent 32%);
+}
+
+.ctaPanel h2 {
+    margin-bottom: 0.75rem;
 }
 
 @media screen and (max-width: 996px) {
     .heroBanner {
-        padding: 2rem;
+        padding: 3rem 0;
+    }
+
+    .infoGrid,
+    .linkGrid,
+    .stepsGrid,
+    .ctaPanel {
+        grid-template-columns: 1fr;
+    }
+
+    .ctaPanel {
+        display: grid;
+    }
+
+    .heroTitle {
+        font-size: clamp(2.5rem, 12vw, 4rem);
     }
 }
 
-.buttons {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+@media screen and (max-width: 640px) {
+    .section {
+        padding: 3rem 0;
+    }
+
+    .heroActions,
+    .sectionActions {
+        flex-direction: column;
+    }
+
+    .heroActions :global(.button),
+    .sectionActions :global(.button) {
+        width: 100%;
+        justify-content: center;
+    }
 }

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -58,6 +58,10 @@
     gap: 0.75rem;
 }
 
+.installActions {
+    margin-top: 1.5rem;
+}
+
 .marketPanel {
     margin-top: 2rem;
     padding: 1.5rem;
@@ -84,6 +88,43 @@
 .marketSummary p {
     margin: 0;
     color: var(--emf-text-muted);
+}
+
+.marketStatsGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.marketStat {
+    padding: 1rem 1.1rem;
+    border-radius: 1.15rem;
+    border: 1px solid var(--emf-border);
+    background: color-mix(in srgb, var(--emf-surface) 88%, transparent);
+}
+
+.marketStatLabel {
+    display: block;
+    margin-bottom: 0.45rem;
+    color: var(--emf-text-soft);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.marketStat strong {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: var(--emf-section-title);
+    font-size: 1.35rem;
+    line-height: 1.15;
+}
+
+.marketStat p {
+    margin: 0;
+    color: var(--emf-text-muted);
+    font-size: 0.95rem;
 }
 
 .modrinthButton,
@@ -254,6 +295,7 @@
         padding: 3rem 0;
     }
 
+    .marketStatsGrid,
     .infoGrid,
     .linkGrid,
     .stepsGrid,

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -10,6 +10,7 @@ import styles from './index.module.css';
 
 const modrinthUrl = 'https://modrinth.com/plugin/evenmorefish';
 const discordUrl = 'https://discord.gg/9fRbqWTnHS';
+const jenkinsUrl = 'https://ci.codemc.io/job/EvenMoreFish/job/EvenMoreFish/';
 const docsUrl = '/docs/intro';
 
 const whyUseIt = [
@@ -24,6 +25,9 @@ const marketStats = {
   spigotDownloads: 62423,
   spigotRating: 4.6,
   spigotRatings: 136,
+  activeServers: 1436,
+  activePlayers: 6275,
+  playersRecord: 8186,
 };
 
 const totalDownloads =
@@ -130,6 +134,17 @@ function HomepageHeader() {
                 {formatNumber(marketStats.spigotDownloads)} on Spigot.
               </p>
             </div>
+            <div className={styles.marketStatsGrid}>
+              <div className={styles.marketStat}>
+                <span className={styles.marketStatLabel}>Active servers</span>
+                <strong>{formatNumber(marketStats.activeServers)}</strong>
+              </div>
+              <div className={styles.marketStat}>
+                <span className={styles.marketStatLabel}>Active players</span>
+                <strong>{formatNumber(marketStats.activePlayers)}</strong>
+                <p>Peak in sampled history: {formatNumber(marketStats.playersRecord)}</p>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -193,7 +208,7 @@ export default function Home(): ReactNode {
                 </div>
               ))}
             </div>
-            <div className={styles.sectionActions}>
+            <div className={clsx(styles.sectionActions, styles.installActions)}>
               <Link className={clsx('button', styles.docsButton)} to={docsUrl}>
                 Open installation guide
               </Link>
@@ -263,14 +278,14 @@ export default function Home(): ReactNode {
                   Download now
                 </Link>
                 <Link
-                  className={clsx('button button--lg', styles.docsButton)}
-                  to="/docs/downloads">
-                  View all downloads
-                </Link>
-                <Link
                   className={clsx('button button--lg', styles.discordButton)}
                   href={discordUrl}>
                   Join Discord
+                </Link>
+                <Link
+                  className={clsx('button button--lg', styles.docsButton)}
+                  href={jenkinsUrl}>
+                  Dev Builds
                 </Link>
               </div>
             </div>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,35 +1,281 @@
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
+import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 
 import styles from './index.module.css';
 
+const modrinthUrl = 'https://modrinth.com/plugin/evenmorefish';
+const discordUrl = 'https://discord.gg/9fRbqWTnHS';
+const docsUrl = '/docs/intro';
+
+const whyUseIt = [
+  'Start with 70+ fish out of the box, then shape the experience around your server.',
+  'Run competitions, rewards, shops, baits, and progression without stitching together multiple plugins.',
+  'Control catches by biome, region, rarity, commands, and economy integration.',
+];
+
+const marketStats = {
+  modrinthDownloads: 23054,
+  modrinthFollowers: 94,
+  spigotDownloads: 62423,
+  spigotRating: 4.6,
+  spigotRatings: 136,
+};
+
+const totalDownloads =
+  marketStats.modrinthDownloads + marketStats.spigotDownloads;
+
+const installSteps = [
+  'Download the latest release from Modrinth.',
+  'Drop the .jar into your server\'s plugins folder.',
+  'Restart the server, then edit the generated config files.',
+];
+
+const popularDocs = [
+  {
+    title: 'Installation',
+    description: 'Set up the plugin and get your first server running quickly.',
+    to: '/docs/intro',
+  },
+  {
+    title: 'Commands',
+    description: 'Find player and admin commands for fish, bait, shops, and more.',
+    to: '/docs/commands',
+  },
+  {
+    title: 'Configuration',
+    description: 'Customize fish, rarities, regions, rewards, and gameplay rules.',
+    to: '/docs/category/configuration',
+  },
+  {
+    title: 'Competitions',
+    description: 'Configure events, schedules, bossbars, and leaderboards.',
+    to: '/docs/features/competitions/types',
+  },
+];
+
+const usefulLinks = [
+  {
+    title: 'FAQ',
+    description: 'Answers for admin commands, fish rewards, bait, shop values, and common setup questions.',
+    to: '/docs/support/faq',
+  },
+  {
+    title: 'Downloads',
+    description: 'Stable Modrinth releases, dev builds on Jenkins, and legacy Spigot downloads.',
+    to: '/docs/downloads',
+  },
+  {
+    title: 'Support',
+    description: 'Join Discord for help with configuration, bugs, migrations, and integrations.',
+    href: discordUrl,
+  },
+  {
+    title: 'GitHub',
+    description: 'Browse the codebase, open issues, and track changes across releases.',
+    href: 'https://github.com/EvenMoreFish/EvenMoreFish',
+  },
+];
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
+
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
-        <div className={styles.cardBg}>
-            <img
-                src={siteConfig.themeConfig.image}
-                alt={siteConfig.title}
-                className={styles.cardImg}
-            />
+      <div className={clsx('container', styles.heroContainer)}>
+        <div className={styles.heroCopy}>
+          <Heading as="h1" className={styles.heroTitle}>
+            {siteConfig.title}
+          </Heading>
+          <p className={styles.heroSubtitle}>
+            A feature-rich fishing plugin for custom fish, competitions, baits,
+            shops, rewards, and server-specific progression.
+          </p>
+          <p className={styles.heroDescription}>
+            Build a fishing system that fits your server: create collectible
+            catches, run timed events, reward players, restrict fish by biome or
+            region, and connect the whole experience to your economy and
+            PlaceholderAPI setup.
+          </p>
+          <div className={styles.heroActions}>
+            <Link
+              className={clsx('button button--lg', styles.modrinthButton)}
+              href={modrinthUrl}>
+              Download on Modrinth
+            </Link>
+            <Link
+              className={clsx('button button--lg', styles.docsButton)}
+              to={docsUrl}>
+              Read installation guide
+            </Link>
+            <Link
+              className={clsx('button button--lg', styles.discordButton)}
+              href={discordUrl}>
+              Join Discord
+            </Link>
+          </div>
+          <div className={styles.marketPanel}>
+            <div className={styles.marketSummary}>
+              <strong>{formatNumber(totalDownloads)} downloads</strong>
+              <p>
+                {formatNumber(marketStats.modrinthDownloads)} on Modrinth and{' '}
+                {formatNumber(marketStats.spigotDownloads)} on Spigot.
+              </p>
+            </div>
+          </div>
         </div>
+      </div>
     </header>
+  );
+}
+
+function SectionHeading({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div className={styles.sectionHeading}>
+      <Heading as="h2">{title}</Heading>
+      <p>{subtitle}</p>
+    </div>
   );
 }
 
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
+
   return (
     <Layout
       title={`${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description="EvenMoreFish is a Minecraft fishing plugin with custom fish, competitions, baits, shops, rewards, and extensive server customization.">
       <HomepageHeader />
       <main className={styles.emfHome}>
+        <section className={styles.section}>
+          <div className="container">
+            <SectionHeading
+              title="Why use EvenMoreFish?"
+              subtitle="Custom fish, competitions, baits, economy tools, and server-side control in one plugin."
+            />
+            <div className={styles.infoGrid}>
+              {whyUseIt.map((item) => (
+                <div key={item} className={styles.infoCard}>
+                  <p>{item}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
         <HomepageFeatures />
+
+        <section className={styles.section} id="install">
+          <div className="container">
+            <SectionHeading
+              title="Install in 60 seconds"
+              subtitle="Download it, drop it into your plugins folder, restart, and start configuring."
+            />
+            <div className={styles.stepsGrid}>
+              {installSteps.map((step, index) => (
+                <div key={step} className={styles.stepCard}>
+                  <span className={styles.stepNumber}>0{index + 1}</span>
+                  <p>{step}</p>
+                </div>
+              ))}
+            </div>
+            <div className={styles.sectionActions}>
+              <Link className={clsx('button', styles.docsButton)} to={docsUrl}>
+                Open installation guide
+              </Link>
+              <Link className={clsx('button', styles.modrinthButton)} href={modrinthUrl}>
+                Go to Modrinth
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className="container">
+            <SectionHeading
+              title="Popular docs"
+              subtitle="Start with setup, commands, configuration, and competition docs."
+            />
+            <div className={styles.linkGrid}>
+              {popularDocs.map((doc) => (
+                <Link key={doc.title} className={styles.linkCard} to={doc.to}>
+                  <Heading as="h3">{doc.title}</Heading>
+                  <p>{doc.description}</p>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <div className="container">
+            <SectionHeading
+              title="FAQ & useful links"
+              subtitle="The fastest way to get answers, downloads, and support."
+            />
+            <div className={styles.linkGrid}>
+              {usefulLinks.map((item) =>
+                item.to ? (
+                  <Link key={item.title} className={styles.linkCard} to={item.to}>
+                    <Heading as="h3">{item.title}</Heading>
+                    <p>{item.description}</p>
+                  </Link>
+                ) : (
+                  <Link key={item.title} className={styles.linkCard} href={item.href}>
+                    <Heading as="h3">{item.title}</Heading>
+                    <p>{item.description}</p>
+                  </Link>
+                ),
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className={clsx(styles.section, styles.finalSection)}>
+          <div className="container">
+            <div className={styles.ctaPanel}>
+              <div>
+                <Heading as="h2">Ready to add fishing progression to your server?</Heading>
+                <p>
+                  Start with the stable Modrinth release, use the docs for setup,
+                  and join Discord if you need help configuring competitions,
+                  regions, rewards, or integrations.
+                </p>
+              </div>
+              <div className={styles.sectionActions}>
+                <Link
+                  className={clsx('button button--lg', styles.modrinthButton)}
+                  href={modrinthUrl}>
+                  Download now
+                </Link>
+                <Link
+                  className={clsx('button button--lg', styles.docsButton)}
+                  to="/docs/downloads">
+                  View all downloads
+                </Link>
+                <Link
+                  className={clsx('button button--lg', styles.discordButton)}
+                  href={discordUrl}>
+                  Join Discord
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
     </Layout>
   );

--- a/docs/static/img/home/bait.svg
+++ b/docs/static/img/home/bait.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="24px" height="24px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
-     color="#000000">
+     >
     <path d="M16 7C17.1046 7 18 6.10457 18 5C18 3.89543 17.1046 3 16 3C14.8954 3 14 3.89543 14 5C14 6.10457 14.8954 7 16 7ZM16 7C16 7 16 13.0948 16 17C16 23 6 23 6 17V13L8 15"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
+

--- a/docs/static/img/home/coins-swap.svg
+++ b/docs/static/img/home/coins-swap.svg
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
+<svg viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" >
     <path d="M9.01894 9C9.00639 8.83498 9 8.66824 9 8.5C9 4.91015 11.9101 2 15.5 2C19.0899 2 22 4.91015 22 8.5C22 12.0899 19.0899 15 15.5 15C15.3318 15 15.165 14.9936 15 14.9811"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
     <path d="M8.5 22C4.91015 22 2 19.0899 2 15.5C2 11.9101 4.91015 9 8.5 9C12.0899 9 15 11.9101 15 15.5C15 19.0899 12.0899 22 8.5 22Z"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M22 17C22 18.6569 20.6569 20 19 20H17M17 20L19 18M17 20L19 22" stroke="#b86524" stroke-width="1.5"
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+    <path d="M22 17C22 18.6569 20.6569 20 19 20H17M17 20L19 18M17 20L19 22" stroke="currentColor" stroke-width="1.5"
           stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 7C2 5.34315 3.34315 4 5 4H7M7 4L5 6M7 4L5 2" stroke="#b86524" stroke-width="1.5" stroke-linecap="round"
+    <path d="M2 7C2 5.34315 3.34315 4 5 4H7M7 4L5 6M7 4L5 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
           stroke-linejoin="round"></path>
 </svg>
+

--- a/docs/static/img/home/fish.svg
+++ b/docs/static/img/home/fish.svg
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="24px" height="24px" viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg"
-     color="#000000">
+     >
     <path d="M10.5 9C10.5 9 10.5 7 9.5 5C13.5 5 16 7.49997 16 7.49997C16 7.49997 19.5 7 22 12C21 17.5 16 18 16 18L12 20.5C12 20.5 12 19.5 12 17.5C9.5 16.5 6.99998 14 7 12.5C7.00001 11 10.5 9 10.5 9ZM10.5 9C10.5 9 11.5 8.5 12.5 8.5"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M2 9.5L3 12.5L2 15.5C2 15.5 7 15.5 7 12.5C7 9.5 2 9.5 2 9.5Z" stroke="#b86524" stroke-width="1.5"
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+    <path d="M2 9.5L3 12.5L2 15.5C2 15.5 7 15.5 7 12.5C7 9.5 2 9.5 2 9.5Z" stroke="currentColor" stroke-width="1.5"
           stroke-linecap="round" stroke-linejoin="round"></path>
-    <path d="M17 12.01L17.01 11.9989" stroke="#b86524" stroke-width="1.5" stroke-linecap="round"
+    <path d="M17 12.01L17.01 11.9989" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
           stroke-linejoin="round"></path>
 </svg>
+

--- a/docs/static/img/home/leaderboard-star.svg
+++ b/docs/static/img/home/leaderboard-star.svg
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
-    <path d="M15 21H9V12.6C9 12.2686 9.26863 12 9.6 12H14.4C14.7314 12 15 12.2686 15 12.6V21Z" stroke="#b86524"
+<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
+    <path d="M15 21H9V12.6C9 12.2686 9.26863 12 9.6 12H14.4C14.7314 12 15 12.2686 15 12.6V21Z" stroke="currentColor"
           stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
     <path d="M20.4 21H15V18.1C15 17.7686 15.2686 17.5 15.6 17.5H20.4C20.7314 17.5 21 17.7686 21 18.1V20.4C21 20.7314 20.7314 21 20.4 21Z"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
     <path d="M9 21V16.1C9 15.7686 8.73137 15.5 8.4 15.5H3.6C3.26863 15.5 3 15.7686 3 16.1V20.4C3 20.7314 3.26863 21 3.6 21H9Z"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
     <path d="M10.8056 5.11325L11.7147 3.1856C11.8314 2.93813 12.1686 2.93813 12.2853 3.1856L13.1944 5.11325L15.2275 5.42427C15.4884 5.46418 15.5923 5.79977 15.4035 5.99229L13.9326 7.4917L14.2797 9.60999C14.3243 9.88202 14.0515 10.0895 13.8181 9.96099L12 8.96031L10.1819 9.96099C9.94851 10.0895 9.67568 9.88202 9.72026 9.60999L10.0674 7.4917L8.59651 5.99229C8.40766 5.79977 8.51163 5.46418 8.77248 5.42427L10.8056 5.11325Z"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
+

--- a/docs/static/img/home/placeholder.svg
+++ b/docs/static/img/home/placeholder.svg
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="24px" stroke-width="1.5" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"
-     color="#000000">
+     >
     <path d="M9.00001 21L8.00001 21C6.89544 21 6.00001 20.1057 6.00001 19.0011C6.00001 17.4501 6.00001 15.3443 6 14C6 13 4.5 12 4.5 12C4.5 12 6.00001 11 6.00001 10C6.00001 8.827 6.00001 6.62207 6.00001 4.99914C6.00001 3.89457 6.89544 3 8.00001 3L9.00001 3"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
     <path d="M15 21L16 21C17.1046 21 18 20.1057 18 19.0011C18 17.4501 18 15.3443 18 14C18 13 19.5 12 19.5 12C19.5 12 18 11 18 10C18 8.827 18 6.62207 18 4.99914C18 3.89457 17.1046 3 16 3L15 3"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
+

--- a/docs/static/img/home/settings.svg
+++ b/docs/static/img/home/settings.svg
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#000000">
+<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
     <path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
     <path d="M19.6224 10.3954L18.5247 7.7448L20 6L18 4L16.2647 5.48295L13.5578 4.36974L12.9353 2H10.981L10.3491 4.40113L7.70441 5.51596L6 4L4 6L5.45337 7.78885L4.3725 10.4463L2 11V13L4.40111 13.6555L5.51575 16.2997L4 18L6 20L7.79116 18.5403L10.397 19.6123L11 22H13L13.6045 19.6132L16.2551 18.5155C16.6969 18.8313 18 20 18 20L20 18L18.5159 16.2494L19.6139 13.598L21.9999 12.9772L22 11L19.6224 10.3954Z"
-          stroke="#b86524" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
 </svg>
+


### PR DESCRIPTION
## Description
Refines the documentation homepage hero and CTA flow by improving the stats panel, simplifying the final action area, and adjusting install section spacing.

<img width="1421" height="858" alt="explorer_4FqZKzmz09" src="https://github.com/user-attachments/assets/a8311cfb-f9c1-4d50-8522-3944c02cab91" />

---

### What has changed?
- updated the homepage stats panel to show download totals plus relevant usage metrics
- simplified the final CTA buttons to `Download now`, `Join Discord`, and `Dev Builds`
- added spacing between the install steps and the install action buttons
- refined homepage styling in the page-level CSS to support the updated layout
- 

---

### Related Issues
Improves the documentation homepage based on review feedback around landing-page clarity, CTA priority, and visible project credibility.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation as needed.
