### PR TITLE
Handle legacy embedded DB timestamps safely

### DIFF
--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/Database.java
@@ -110,12 +110,13 @@ public class Database implements DatabaseAPI {
 
     private Jdbi createJdbi() {
         Jdbi database = Jdbi.create(connectionFactory::getConnection);
+        boolean normalizeLegacyText = supportsLegacyTimestampNormalization();
         database.installPlugin(new SqlObjectPlugin());
         database.registerRowMapper(UserReport.class, new UserReportMapper());
-        database.registerRowMapper(FishLog.class, new FishLogMapper());
-        database.registerRowMapper(FishStats.class, new FishStatsMapper());
-        database.registerRowMapper(UserFishStats.class, new UserFishStatsMapper());
-        database.registerRowMapper(CompetitionReport.class, new CompetitionReportMapper());
+        database.registerRowMapper(FishLog.class, new FishLogMapper(fishLogTable, normalizeLegacyText));
+        database.registerRowMapper(FishStats.class, new FishStatsMapper(fishTable, normalizeLegacyText));
+        database.registerRowMapper(UserFishStats.class, new UserFishStatsMapper(userFishStatsTable, normalizeLegacyText));
+        database.registerRowMapper(CompetitionReport.class, new CompetitionReportMapper(competitionsTable, normalizeLegacyText));
         return database;
     }
 
@@ -205,7 +206,7 @@ public class Database implements DatabaseAPI {
 
     @Override
     public FishLog getFishLog(int userId, String fishName, String fishRarity, LocalDateTime time) {
-        return withHandle(handle -> handle.createQuery("select user_id, fish_name, fish_rarity, fish_length, catch_time, competition_id from " + fishLogTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity and catch_time = :catch_time").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).bind("catch_time", time).mapTo(FishLog.class).findOne().orElse(null), null);
+        return withHandle(handle -> handle.createQuery("select id, user_id, fish_name, fish_rarity, fish_length, catch_time, competition_id from " + fishLogTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity and catch_time = :catch_time").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).bind("catch_time", time).mapTo(FishLog.class).findOne().orElse(null), null);
     }
 
     public void shutdown() {
@@ -241,13 +242,21 @@ public class Database implements DatabaseAPI {
         return withHandle(handle -> handle.createQuery("select user_id, fish_name, fish_rarity, first_catch_time, shortest_length, longest_length, quantity from " + userFishStatsTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(UserFishStats.class).findOne().orElse(null), null);
     }
 
+    public LoadResult<UserFishStats> loadUserFishStats(int userId, String fishName, String fishRarity) {
+        UserFishStats stats = withHandle(handle -> handle.createQuery("select user_id, fish_name, fish_rarity, first_catch_time, shortest_length, longest_length, quantity from " + userFishStatsTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(UserFishStats.class).findOne().orElse(null), null);
+        if (stats != null) {
+            return LoadResult.found(stats);
+        }
+        return didLastHandleFail() ? LoadResult.unreadable() : LoadResult.notFound();
+    }
+
     public void upsertUserFishStats(UserFishStats userFishStats) {
         useHandle(handle -> bindUserFishStatsUpdate(handle, userFishStatsUpsertSql(), userFishStats).execute());
     }
 
     @Override
     public Set<FishLog> getFishLogEntries(int userId, String fishName, String fishRarity) {
-        return withHandle(handle -> new LinkedHashSet<>(handle.createQuery("select user_id, fish_name, fish_rarity, fish_length, catch_time, competition_id from " + fishLogTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(FishLog.class).list()), Set.of());
+        return withHandle(handle -> new LinkedHashSet<>(handle.createQuery("select id, user_id, fish_name, fish_rarity, fish_length, catch_time, competition_id from " + fishLogTable + " where user_id = :user_id and fish_name = :fish_name and fish_rarity = :fish_rarity").bind("user_id", userId).bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(FishLog.class).list()), Set.of());
     }
 
     @Override
@@ -258,6 +267,14 @@ public class Database implements DatabaseAPI {
     @Override
     public FishStats getFishStats(String fishName, String fishRarity) {
         return withHandle(handle -> handle.createQuery("select fish_name, fish_rarity, first_catch_time, discoverer, shortest_length, shortest_fisher, largest_fish, largest_fisher, total_caught from " + fishTable + " where fish_name = :fish_name and fish_rarity = :fish_rarity").bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(FishStats.class).findOne().orElse(null), null);
+    }
+
+    public LoadResult<FishStats> loadFishStats(String fishName, String fishRarity) {
+        FishStats stats = withHandle(handle -> handle.createQuery("select fish_name, fish_rarity, first_catch_time, discoverer, shortest_length, shortest_fisher, largest_fish, largest_fisher, total_caught from " + fishTable + " where fish_name = :fish_name and fish_rarity = :fish_rarity").bind("fish_name", fishName).bind("fish_rarity", fishRarity).mapTo(FishStats.class).findOne().orElse(null), null);
+        if (stats != null) {
+            return LoadResult.found(stats);
+        }
+        return didLastHandleFail() ? LoadResult.unreadable() : LoadResult.notFound();
     }
 
     public void upsertFishStats(@NotNull FishStats fishStats) {
@@ -328,7 +345,7 @@ public class Database implements DatabaseAPI {
     }
 
     public CompetitionReport getCompetitionReport(int id) {
-        return withHandle(handle -> handle.createQuery("select competition_name, winner_fish, winner_uuid, winner_score, contestants, start_time, end_time from " + competitionsTable + " where id = :id").bind("id", id).mapTo(CompetitionReport.class).findOne().orElse(null), null);
+        return withHandle(handle -> handle.createQuery("select id, competition_name, winner_fish, winner_uuid, winner_score, contestants, start_time, end_time from " + competitionsTable + " where id = :id").bind("id", id).mapTo(CompetitionReport.class).findOne().orElse(null), null);
     }
 
     public void batchUpdateCompetitions(Collection<CompetitionReport> competitions) {
@@ -359,12 +376,14 @@ public class Database implements DatabaseAPI {
 
     private <T> T withHandle(HandleCallback<T> callback, T fallback) {
         try {
+            handleFailureState().set(false);
             if (jdbi == null) {
                 return fallback;
             }
             return jdbi.withHandle(callback::apply);
         } catch (Exception exception) {
-            EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, "Query execution failed", exception);
+            handleFailureState().set(true);
+            logQueryFailure(exception);
             return fallback;
         }
     }
@@ -447,4 +466,84 @@ public class Database implements DatabaseAPI {
     private interface HandleConsumer {
         void accept(Handle handle) throws Exception;
     }
+
+    private void logQueryFailure(Exception exception) {
+        UnreadableTimestampException unreadableTimestampException = findCause(exception, UnreadableTimestampException.class);
+        if (unreadableTimestampException != null) {
+            EvenMoreFish.getInstance().getLogger().warning("Query execution failed: " + unreadableTimestampException.getMessage());
+            EvenMoreFish.getInstance().debug("Query execution failed due to unreadable timestamp.", exception);
+            return;
+        }
+
+        EvenMoreFish.getInstance().getLogger().log(Level.SEVERE, "Query execution failed", exception);
+    }
+
+    private <T extends Throwable> T findCause(Throwable throwable, Class<T> type) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return type.cast(current);
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private boolean supportsLegacyTimestampNormalization() {
+        String type = connectionFactory.getType();
+        return "SQLITE".equalsIgnoreCase(type) || "H2".equalsIgnoreCase(type);
+    }
+
+    private boolean didLastHandleFail() {
+        return Boolean.TRUE.equals(handleFailureState().get());
+    }
+
+    private ThreadLocal<Boolean> handleFailureState() {
+        if (lastHandleFailed == null) {
+            lastHandleFailed = ThreadLocal.withInitial(() -> false);
+        }
+        return lastHandleFailed;
+    }
+
+    public static final class LoadResult<T> {
+        private final T value;
+        private final State state;
+
+        private LoadResult(T value, State state) {
+            this.value = value;
+            this.state = state;
+        }
+
+        public static <T> LoadResult<T> found(T value) {
+            return new LoadResult<>(value, State.FOUND);
+        }
+
+        public static <T> LoadResult<T> notFound() {
+            return new LoadResult<>(null, State.NOT_FOUND);
+        }
+
+        public static <T> LoadResult<T> unreadable() {
+            return new LoadResult<>(null, State.UNREADABLE);
+        }
+
+        public T getValue() {
+            return value;
+        }
+
+        public boolean isFound() {
+            return state == State.FOUND;
+        }
+
+        public boolean isUnreadable() {
+            return state == State.UNREADABLE;
+        }
+
+        private enum State {
+            FOUND,
+            NOT_FOUND,
+            UNREADABLE
+        }
+    }
+
+    private ThreadLocal<Boolean> lastHandleFailed = ThreadLocal.withInitial(() -> false);
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/UnreadableTimestampException.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/UnreadableTimestampException.java
@@ -1,0 +1,9 @@
+package com.oheers.fish.database;
+
+import java.sql.SQLException;
+
+public class UnreadableTimestampException extends SQLException {
+    public UnreadableTimestampException(String tableName, String columnName, String rawValue, Throwable cause) {
+        super("Unable to parse timestamp value '%s' from %s.%s".formatted(rawValue, tableName, columnName), cause);
+    }
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/DataManager.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/data/manager/DataManager.java
@@ -86,6 +86,16 @@ public class DataManager<T> {
         return get(key, defaultLoader);
     }
 
+    public T peek(String key) {
+        return cache.get(key);
+    }
+
+    public void cacheLoadedValue(String key, T data) {
+        if (data != null) {
+            cache.putIfAbsent(key, data);
+        }
+    }
+
     public void update(String key, T data) {
         cache.put(key, data);
         if (savingStrategy.writesThrough()) {

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/CompatibleLocalDateTimeReader.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/CompatibleLocalDateTimeReader.java
@@ -1,0 +1,167 @@
+package com.oheers.fish.database.mapper;
+
+import com.oheers.fish.EvenMoreFish;
+import com.oheers.fish.database.UnreadableTimestampException;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class CompatibleLocalDateTimeReader {
+
+    private CompatibleLocalDateTimeReader() {
+        throw new UnsupportedOperationException();
+    }
+
+    static LocalDateTime read(
+        ResultSet resultSet,
+        String tableName,
+        String columnName,
+        LinkedHashMap<String, Object> rowIdentity,
+        boolean normalizeLegacyText
+    ) throws SQLException {
+        try {
+            Timestamp timestamp = resultSet.getTimestamp(columnName);
+            if (timestamp != null) {
+                return timestamp.toLocalDateTime();
+            }
+        } catch (SQLException exception) {
+            LocalDateTime compatibleValue = parseCompatibleValue(resultSet, tableName, columnName, exception);
+            warnAndNormalize(resultSet, tableName, columnName, rowIdentity, normalizeLegacyText, compatibleValue, exception);
+            return compatibleValue;
+        }
+
+        String rawValue = resultSet.getString(columnName);
+        if (rawValue == null || rawValue.isBlank()) {
+            return null;
+        }
+
+        LocalDateTime compatibleValue = parseCompatibleValue(rawValue, tableName, columnName, null);
+        warnAndNormalize(resultSet, tableName, columnName, rowIdentity, normalizeLegacyText, compatibleValue, null);
+        return compatibleValue;
+    }
+
+    private static LocalDateTime parseCompatibleValue(
+        ResultSet resultSet,
+        String tableName,
+        String columnName,
+        SQLException originalException
+    ) throws SQLException {
+        String rawValue = resultSet.getString(columnName);
+        return parseCompatibleValue(rawValue, tableName, columnName, originalException);
+    }
+
+    private static LocalDateTime parseCompatibleValue(
+        String rawValue,
+        String tableName,
+        String columnName,
+        SQLException originalException
+    ) throws SQLException {
+        if (rawValue == null || rawValue.isBlank()) {
+            if (originalException != null) {
+                throw originalException;
+            }
+            return null;
+        }
+
+        try {
+            return Timestamp.valueOf(rawValue).toLocalDateTime();
+        } catch (IllegalArgumentException ignored) {
+            try {
+                return LocalDateTime.parse(rawValue);
+            } catch (DateTimeParseException parseException) {
+                throw new UnreadableTimestampException(tableName, columnName, rawValue, originalException == null ? parseException : originalException);
+            }
+        }
+    }
+
+    private static void warnAndNormalize(
+        ResultSet resultSet,
+        String tableName,
+        String columnName,
+        LinkedHashMap<String, Object> rowIdentity,
+        boolean normalizeLegacyText,
+        LocalDateTime compatibleValue,
+        SQLException originalException
+    ) {
+        String rowDescription = describeIdentity(rowIdentity);
+        EvenMoreFish plugin = EvenMoreFish.getInstance();
+        plugin.getLogger().warning(
+            "Parsed legacy timestamp text for %s.%s (%s) using compatibility fallback."
+                .formatted(tableName, columnName, rowDescription)
+        );
+        if (originalException != null) {
+            plugin.debug("Legacy timestamp fallback used for %s.%s (%s).".formatted(tableName, columnName, rowDescription), originalException);
+        }
+
+        if (!normalizeLegacyText) {
+            return;
+        }
+
+        try {
+            normalizeTimestamp(resultSet, tableName, columnName, rowIdentity, compatibleValue);
+        } catch (SQLException exception) {
+            plugin.getLogger().warning(
+                "Failed to normalize legacy timestamp text for %s.%s (%s)."
+                    .formatted(tableName, columnName, rowDescription)
+            );
+            plugin.debug("Failed to normalize legacy timestamp text.", exception);
+        }
+    }
+
+    private static void normalizeTimestamp(
+        ResultSet resultSet,
+        String tableName,
+        String columnName,
+        LinkedHashMap<String, Object> rowIdentity,
+        LocalDateTime compatibleValue
+    ) throws SQLException {
+        if (rowIdentity.isEmpty()) {
+            return;
+        }
+        PreparedStatement statement = null;
+        try {
+            StringBuilder sql = new StringBuilder("update ");
+            sql.append(tableName).append(" set ").append(columnName).append(" = ? where ");
+
+            int clauseIndex = 0;
+            for (String key : rowIdentity.keySet()) {
+                if (clauseIndex++ > 0) {
+                    sql.append(" and ");
+                }
+                sql.append(key).append(" = ?");
+            }
+
+            statement = resultSet.getStatement().getConnection().prepareStatement(sql.toString());
+            statement.setTimestamp(1, Timestamp.valueOf(compatibleValue));
+
+            int parameterIndex = 2;
+            for (Object value : rowIdentity.values()) {
+                statement.setObject(parameterIndex++, value);
+            }
+
+            statement.executeUpdate();
+        } finally {
+            if (statement != null) {
+                statement.close();
+            }
+        }
+    }
+
+    private static String describeIdentity(LinkedHashMap<String, Object> rowIdentity) {
+        StringBuilder builder = new StringBuilder();
+        int index = 0;
+        for (Map.Entry<String, Object> entry : rowIdentity.entrySet()) {
+            if (index++ > 0) {
+                builder.append(", ");
+            }
+            builder.append(entry.getKey()).append('=').append(entry.getValue());
+        }
+        return builder.toString();
+    }
+}

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/CompetitionReportMapper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/CompetitionReportMapper.java
@@ -7,9 +7,8 @@ import org.jdbi.v3.core.statement.StatementContext;
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 
 public class CompetitionReportMapper implements RowMapper<CompetitionReport> {
@@ -17,6 +16,13 @@ public class CompetitionReportMapper implements RowMapper<CompetitionReport> {
     private static final UUID NIL_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
     private static final Field WINNER_UUID_FIELD = getField("winnerUuid");
     private static final Field CONTESTANTS_FIELD = getField("contestants");
+    private final String tableName;
+    private final boolean normalizeLegacyText;
+
+    public CompetitionReportMapper(String tableName, boolean normalizeLegacyText) {
+        this.tableName = tableName;
+        this.normalizeLegacyText = normalizeLegacyText;
+    }
 
     @Override
     public CompetitionReport map(ResultSet rs, StatementContext ctx) throws SQLException {
@@ -32,8 +38,8 @@ public class CompetitionReportMapper implements RowMapper<CompetitionReport> {
                 noWinner ? NIL_UUID.toString() : winnerUuid.trim(),
                 rs.getFloat("winner_score"),
                 noContestants ? NIL_UUID.toString() : normalizeContestants(contestants),
-                getLocalDateTime(rs, "start_time"),
-                getLocalDateTime(rs, "end_time")
+                CompatibleLocalDateTimeReader.read(rs, tableName, "start_time", identityFor(rs), normalizeLegacyText),
+                CompatibleLocalDateTimeReader.read(rs, tableName, "end_time", identityFor(rs), normalizeLegacyText)
         );
 
         if (noWinner) {
@@ -73,8 +79,9 @@ public class CompetitionReportMapper implements RowMapper<CompetitionReport> {
         }
     }
 
-    private LocalDateTime getLocalDateTime(ResultSet rs, String column) throws SQLException {
-        Timestamp timestamp = rs.getTimestamp(column);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+    private LinkedHashMap<String, Object> identityFor(ResultSet rs) throws SQLException {
+        LinkedHashMap<String, Object> identity = new LinkedHashMap<>();
+        identity.put("id", rs.getInt("id"));
+        return identity;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/FishLogMapper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/FishLogMapper.java
@@ -6,10 +6,16 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 
 public class FishLogMapper implements RowMapper<FishLog> {
+    private final String tableName;
+    private final boolean normalizeLegacyText;
+
+    public FishLogMapper(String tableName, boolean normalizeLegacyText) {
+        this.tableName = tableName;
+        this.normalizeLegacyText = normalizeLegacyText;
+    }
 
     @Override
     public FishLog map(ResultSet rs, StatementContext ctx) throws SQLException {
@@ -17,14 +23,15 @@ public class FishLogMapper implements RowMapper<FishLog> {
                 rs.getInt("user_id"),
                 rs.getString("fish_name"),
                 rs.getString("fish_rarity"),
-                getLocalDateTime(rs, "catch_time"),
+                CompatibleLocalDateTimeReader.read(rs, tableName, "catch_time", identityFor(rs), normalizeLegacyText),
                 rs.getFloat("fish_length"),
                 rs.getString("competition_id")
         );
     }
 
-    private LocalDateTime getLocalDateTime(ResultSet rs, String column) throws SQLException {
-        Timestamp timestamp = rs.getTimestamp(column);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+    private LinkedHashMap<String, Object> identityFor(ResultSet rs) throws SQLException {
+        LinkedHashMap<String, Object> identity = new LinkedHashMap<>();
+        identity.put("id", rs.getInt("id"));
+        return identity;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/FishStatsMapper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/FishStatsMapper.java
@@ -6,18 +6,25 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 
 public class FishStatsMapper implements RowMapper<FishStats> {
+    private final String tableName;
+    private final boolean normalizeLegacyText;
+
+    public FishStatsMapper(String tableName, boolean normalizeLegacyText) {
+        this.tableName = tableName;
+        this.normalizeLegacyText = normalizeLegacyText;
+    }
 
     @Override
     public FishStats map(ResultSet rs, StatementContext ctx) throws SQLException {
         return new FishStats(
                 rs.getString("fish_name"),
                 rs.getString("fish_rarity"),
-                getLocalDateTime(rs, "first_catch_time"),
+                CompatibleLocalDateTimeReader.read(rs, tableName, "first_catch_time", identityFor(rs), normalizeLegacyText),
                 UUID.fromString(rs.getString("discoverer")),
                 rs.getFloat("shortest_length"),
                 UUID.fromString(rs.getString("shortest_fisher")),
@@ -27,8 +34,10 @@ public class FishStatsMapper implements RowMapper<FishStats> {
         );
     }
 
-    private LocalDateTime getLocalDateTime(ResultSet rs, String column) throws SQLException {
-        Timestamp timestamp = rs.getTimestamp(column);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+    private LinkedHashMap<String, Object> identityFor(ResultSet rs) throws SQLException {
+        LinkedHashMap<String, Object> identity = new LinkedHashMap<>();
+        identity.put("fish_name", rs.getString("fish_name"));
+        identity.put("fish_rarity", rs.getString("fish_rarity"));
+        return identity;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/UserFishStatsMapper.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/database/mapper/UserFishStatsMapper.java
@@ -6,10 +6,16 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 
 public class UserFishStatsMapper implements RowMapper<UserFishStats> {
+    private final String tableName;
+    private final boolean normalizeLegacyText;
+
+    public UserFishStatsMapper(String tableName, boolean normalizeLegacyText) {
+        this.tableName = tableName;
+        this.normalizeLegacyText = normalizeLegacyText;
+    }
 
     @Override
     public UserFishStats map(ResultSet rs, StatementContext ctx) throws SQLException {
@@ -17,15 +23,18 @@ public class UserFishStatsMapper implements RowMapper<UserFishStats> {
                 rs.getInt("user_id"),
                 rs.getString("fish_name"),
                 rs.getString("fish_rarity"),
-                getLocalDateTime(rs, "first_catch_time"),
+                CompatibleLocalDateTimeReader.read(rs, tableName, "first_catch_time", identityFor(rs), normalizeLegacyText),
                 rs.getFloat("shortest_length"),
                 rs.getFloat("longest_length"),
                 rs.getInt("quantity")
         );
     }
 
-    private LocalDateTime getLocalDateTime(ResultSet rs, String column) throws SQLException {
-        Timestamp timestamp = rs.getTimestamp(column);
-        return timestamp == null ? null : timestamp.toLocalDateTime();
+    private LinkedHashMap<String, Object> identityFor(ResultSet rs) throws SQLException {
+        LinkedHashMap<String, Object> identity = new LinkedHashMap<>();
+        identity.put("user_id", rs.getInt("user_id"));
+        identity.put("fish_name", rs.getString("fish_name"));
+        identity.put("fish_rarity", rs.getString("fish_rarity"));
+        return identity;
     }
 }

--- a/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/EMFFishListener.java
+++ b/even-more-fish-plugin/src/main/java/com/oheers/fish/fishing/EMFFishListener.java
@@ -81,11 +81,21 @@ public class EMFFishListener implements Listener {
     private void handleFishStats(final @NotNull Fish fish) {
         final DataManager<FishStats> fishStatsDataManager = EvenMoreFish.getInstance().getPluginDataManager().getFishStatsDataManager();
         final FishRarityKey fishRarityKey = FishRarityKey.of(fish);
-        final FishStats stats = fishStatsDataManager.getOrCreate(
-                fishRarityKey.toString(),
-                key -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().getFishStats(fish.getName(),fish.getRarity().getId()),
-                () -> FishStats.empty(fish,LocalDateTime.now())
-        );
+        final String key = fishRarityKey.toString();
+        FishStats stats = fishStatsDataManager.peek(key);
+        if (stats == null) {
+            final var loadResult = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().loadFishStats(fish.getName(), fish.getRarity().getId());
+            if (loadResult.isUnreadable()) {
+                EvenMoreFish.getInstance().getLogger().warning("Skipping fish stats update for " + key + " because the stored row could not be read.");
+                return;
+            }
+            if (loadResult.isFound()) {
+                stats = loadResult.getValue();
+                fishStatsDataManager.cacheLoadedValue(key, stats);
+            } else {
+                stats = FishStats.empty(fish, LocalDateTime.now());
+            }
+        }
 
         UUID fishermanUuid = fish.getFishermanUUID();
         float length = fish.getLength();
@@ -102,7 +112,7 @@ public class EMFFishListener implements Listener {
         }
 
         stats.incrementQuantity();
-        fishStatsDataManager.update(fishRarityKey.toString(), stats);
+        fishStatsDataManager.update(key, stats);
         EvenMoreFish.getInstance().debug("Fish Stats: %s".formatted( stats.toString()));
     }
 
@@ -116,11 +126,21 @@ public class EMFFishListener implements Listener {
 
     private void handleUserFishStats(final int userId, final @NotNull Fish fish) {
         final DataManager<UserFishStats> userFishStatsDataManager = EvenMoreFish.getInstance().getPluginDataManager().getUserFishStatsDataManager();
-        final UserFishStats stats = userFishStatsDataManager.getOrCreate(
-                UserFishRarityKey.of(userId,fish).toString(),
-                id -> EvenMoreFish.getInstance().getPluginDataManager().getDatabase().getUserFishStats(userId, fish.getName(), fish.getRarity().getId()),
-                () -> new UserFishStats(userId, fish, LocalDateTime.now())
-        );
+        final String key = UserFishRarityKey.of(userId,fish).toString();
+        UserFishStats stats = userFishStatsDataManager.peek(key);
+        if (stats == null) {
+            final var loadResult = EvenMoreFish.getInstance().getPluginDataManager().getDatabase().loadUserFishStats(userId, fish.getName(), fish.getRarity().getId());
+            if (loadResult.isUnreadable()) {
+                EvenMoreFish.getInstance().getLogger().warning("Skipping user fish stats update for " + key + " because the stored row could not be read.");
+                return;
+            }
+            if (loadResult.isFound()) {
+                stats = loadResult.getValue();
+                userFishStatsDataManager.cacheLoadedValue(key, stats);
+            } else {
+                stats = new UserFishStats(userId, fish, LocalDateTime.now());
+            }
+        }
 
         if (stats.getLongestLength() < fish.getLength()) {
             stats.setLongestLength(fish.getLength());
@@ -131,7 +151,6 @@ public class EMFFishListener implements Listener {
         }
 
         stats.incrementQuantity();
-        final String key = UserFishRarityKey.of(userId,fish).toString();
         userFishStatsDataManager.update(key, stats);
     }
 }


### PR DESCRIPTION
## Description
This PR makes embedded database timestamp reads backward-compatible so legacy text-formatted timestamps no longer break fish and competition data loading. It also avoids overwriting stats when a legacy row cannot be parsed, and normalizes compatible legacy timestamp values back to proper timestamp storage when possible.

---

### What has changed?
- Added `CompatibleLocalDateTimeReader` and `UnreadableTimestampException` to safely read legacy timestamp text values from embedded databases.
- Updated database row mappers to use compatibility-based timestamp parsing and to normalize legacy values for SQLite/H2 rows after successful reads.
- Added `LoadResult` handling in `Database` so callers can distinguish between missing rows and unreadable rows, with targeted logging for timestamp parsing failures.
- Added `peek` and `cacheLoadedValue` to `DataManager` to support controlled cache population without forcing writes.
- Updated `EMFFishListener` to skip fish stats and user fish stats updates when the stored row is unreadable instead of creating replacement rows from incomplete state.
- Included row `id` fields in affected queries so timestamp normalization can target the original records safely.

---

### Related Issues
Fixes ticket-0247.

---

### Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation as needed.
